### PR TITLE
refactor(ui): add mobile responsive redesign for feed, nav, and theme

### DIFF
--- a/src/components/AppHeader.tsx
+++ b/src/components/AppHeader.tsx
@@ -62,14 +62,14 @@ export function AppHeader({ className }: AppHeaderProps) {
           </button>
         </div>
         <div className="flex items-center gap-2">
-          {/* Main navigation - hidden on mobile when BottomNav is visible */}
+          {/* Main navigation - hidden on mobile/tablet when BottomNav is visible */}
           {user && (
             <Button
               variant="ghost"
               size="sm"
               onClick={() => navigate('/')}
               className={cn(
-                "hidden md:flex items-center gap-2",
+                "hidden lg:flex items-center gap-2",
                 isActive('/') && "bg-primary text-primary-foreground"
               )}
             >
@@ -82,7 +82,7 @@ export function AppHeader({ className }: AppHeaderProps) {
             size="sm"
             onClick={() => navigate('/discovery')}
             className={cn(
-              "hidden md:flex items-center gap-2",
+              "hidden lg:flex items-center gap-2",
               isActive('/discovery') && "bg-primary text-primary-foreground"
             )}
             >
@@ -94,7 +94,7 @@ export function AppHeader({ className }: AppHeaderProps) {
             size="sm"
             onClick={() => navigate('/search')}
             className={cn(
-              "hidden md:flex items-center gap-2",
+              "hidden lg:flex items-center gap-2",
               isActive('/search') && "bg-primary text-primary-foreground"
             )}
             >

--- a/src/components/AppLayout.tsx
+++ b/src/components/AppLayout.tsx
@@ -52,15 +52,16 @@ export function AppLayout() {
   return (
     <>
       {/* Sidebar - desktop only (fixed position), hidden on landing page */}
-      {!isLandingPage && <AppSidebar className="hidden md:flex" />}
+      {!isLandingPage && <AppSidebar className="hidden lg:flex" />}
 
       {/* Main content area - offset by sidebar width on desktop */}
-      <div className={`flex min-h-screen flex-col bg-background ${!isLandingPage ? 'md:ml-[240px]' : ''}`}>
-        {/* Header - mobile only (sidebar replaces it on desktop), hidden on landing page */}
-        {!isLandingPage && <AppHeader className="md:hidden" />}
+      <div className={`flex min-h-screen flex-col bg-background ${!isLandingPage ? 'lg:ml-[240px]' : ''}`}>
+        {/* Header - mobile/tablet only (sidebar replaces it on desktop), hidden on landing page */}
+        {/* TODO: Replace AppHeader with ImmersiveTopBar for < lg viewports */}
+        {!isLandingPage && <AppHeader className="lg:hidden" />}
 
         {/* Main content */}
-        <main className="flex-1 pb-[calc(4rem+env(safe-area-inset-bottom))] md:pb-0">
+        <main className="flex-1 pb-[calc(4rem+env(safe-area-inset-bottom))] lg:pb-0">
           <Outlet />
         </main>
 

--- a/src/components/AppLayout.tsx
+++ b/src/components/AppLayout.tsx
@@ -81,7 +81,11 @@ export function AppLayout() {
         )}
 
         {/* Main content */}
-        <main className="flex-1 pb-[calc(4rem+env(safe-area-inset-bottom))] lg:pb-0">
+        <main
+          className={`flex-1 pb-[var(--bottom-nav-height)] lg:pb-0 ${
+            !isLandingPage && topBarConfig.variant === 'solid' ? 'pt-[var(--top-bar-height)] lg:pt-0' : ''
+          }`}
+        >
           <Outlet />
         </main>
 

--- a/src/components/AppLayout.tsx
+++ b/src/components/AppLayout.tsx
@@ -1,6 +1,6 @@
 import { Outlet, useLocation, useSearchParams } from 'react-router-dom';
-import { AppHeader } from '@/components/AppHeader';
 import { BottomNav } from '@/components/BottomNav';
+import { ImmersiveTopBar } from '@/components/ImmersiveTopBar';
 import { PWAInstallPrompt } from '@/components/PWAInstallPrompt';
 import { FullscreenFeed } from '@/components/FullscreenFeed';
 import { AppSidebar } from '@/components/AppSidebar';
@@ -49,6 +49,22 @@ export function AppLayout() {
     setSearchParams(nextParams, { replace: true });
   };
 
+  // Determine top bar title and variant based on route
+  const getTopBarConfig = (): { title: string; variant: 'transparent' | 'solid' } => {
+    const path = location.pathname;
+    if (path === '/' || path === '/home') return { title: 'Home', variant: 'transparent' };
+    if (path.startsWith('/discovery')) return { title: 'Discover', variant: 'solid' };
+    if (path.startsWith('/search')) return { title: 'Search', variant: 'solid' };
+    if (path.startsWith('/notifications')) return { title: 'Notifications', variant: 'solid' };
+    if (path.startsWith('/profile')) return { title: 'Profile', variant: 'solid' };
+    if (path.startsWith('/hashtag')) return { title: 'Hashtag', variant: 'solid' };
+    if (path.startsWith('/category')) return { title: 'Category', variant: 'solid' };
+    if (path.startsWith('/settings')) return { title: 'Settings', variant: 'solid' };
+    return { title: 'diVine', variant: 'solid' };
+  };
+
+  const topBarConfig = getTopBarConfig();
+
   return (
     <>
       {/* Sidebar - desktop only (fixed position), hidden on landing page */}
@@ -56,9 +72,13 @@ export function AppLayout() {
 
       {/* Main content area - offset by sidebar width on desktop */}
       <div className={`flex min-h-screen flex-col bg-background ${!isLandingPage ? 'lg:ml-[240px]' : ''}`}>
-        {/* Header - mobile/tablet only (sidebar replaces it on desktop), hidden on landing page */}
-        {/* TODO: Replace AppHeader with ImmersiveTopBar for < lg viewports */}
-        {!isLandingPage && <AppHeader className="lg:hidden" />}
+        {/* ImmersiveTopBar - mobile/tablet only (< lg), hidden on landing page */}
+        {!isLandingPage && (
+          <ImmersiveTopBar
+            title={topBarConfig.title}
+            variant={topBarConfig.variant}
+          />
+        )}
 
         {/* Main content */}
         <main className="flex-1 pb-[calc(4rem+env(safe-area-inset-bottom))] lg:pb-0">

--- a/src/components/BottomNav.test.tsx
+++ b/src/components/BottomNav.test.tsx
@@ -6,8 +6,12 @@ import { LoginDialogProvider } from '@/contexts/LoginDialogContext';
 import { initializeI18n } from '@/lib/i18n';
 import { BottomNav } from './BottomNav';
 
+type MockCurrentUser = { user: { pubkey: string } | null };
+
+const mockCurrentUser = vi.fn((): MockCurrentUser => ({ user: null }));
+
 vi.mock('@/hooks/useCurrentUser', () => ({
-  useCurrentUser: () => ({ user: null }),
+  useCurrentUser: () => mockCurrentUser(),
 }));
 
 vi.mock('@/hooks/useNotifications', () => ({
@@ -34,6 +38,7 @@ async function renderBottomNav(initialEntry = '/') {
 describe('BottomNav', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockCurrentUser.mockReturnValue({ user: null });
     const storage = new Map<string, string>();
     Object.defineProperty(window, 'localStorage', {
       configurable: true,
@@ -53,5 +58,17 @@ describe('BottomNav', () => {
     await user.click(screen.getByRole('button', { name: 'Discover' }));
 
     expect(screen.getByTestId('location-display')).toHaveTextContent('/discovery');
+  });
+
+  it('explains why camera uploads are unavailable instead of routing to upload', async () => {
+    const user = userEvent.setup();
+    mockCurrentUser.mockReturnValue({ user: { pubkey: 'a'.repeat(64) } });
+    await renderBottomNav('/');
+
+    await user.click(screen.getByRole('button', { name: 'Camera' }));
+
+    expect(screen.getByRole('dialog')).toHaveTextContent('Why no upload?');
+    expect(screen.getByRole('dialog')).toHaveTextContent('What you see on Divine is human-made');
+    expect(screen.getByTestId('location-display')).toHaveTextContent('/');
   });
 });

--- a/src/components/BottomNav.test.tsx
+++ b/src/components/BottomNav.test.tsx
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MemoryRouter, useLocation } from 'react-router-dom';
+import { LoginDialogProvider } from '@/contexts/LoginDialogContext';
 import { initializeI18n } from '@/lib/i18n';
 import { BottomNav } from './BottomNav';
 
@@ -22,8 +23,10 @@ async function renderBottomNav(initialEntry = '/') {
   await initializeI18n({ force: true, languages: ['en-US'] });
   return render(
     <MemoryRouter initialEntries={[initialEntry]}>
-      <BottomNav />
-      <LocationDisplay />
+      <LoginDialogProvider>
+        <BottomNav />
+        <LocationDisplay />
+      </LoginDialogProvider>
     </MemoryRouter>
   );
 }
@@ -43,12 +46,12 @@ describe('BottomNav', () => {
     });
   });
 
-  it('links mobile users to the popular page', async () => {
+  it('links mobile users to the discovery page', async () => {
     const user = userEvent.setup();
     await renderBottomNav('/');
 
-    await user.click(screen.getByRole('button', { name: 'Popular' }));
+    await user.click(screen.getByRole('button', { name: 'Search' }));
 
-    expect(screen.getByTestId('location-display')).toHaveTextContent('/popular');
+    expect(screen.getByTestId('location-display')).toHaveTextContent('/discovery');
   });
 });

--- a/src/components/BottomNav.test.tsx
+++ b/src/components/BottomNav.test.tsx
@@ -50,7 +50,7 @@ describe('BottomNav', () => {
     const user = userEvent.setup();
     await renderBottomNav('/');
 
-    await user.click(screen.getByRole('button', { name: 'Search' }));
+    await user.click(screen.getByRole('button', { name: 'Discover' }));
 
     expect(screen.getByTestId('location-display')).toHaveTextContent('/discovery');
   });

--- a/src/components/BottomNav.tsx
+++ b/src/components/BottomNav.tsx
@@ -1,7 +1,7 @@
-import { House as Home, Compass, MagnifyingGlass as Search, Bell, User, TrendUp } from '@phosphor-icons/react';
+import { House as Home, MagnifyingGlass as Search, VideoCamera as Video, Bell, UserCircle } from '@phosphor-icons/react';
 import { useLocation } from 'react-router-dom';
-import { useTranslation } from 'react-i18next';
 import { Button } from '@/components/ui/button';
+import { useLoginDialog } from '@/contexts/LoginDialogContext';
 import { useCurrentUser } from '@/hooks/useCurrentUser';
 import { useUnreadNotificationCount } from '@/hooks/useNotifications';
 import { useSubdomainNavigate } from '@/hooks/useSubdomainNavigate';
@@ -11,9 +11,9 @@ import { cn } from '@/lib/utils';
 export function BottomNav() {
   const navigate = useSubdomainNavigate();
   const location = useLocation();
-  const { t } = useTranslation();
   const { user } = useCurrentUser();
   const { data: unreadCount } = useUnreadNotificationCount();
+  const { openLoginDialog } = useLoginDialog();
 
   const getUserProfilePath = () => {
     if (!user?.pubkey) return '/';
@@ -23,107 +23,101 @@ export function BottomNav() {
     });
   };
 
-  const isActive = (path: string) => location.pathname === path;
-  const isHomePage = location.pathname === '/';
+  const isActive = (path: string) => location.pathname === path || location.pathname.startsWith(path + '/');
+  const isHomePage = location.pathname === '/' || location.pathname === '/home';
+
+  const handleAuthAction = (action: () => void) => {
+    if (user) {
+      action();
+    } else {
+      openLoginDialog();
+    }
+  };
+
+  const handleProfileClick = () => {
+    if (!user?.pubkey) {
+      openLoginDialog();
+      return;
+    }
+
+    navigate(getUserProfilePath(), { ownerPubkey: user.pubkey });
+  };
 
   return (
-    <nav className="lg:hidden fixed bottom-0 left-0 right-0 z-50 border-t border-brand-light-green bg-background backdrop-blur-md shadow-lg pb-[env(safe-area-inset-bottom)] dark:border-brand-dark-green">
-      <div className="flex items-center justify-around h-16 px-2">
-        {/* Home - Shows Home/Explore tabs */}
+    <nav className="lg:hidden fixed bottom-0 left-0 right-0 z-50 bg-[#00150d] pb-[env(safe-area-inset-bottom)]">
+      <div className="flex items-center justify-center gap-12 h-16 px-2">
+        {/* Home */}
         <Button
           variant="ghost"
           size="sm"
           onClick={() => navigate('/')}
           className={cn(
-            "flex flex-col items-center justify-center gap-1 h-full flex-1 rounded-none hover:bg-transparent",
-            isHomePage && "text-primary"
+            "flex flex-col items-center justify-center gap-1 rounded-none hover:bg-transparent p-0",
+            isHomePage ? "text-primary" : "text-white"
           )}
         >
-          <Home className={cn("h-5 w-5", isHomePage && "text-primary")} weight={isHomePage ? 'fill' : 'bold'} />
-          <span className={cn("text-xs", isHomePage && "text-primary")}>{t('nav.home')}</span>
-        </Button>
-
-        {/* Explore - Redirects to home page with explore tab */}
-        <Button
-          variant="ghost"
-          size="sm"
-          onClick={() => navigate('/discovery')}
-          className={cn(
-            "flex flex-col items-center justify-center gap-1 h-full flex-1 rounded-none hover:bg-transparent",
-            isActive('/discovery') && "text-primary"
-          )}
-        >
-          <Compass className={cn("h-5 w-5", isActive('/discovery') && "text-primary")} weight={isActive('/discovery') ? 'fill' : 'bold'} />
-          <span className={cn("text-xs", isActive('/discovery') && "text-primary")}>{t('nav.discover')}</span>
-        </Button>
-
-        {/* Popular */}
-        <Button
-          variant="ghost"
-          size="sm"
-          onClick={() => navigate('/popular')}
-          className={cn(
-            "flex flex-col items-center justify-center gap-1 h-full flex-1 rounded-none hover:bg-transparent",
-            isActive('/popular') && "text-primary"
-          )}
-        >
-          <TrendUp className={cn("h-5 w-5", isActive('/popular') && "text-primary")} weight={isActive('/popular') ? 'fill' : 'bold'} />
-          <span className={cn("text-xs", isActive('/popular') && "text-primary")}>{t('nav.popular')}</span>
+          <Home className="w-8 h-8" weight={isHomePage ? 'fill' : 'bold'} />
         </Button>
 
         {/* Search */}
         <Button
           variant="ghost"
           size="sm"
-          onClick={() => navigate('/search')}
+          onClick={() => navigate('/discovery')}
           className={cn(
-            "flex flex-col items-center justify-center gap-1 h-full flex-1 rounded-none hover:bg-transparent",
-            isActive('/search') && "text-primary"
+            "flex flex-col items-center justify-center gap-1 rounded-none hover:bg-transparent p-0",
+            isActive('/discovery') ? "text-primary" : "text-white"
           )}
         >
-          <Search className={cn("h-5 w-5", isActive('/search') && "text-primary")} weight={isActive('/search') ? 'fill' : 'bold'} />
-          <span className={cn("text-xs", isActive('/search') && "text-primary")}>{t('nav.search')}</span>
+          <Search className="w-8 h-8" weight={isActive('/discovery') ? 'bold' : 'regular'} />
+        </Button>
+
+        {/* Camera - green pill */}
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={() => handleAuthAction(() => navigate('/upload'))}
+          className="flex items-center justify-center bg-[#27c58b] rounded-[20px] px-5 py-2 hover:bg-[#27c58b]/90 text-white p-0"
+        >
+          <Video className="w-8 h-8 drop-shadow" weight="fill" />
         </Button>
 
         {/* Notifications */}
-        {user && (
-          <Button
-            variant="ghost"
-            size="sm"
-            onClick={() => navigate('/notifications')}
-            className={cn(
-              "flex flex-col items-center justify-center gap-1 h-full flex-1 rounded-none hover:bg-transparent",
-              isActive('/notifications') && "text-primary"
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={() => handleAuthAction(() => navigate('/notifications'))}
+          className={cn(
+            "flex flex-col items-center justify-center gap-1 rounded-none hover:bg-transparent p-0",
+            isActive('/notifications') ? "text-primary" : "text-white"
+          )}
+        >
+          <div className="relative">
+            <Bell className="w-8 h-8" weight={isActive('/notifications') ? 'fill' : 'bold'} />
+            {(unreadCount ?? 0) > 0 && (
+              <span className="absolute -top-1 -right-1.5 flex h-3.5 min-w-3.5 items-center justify-center rounded-full bg-destructive px-0.5 text-[9px] font-bold text-destructive-foreground">
+                {(unreadCount ?? 0) > 99 ? '99+' : unreadCount}
+              </span>
             )}
-          >
-            <div className="relative">
-              <Bell className={cn("h-5 w-5", isActive('/notifications') && "text-primary")} weight={isActive('/notifications') ? 'fill' : 'bold'} />
-              {(unreadCount ?? 0) > 0 && (
-                <span className="absolute -top-1 -right-1.5 flex h-3.5 min-w-3.5 items-center justify-center rounded-full bg-destructive px-0.5 text-[9px] font-bold text-destructive-foreground">
-                  {(unreadCount ?? 0) > 99 ? '99+' : unreadCount}
-                </span>
-              )}
-            </div>
-            <span className={cn("text-xs", isActive('/notifications') && "text-primary")}>{t('nav.notifications')}</span>
-          </Button>
-        )}
+          </div>
+        </Button>
 
         {/* Profile */}
-        {user && (
-          <Button
-            variant="ghost"
-            size="sm"
-            onClick={() => navigate(getUserProfilePath(), { ownerPubkey: user.pubkey })}
-            className={cn(
-              "flex flex-col items-center justify-center gap-1 h-full flex-1 rounded-none hover:bg-transparent",
-              isActive(getUserProfilePath()) && "text-primary"
-            )}
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={handleProfileClick}
+          className={cn(
+            "flex flex-col items-center justify-center gap-1 rounded-none hover:bg-transparent p-0",
+            user && isActive(getUserProfilePath()) ? "text-primary" : "text-white"
+          )}
         >
-          <User className={cn("h-5 w-5", isActive(getUserProfilePath()) && "text-primary")} weight={isActive(getUserProfilePath()) ? 'fill' : 'bold'} />
-          <span className={cn("text-xs", isActive(getUserProfilePath()) && "text-primary")}>{t('nav.profile')}</span>
+          <UserCircle className="w-8 h-8" weight={user && isActive(getUserProfilePath()) ? 'fill' : 'bold'} />
         </Button>
-      )}
       </div>
+
+      {/* Home indicator bar */}
+      <div className="w-[144px] h-[5px] bg-white rounded-full mx-auto mb-1" />
     </nav>
   );
 }

--- a/src/components/BottomNav.tsx
+++ b/src/components/BottomNav.tsx
@@ -50,6 +50,7 @@ export function BottomNav() {
         <Button
           variant="ghost"
           size="sm"
+          aria-label="Home"
           onClick={() => navigate('/')}
           className={cn(
             "flex flex-col items-center justify-center gap-1 rounded-none hover:bg-transparent p-0",
@@ -63,6 +64,7 @@ export function BottomNav() {
         <Button
           variant="ghost"
           size="sm"
+          aria-label="Search"
           onClick={() => navigate('/discovery')}
           className={cn(
             "flex flex-col items-center justify-center gap-1 rounded-none hover:bg-transparent p-0",
@@ -76,6 +78,7 @@ export function BottomNav() {
         <Button
           variant="ghost"
           size="sm"
+          aria-label="Upload"
           onClick={() => handleAuthAction(() => navigate('/upload'))}
           className="flex items-center justify-center bg-[#27c58b] rounded-[20px] px-5 py-2 hover:bg-[#27c58b]/90 text-white p-0"
         >
@@ -86,6 +89,7 @@ export function BottomNav() {
         <Button
           variant="ghost"
           size="sm"
+          aria-label="Notifications"
           onClick={() => handleAuthAction(() => navigate('/notifications'))}
           className={cn(
             "flex flex-col items-center justify-center gap-1 rounded-none hover:bg-transparent p-0",
@@ -106,6 +110,7 @@ export function BottomNav() {
         <Button
           variant="ghost"
           size="sm"
+          aria-label="Profile"
           onClick={handleProfileClick}
           className={cn(
             "flex flex-col items-center justify-center gap-1 rounded-none hover:bg-transparent p-0",

--- a/src/components/BottomNav.tsx
+++ b/src/components/BottomNav.tsx
@@ -27,7 +27,7 @@ export function BottomNav() {
   const isHomePage = location.pathname === '/';
 
   return (
-    <nav className="md:hidden fixed bottom-0 left-0 right-0 z-50 border-t border-brand-light-green bg-background backdrop-blur-md shadow-lg pb-[env(safe-area-inset-bottom)] dark:border-brand-dark-green">
+    <nav className="lg:hidden fixed bottom-0 left-0 right-0 z-50 border-t border-brand-light-green bg-background backdrop-blur-md shadow-lg pb-[env(safe-area-inset-bottom)] dark:border-brand-dark-green">
       <div className="flex items-center justify-around h-16 px-2">
         {/* Home - Shows Home/Explore tabs */}
         <Button

--- a/src/components/BottomNav.tsx
+++ b/src/components/BottomNav.tsx
@@ -1,6 +1,14 @@
+import { useState } from 'react';
 import { House as Home, Compass, VideoCamera as Video, Bell, UserCircle } from '@phosphor-icons/react';
 import { useLocation } from 'react-router-dom';
 import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
 import { useLoginDialog } from '@/contexts/LoginDialogContext';
 import { useCurrentUser } from '@/hooks/useCurrentUser';
 import { useUnreadNotificationCount } from '@/hooks/useNotifications';
@@ -8,12 +16,19 @@ import { useSubdomainNavigate } from '@/hooks/useSubdomainNavigate';
 import { buildProfileLinkPath } from '@/lib/profileLinks';
 import { cn } from '@/lib/utils';
 
+const uploadExplainer = {
+  title: 'Why no upload?',
+  body: 'What you see on Divine is human-made: raw and captured in the moment. Unlike platforms that allow highly produced or AI-generated uploads, we prioritize the authenticity of the camera-direct experience.',
+  detail: "By keeping creation inside the app, we can better guarantee that content is real and unedited. We aren't opening up external gallery uploads at this time to protect that realness and keep our community free of synthetic content as much as we can.",
+};
+
 export function BottomNav() {
   const navigate = useSubdomainNavigate();
   const location = useLocation();
   const { user } = useCurrentUser();
   const { data: unreadCount } = useUnreadNotificationCount();
   const { openLoginDialog } = useLoginDialog();
+  const [uploadExplainerOpen, setUploadExplainerOpen] = useState(false);
 
   const getUserProfilePath = () => {
     if (!user?.pubkey) return '/';
@@ -44,86 +59,102 @@ export function BottomNav() {
   };
 
   return (
-    <nav className="lg:hidden fixed bottom-0 left-0 right-0 z-50 bg-[#00150d] pb-[env(safe-area-inset-bottom)]">
-      <div className="flex items-center justify-between h-16 px-8 max-[360px]:px-4">
-        {/* Home */}
-        <Button
-          variant="ghost"
-          size="sm"
-          aria-label="Home"
-          onClick={() => navigate('/')}
-          className={cn(
-            "flex flex-col items-center justify-center gap-1 rounded-none hover:bg-transparent p-0",
-            isHomePage ? "text-primary" : "text-white"
-          )}
-        >
-          <Home className="w-8 h-8" weight={isHomePage ? 'fill' : 'bold'} />
-        </Button>
-
-        {/* Discover */}
-        <Button
-          variant="ghost"
-          size="sm"
-          aria-label="Discover"
-          onClick={() => navigate('/discovery')}
-          className={cn(
-            "flex flex-col items-center justify-center gap-1 rounded-none hover:bg-transparent p-0",
-            isActive('/discovery') ? "text-primary" : "text-white"
-          )}
-        >
-          <Compass className="w-8 h-8" weight={isActive('/discovery') ? 'fill' : 'bold'} />
-        </Button>
-
-        {/* Camera - green pill */}
-        <Button
-          variant="ghost"
-          size="sm"
-          aria-label="Upload"
-          onClick={() => handleAuthAction(() => navigate('/upload'))}
-          className="flex items-center justify-center bg-[#27c58b] rounded-[20px] px-5 py-2 hover:bg-[#27c58b]/90 text-white p-0"
-        >
-          <Video className="w-8 h-8 drop-shadow" weight="fill" />
-        </Button>
-
-        {/* Notifications */}
-        <Button
-          variant="ghost"
-          size="sm"
-          aria-label="Notifications"
-          onClick={() => handleAuthAction(() => navigate('/notifications'))}
-          className={cn(
-            "flex flex-col items-center justify-center gap-1 rounded-none hover:bg-transparent p-0",
-            isActive('/notifications') ? "text-primary" : "text-white"
-          )}
-        >
-          <div className="relative">
-            <Bell className="w-8 h-8" weight={isActive('/notifications') ? 'fill' : 'bold'} />
-            {(unreadCount ?? 0) > 0 && (
-              <span className="absolute -top-1 -right-1.5 flex h-3.5 min-w-3.5 items-center justify-center rounded-full bg-destructive px-0.5 text-[9px] font-bold text-destructive-foreground">
-                {(unreadCount ?? 0) > 99 ? '99+' : unreadCount}
-              </span>
+    <>
+      <nav className="lg:hidden fixed bottom-0 left-0 right-0 z-50 bg-brand-dark-green pb-[env(safe-area-inset-bottom)]">
+        <div className="flex items-center justify-between h-16 px-8 max-[360px]:px-4">
+          {/* Home */}
+          <Button
+            variant="ghost"
+            size="sm"
+            aria-label="Home"
+            onClick={() => navigate('/')}
+            className={cn(
+              "flex flex-col items-center justify-center gap-1 rounded-none hover:bg-transparent p-0",
+              isHomePage ? "text-primary" : "text-white"
             )}
-          </div>
-        </Button>
+          >
+            <Home className="w-8 h-8" weight={isHomePage ? 'fill' : 'bold'} />
+          </Button>
 
-        {/* Profile */}
-        <Button
-          variant="ghost"
-          size="sm"
-          aria-label="Profile"
-          onClick={handleProfileClick}
-          className={cn(
-            "flex flex-col items-center justify-center gap-1 rounded-none hover:bg-transparent p-0",
-            user && isActive(getUserProfilePath()) ? "text-primary" : "text-white"
-          )}
-        >
-          <UserCircle className="w-8 h-8" weight={user && isActive(getUserProfilePath()) ? 'fill' : 'bold'} />
-        </Button>
-      </div>
+          {/* Discover */}
+          <Button
+            variant="ghost"
+            size="sm"
+            aria-label="Discover"
+            onClick={() => navigate('/discovery')}
+            className={cn(
+              "flex flex-col items-center justify-center gap-1 rounded-none hover:bg-transparent p-0",
+              isActive('/discovery') ? "text-primary" : "text-white"
+            )}
+          >
+            <Compass className="w-8 h-8" weight={isActive('/discovery') ? 'fill' : 'bold'} />
+          </Button>
 
-      {/* Home indicator bar */}
-      <div className="w-[144px] h-[5px] bg-white rounded-full mx-auto mb-1" />
-    </nav>
+          {/* Camera */}
+          <Button
+            variant="ghost"
+            size="sm"
+            aria-label="Camera"
+            onClick={() => setUploadExplainerOpen(true)}
+            className="flex items-center justify-center bg-primary rounded-[20px] px-5 py-2 hover:bg-primary/90 text-white p-0"
+          >
+            <Video className="w-8 h-8 drop-shadow" weight="fill" />
+          </Button>
+
+          {/* Notifications */}
+          <Button
+            variant="ghost"
+            size="sm"
+            aria-label="Notifications"
+            onClick={() => handleAuthAction(() => navigate('/notifications'))}
+            className={cn(
+              "flex flex-col items-center justify-center gap-1 rounded-none hover:bg-transparent p-0",
+              isActive('/notifications') ? "text-primary" : "text-white"
+            )}
+          >
+            <div className="relative">
+              <Bell className="w-8 h-8" weight={isActive('/notifications') ? 'fill' : 'bold'} />
+              {(unreadCount ?? 0) > 0 && (
+                <span className="absolute -top-1 -right-1.5 flex h-3.5 min-w-3.5 items-center justify-center rounded-full bg-destructive px-0.5 text-[9px] font-bold text-destructive-foreground">
+                  {(unreadCount ?? 0) > 99 ? '99+' : unreadCount}
+                </span>
+              )}
+            </div>
+          </Button>
+
+          {/* Profile */}
+          <Button
+            variant="ghost"
+            size="sm"
+            aria-label="Profile"
+            onClick={handleProfileClick}
+            className={cn(
+              "flex flex-col items-center justify-center gap-1 rounded-none hover:bg-transparent p-0",
+              user && isActive(getUserProfilePath()) ? "text-primary" : "text-white"
+            )}
+          >
+            <UserCircle className="w-8 h-8" weight={user && isActive(getUserProfilePath()) ? 'fill' : 'bold'} />
+          </Button>
+        </div>
+
+        {/* Home indicator bar */}
+        <div className="w-[144px] h-[5px] bg-white rounded-full mx-auto mb-1" />
+      </nav>
+
+      <Dialog open={uploadExplainerOpen} onOpenChange={setUploadExplainerOpen}>
+        <DialogContent className="max-w-[calc(100vw-2rem)] rounded-[20px] border-brand-dark-green">
+          <DialogHeader>
+            <DialogTitle className="font-['Bricolage_Grotesque'] text-2xl font-extrabold text-foreground">
+              {uploadExplainer.title}
+            </DialogTitle>
+            <DialogDescription className="space-y-3 pt-2 text-left text-sm leading-6 text-muted-foreground">
+              <span className="block">{uploadExplainer.body}</span>
+              <span className="block">{uploadExplainer.detail}</span>
+            </DialogDescription>
+          </DialogHeader>
+        </DialogContent>
+      </Dialog>
+    </>
   );
 }
 

--- a/src/components/BottomNav.tsx
+++ b/src/components/BottomNav.tsx
@@ -1,4 +1,4 @@
-import { House as Home, MagnifyingGlass as Search, VideoCamera as Video, Bell, UserCircle } from '@phosphor-icons/react';
+import { House as Home, Compass, VideoCamera as Video, Bell, UserCircle } from '@phosphor-icons/react';
 import { useLocation } from 'react-router-dom';
 import { Button } from '@/components/ui/button';
 import { useLoginDialog } from '@/contexts/LoginDialogContext';
@@ -45,7 +45,7 @@ export function BottomNav() {
 
   return (
     <nav className="lg:hidden fixed bottom-0 left-0 right-0 z-50 bg-[#00150d] pb-[env(safe-area-inset-bottom)]">
-      <div className="flex items-center justify-center gap-12 h-16 px-2">
+      <div className="flex items-center justify-between h-16 px-8 max-[360px]:px-4">
         {/* Home */}
         <Button
           variant="ghost"
@@ -60,18 +60,18 @@ export function BottomNav() {
           <Home className="w-8 h-8" weight={isHomePage ? 'fill' : 'bold'} />
         </Button>
 
-        {/* Search */}
+        {/* Discover */}
         <Button
           variant="ghost"
           size="sm"
-          aria-label="Search"
+          aria-label="Discover"
           onClick={() => navigate('/discovery')}
           className={cn(
             "flex flex-col items-center justify-center gap-1 rounded-none hover:bg-transparent p-0",
             isActive('/discovery') ? "text-primary" : "text-white"
           )}
         >
-          <Search className="w-8 h-8" weight={isActive('/discovery') ? 'bold' : 'regular'} />
+          <Compass className="w-8 h-8" weight={isActive('/discovery') ? 'fill' : 'bold'} />
         </Button>
 
         {/* Camera - green pill */}

--- a/src/components/DeleteCommentDialog.tsx
+++ b/src/components/DeleteCommentDialog.tsx
@@ -62,7 +62,7 @@ export function DeleteCommentDialog({
         <div className="space-y-4 py-4">
           {/* Comment preview */}
           {comment.content && (
-            <div className="rounded-lg border p-3 bg-brand-light-green dark:bg-brand-dark-green">
+            <div className="rounded-lg border p-3 bg-brand-light-green dark:bg-brand-dark-green max-lg:bg-brand-dark-green">
               <p className="text-sm line-clamp-3">{comment.content}</p>
             </div>
           )}
@@ -86,8 +86,8 @@ export function DeleteCommentDialog({
           </div>
 
           {/* Warning */}
-          <div className="bg-brand-yellow-light border border-brand-yellow rounded-lg p-3 dark:bg-brand-yellow-dark">
-            <p className="text-sm text-brand-yellow-dark dark:text-brand-yellow-light">
+          <div className="bg-brand-yellow-light border border-brand-yellow rounded-lg p-3 dark:bg-brand-yellow-dark max-lg:bg-brand-yellow-dark">
+            <p className="text-sm text-brand-yellow-dark dark:text-brand-yellow-light max-lg:text-brand-yellow-light">
               <strong>{t('deleteCommentDialog.noteLabel')}</strong> {t('deleteCommentDialog.noteBody')}
             </p>
           </div>

--- a/src/components/ImmersiveTopBar.tsx
+++ b/src/components/ImmersiveTopBar.tsx
@@ -1,0 +1,59 @@
+// ABOUTME: Transparent/solid overlay top bar for mobile/tablet screens (< lg)
+// ABOUTME: Shows hamburger menu, page title, and search button with scrim pill styling
+
+import { useState } from 'react';
+import { Menu, Search } from 'lucide-react';
+import { useSubdomainNavigate } from '@/hooks/useSubdomainNavigate';
+import { MobileDrawer } from '@/components/MobileDrawer';
+
+export interface ImmersiveTopBarProps {
+  title?: string;
+  variant?: 'transparent' | 'solid';
+}
+
+export function ImmersiveTopBar({ title = 'Home', variant = 'transparent' }: ImmersiveTopBarProps) {
+  const navigate = useSubdomainNavigate();
+  const [drawerOpen, setDrawerOpen] = useState(false);
+
+  return (
+    <>
+      <header
+        className={`fixed top-0 left-0 right-0 z-50 lg:hidden pt-[env(safe-area-inset-top)] ${
+          variant === 'solid' ? 'bg-background' : 'bg-transparent'
+        }`}
+      >
+        <div className="flex h-14 items-center justify-between px-4">
+          {/* Left: Menu button in scrim pill */}
+          <button
+            onClick={() => setDrawerOpen(true)}
+            className="flex items-center justify-center bg-black/65 rounded-[20px] p-3"
+            aria-label="Open menu"
+          >
+            <Menu className="h-6 w-6 text-white" />
+          </button>
+
+          {/* Center: Page title */}
+          <span
+            className="font-extrabold text-xl text-white"
+            style={{ fontFamily: "'Bricolage Grotesque', system-ui, sans-serif" }}
+          >
+            {title}
+          </span>
+
+          {/* Right: Search button in scrim pill */}
+          <button
+            onClick={() => navigate('/search')}
+            className="flex items-center justify-center bg-black/65 rounded-[20px] p-3"
+            aria-label="Search"
+          >
+            <Search className="h-6 w-6 text-white" />
+          </button>
+        </div>
+      </header>
+
+      <MobileDrawer open={drawerOpen} onOpenChange={setDrawerOpen} />
+    </>
+  );
+}
+
+export default ImmersiveTopBar;

--- a/src/components/ImmersiveTopBar.tsx
+++ b/src/components/ImmersiveTopBar.tsx
@@ -18,15 +18,15 @@ export function ImmersiveTopBar({ title = 'Home', variant = 'transparent' }: Imm
   return (
     <>
       <header
-        className={`fixed top-0 left-0 right-0 z-50 lg:hidden pt-[env(safe-area-inset-top)] ${
+        className={`fixed left-0 top-0 z-50 w-screen overflow-hidden pt-[env(safe-area-inset-top)] lg:hidden ${
           variant === 'solid' ? 'bg-background' : 'bg-transparent'
         }`}
       >
-        <div className="flex h-14 items-center justify-between px-4">
+        <div className="grid h-14 grid-cols-[48px_1fr_48px] items-center px-4">
           {/* Left: Menu button in scrim pill */}
           <button
             onClick={() => setDrawerOpen(true)}
-            className="flex items-center justify-center bg-black/65 rounded-[20px] p-3"
+            className="flex h-12 w-12 items-center justify-center rounded-[20px] bg-black/65"
             aria-label="Open menu"
           >
             <Menu className="h-6 w-6 text-white" />
@@ -34,7 +34,7 @@ export function ImmersiveTopBar({ title = 'Home', variant = 'transparent' }: Imm
 
           {/* Center: Page title */}
           <span
-            className="font-extrabold text-xl text-white"
+            className="min-w-0 justify-self-center truncate px-3 text-xl font-extrabold text-white"
             style={{ fontFamily: "'Bricolage Grotesque', system-ui, sans-serif" }}
           >
             {title}
@@ -43,7 +43,7 @@ export function ImmersiveTopBar({ title = 'Home', variant = 'transparent' }: Imm
           {/* Right: Search button in scrim pill */}
           <button
             onClick={() => navigate('/search')}
-            className="flex items-center justify-center bg-black/65 rounded-[20px] p-3"
+            className="flex h-12 w-12 items-center justify-center rounded-[20px] bg-black/65"
             aria-label="Search"
           >
             <Search className="h-6 w-6 text-white" />

--- a/src/components/ImmersiveTopBar.tsx
+++ b/src/components/ImmersiveTopBar.tsx
@@ -18,7 +18,7 @@ export function ImmersiveTopBar({ title = 'Home', variant = 'transparent' }: Imm
   return (
     <>
       <header
-        className={`fixed left-0 top-0 z-50 w-screen overflow-hidden pt-[env(safe-area-inset-top)] lg:hidden ${
+        className={`fixed left-0 top-0 z-50 h-[var(--top-bar-height)] w-screen overflow-hidden pt-[var(--sat)] lg:hidden ${
           variant === 'solid' ? 'bg-background' : 'bg-transparent'
         }`}
       >

--- a/src/components/ImmersiveTopBar.tsx
+++ b/src/components/ImmersiveTopBar.tsx
@@ -2,7 +2,7 @@
 // ABOUTME: Shows hamburger menu, page title, and search button with scrim pill styling
 
 import { useState } from 'react';
-import { Menu, Search } from 'lucide-react';
+import { List as Menu, MagnifyingGlass as Search } from '@phosphor-icons/react';
 import { useSubdomainNavigate } from '@/hooks/useSubdomainNavigate';
 import { MobileDrawer } from '@/components/MobileDrawer';
 

--- a/src/components/MobileDrawer.tsx
+++ b/src/components/MobileDrawer.tsx
@@ -1,0 +1,275 @@
+// ABOUTME: Left-sliding drawer for mobile navigation, mirrors AppSidebar nav items
+// ABOUTME: Uses shadcn Sheet component, slides from left, closes on nav item tap
+
+import { useLocation } from 'react-router-dom';
+import { Home, Compass, Search, Bell, User, Sun, Moon, MessageCircle, BarChart3, LayoutGrid, ChevronDown } from 'lucide-react';
+import { useState } from 'react';
+import { nip19 } from 'nostr-tools';
+
+import {
+  Sheet,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+} from '@/components/ui/sheet';
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from '@/components/ui/collapsible';
+import { useCurrentUser } from '@/hooks/useCurrentUser';
+import { useUnreadNotificationCount } from '@/hooks/useNotifications';
+import { useDmCapability, useUnreadDmCount } from '@/hooks/useDirectMessages';
+import { useSubdomainNavigate } from '@/hooks/useSubdomainNavigate';
+import { getSubdomainUser } from '@/hooks/useSubdomainUser';
+import { useTheme } from '@/hooks/useTheme';
+import { useCategories } from '@/hooks/useCategories';
+import { LoginArea } from '@/components/auth/LoginArea';
+import { cn } from '@/lib/utils';
+
+export interface MobileDrawerProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+function DrawerNavItem({
+  icon,
+  label,
+  onClick,
+  isActive,
+}: {
+  icon: React.ReactNode;
+  label: string;
+  onClick: () => void;
+  isActive?: boolean;
+}) {
+  return (
+    <button
+      onClick={onClick}
+      className={cn(
+        "flex w-full items-center gap-3 rounded-lg px-3 py-2.5 text-[15px] transition-all duration-150",
+        isActive
+          ? "bg-primary text-primary-foreground font-medium"
+          : "text-muted-foreground font-normal hover:bg-muted hover:text-foreground hover:font-medium"
+      )}
+    >
+      {icon}
+      <span>{label}</span>
+    </button>
+  );
+}
+
+export function MobileDrawer({ open, onOpenChange }: MobileDrawerProps) {
+  const navigate = useSubdomainNavigate();
+  const location = useLocation();
+  const { user } = useCurrentUser();
+  const { canUseDirectMessages } = useDmCapability();
+  const { displayTheme, setTheme } = useTheme();
+  const subdomainUser = getSubdomainUser();
+  const { data: unreadCount } = useUnreadNotificationCount();
+  const { data: unreadDmCount } = useUnreadDmCount();
+  const { data: categories } = useCategories();
+  const [categoriesOpen, setCategoriesOpen] = useState(true);
+
+  const isActive = (path: string) => location.pathname === path;
+  const isDiscoveryActive = () =>
+    location.pathname === '/discovery' || location.pathname.startsWith('/discovery/');
+  const isMessagesActive = () =>
+    location.pathname === '/messages' || location.pathname.startsWith('/messages/');
+
+  const profilePath = user?.pubkey
+    ? `/profile/${nip19.npubEncode(user.pubkey)}`
+    : null;
+
+  const navigateAndClose = (path: string) => {
+    navigate(path);
+    onOpenChange(false);
+  };
+
+  const toggleTheme = () => {
+    setTheme(displayTheme === 'dark' ? 'light' : 'dark');
+  };
+
+  return (
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetContent side="left" className="w-[80%] max-w-[320px] p-0 overflow-y-auto">
+        <SheetHeader className="px-5 pt-5 pb-2">
+          <SheetTitle className="text-left">
+            <button
+              onClick={() => navigateAndClose('/')}
+              aria-label="Go to home"
+              className="transition-opacity hover:opacity-80"
+            >
+              <img
+                src="/divine-logo.svg"
+                alt="diVine"
+                className="h-[22px]"
+              />
+            </button>
+          </SheetTitle>
+        </SheetHeader>
+
+        {/* Main Navigation */}
+        <nav className="flex flex-col gap-0.5 px-3 pt-2">
+          <DrawerNavItem
+            icon={<Search className="h-[18px] w-[18px]" />}
+            label="Search"
+            onClick={() => navigateAndClose('/search')}
+            isActive={isActive('/search')}
+          />
+
+          {user && (
+            <DrawerNavItem
+              icon={<Home className="h-[18px] w-[18px]" />}
+              label="Home"
+              onClick={() => navigateAndClose('/')}
+              isActive={isActive('/')}
+            />
+          )}
+
+          <DrawerNavItem
+            icon={<Compass className="h-[18px] w-[18px]" />}
+            label="Discover"
+            onClick={() => navigateAndClose('/discovery')}
+            isActive={isDiscoveryActive()}
+          />
+
+          {user && canUseDirectMessages && (
+            <DrawerNavItem
+              icon={
+                <div className="relative">
+                  <MessageCircle className="h-[18px] w-[18px]" />
+                  {(unreadDmCount ?? 0) > 0 && (
+                    <span className="absolute -top-1 -right-2 flex h-3.5 min-w-3.5 items-center justify-center rounded-full bg-primary px-0.5 text-[9px] font-bold text-primary-foreground">
+                      {(unreadDmCount ?? 0) > 99 ? '99+' : unreadDmCount}
+                    </span>
+                  )}
+                </div>
+              }
+              label="Messages"
+              onClick={() => navigateAndClose('/messages')}
+              isActive={isMessagesActive()}
+            />
+          )}
+
+          {user && (
+            <DrawerNavItem
+              icon={
+                <div className="relative">
+                  <Bell className="h-[18px] w-[18px]" />
+                  {(unreadCount ?? 0) > 0 && (
+                    <span className="absolute -top-1 -right-2 flex h-3.5 min-w-3.5 items-center justify-center rounded-full bg-destructive px-0.5 text-[9px] font-bold text-destructive-foreground">
+                      {(unreadCount ?? 0) > 99 ? '99+' : unreadCount}
+                    </span>
+                  )}
+                </div>
+              }
+              label="Notifications"
+              onClick={() => navigateAndClose('/notifications')}
+              isActive={isActive('/notifications')}
+            />
+          )}
+
+          {user && profilePath && (
+            <DrawerNavItem
+              icon={<User className="h-[18px] w-[18px]" />}
+              label="Profile"
+              onClick={() => navigateAndClose(profilePath)}
+              isActive={location.pathname === profilePath}
+            />
+          )}
+
+          {user && (
+            <DrawerNavItem
+              icon={<BarChart3 className="h-[18px] w-[18px]" />}
+              label="Analytics"
+              onClick={() => navigateAndClose('/analytics')}
+              isActive={isActive('/analytics')}
+            />
+          )}
+        </nav>
+
+        {/* Categories */}
+        {categories && categories.length > 0 && (
+          <div className="mt-4 px-3">
+            <Collapsible open={categoriesOpen} onOpenChange={setCategoriesOpen}>
+              <CollapsibleTrigger asChild>
+                <button
+                  className="group flex w-full items-center gap-2 rounded-lg px-3 py-2 text-[13px] font-semibold text-muted-foreground transition-colors hover:text-foreground"
+                >
+                  <LayoutGrid className="h-4 w-4" />
+                  <span>Categories</span>
+                  <ChevronDown className={cn(
+                    "ml-auto h-3.5 w-3.5 transition-transform duration-200",
+                    categoriesOpen && "rotate-180"
+                  )} />
+                </button>
+              </CollapsibleTrigger>
+              <CollapsibleContent className="overflow-hidden data-[state=closed]:animate-accordion-up data-[state=open]:animate-accordion-down">
+                <div className="flex flex-col gap-0.5 pt-1">
+                  {categories.slice(0, 12).map(cat => (
+                    <button
+                      key={cat.name}
+                      onClick={() => navigateAndClose(`/category/${cat.name}`)}
+                      className={cn(
+                        "flex w-full items-center gap-3 rounded-lg px-3 py-2 text-[14px] transition-all duration-150",
+                        location.pathname === `/category/${cat.name}`
+                          ? "bg-primary text-primary-foreground font-medium"
+                          : "text-muted-foreground hover:bg-muted hover:text-foreground"
+                      )}
+                    >
+                      <span className="text-base leading-none w-5 text-center">
+                        {cat.config?.emoji || ''}
+                      </span>
+                      <span>{cat.config?.label || cat.name}</span>
+                    </button>
+                  ))}
+                </div>
+              </CollapsibleContent>
+            </Collapsible>
+          </div>
+        )}
+
+        {/* Theme Toggle */}
+        <div className="mt-4 px-3">
+          <button
+            onClick={toggleTheme}
+            className="group flex w-full items-center gap-3 rounded-lg px-3 py-2.5 text-[15px] font-normal text-muted-foreground transition-all duration-150 hover:bg-muted hover:text-foreground hover:font-medium"
+          >
+            <span className="transition-transform duration-150 group-hover:scale-105">
+              {displayTheme === 'dark' ? (
+                <Sun className="h-[18px] w-[18px]" />
+              ) : (
+                <Moon className="h-[18px] w-[18px]" />
+              )}
+            </span>
+            <span>{displayTheme === 'dark' ? 'Light mode' : 'Dark mode'}</span>
+          </button>
+        </div>
+
+        {/* Auth / Login */}
+        <div className="mt-6 px-4 pb-6">
+          {subdomainUser ? (
+            <a
+              href={`https://${subdomainUser.apexDomain}/`}
+              className="flex w-full items-center justify-center rounded-lg border border-border h-11 text-[15px] font-medium text-foreground transition-colors hover:border-primary hover:text-primary"
+            >
+              Log in on Divine
+            </a>
+          ) : (
+            <LoginArea
+              className={cn(
+                "flex-col gap-2.5 w-full",
+                "[&>button]:w-full [&>button]:justify-center [&>button]:rounded-lg [&>button]:h-11 [&>button]:text-[15px]",
+                "[&>button:first-child]:border-border [&>button:first-child]:hover:border-primary",
+                "[&_.account-switcher]:w-full"
+              )}
+            />
+          )}
+        </div>
+      </SheetContent>
+    </Sheet>
+  );
+}
+
+export default MobileDrawer;

--- a/src/components/MobileDrawer.tsx
+++ b/src/components/MobileDrawer.tsx
@@ -2,9 +2,20 @@
 // ABOUTME: Uses shadcn Sheet component, slides from left, closes on nav item tap
 
 import { useLocation } from 'react-router-dom';
-import { Home, Compass, Search, Bell, User, Sun, Moon, MessageCircle, BarChart3, LayoutGrid, ChevronDown } from 'lucide-react';
+import {
+  House as Home,
+  Compass,
+  MagnifyingGlass as Search,
+  Bell,
+  User,
+  Sun,
+  Moon,
+  ChatCircle as MessageCircle,
+  ChartBar as BarChart3,
+  SquaresFour as LayoutGrid,
+  CaretDown as ChevronDown,
+} from '@phosphor-icons/react';
 import { useState } from 'react';
-import { nip19 } from 'nostr-tools';
 
 import {
   Sheet,
@@ -25,6 +36,7 @@ import { getSubdomainUser } from '@/hooks/useSubdomainUser';
 import { useTheme } from '@/hooks/useTheme';
 import { useCategories } from '@/hooks/useCategories';
 import { LoginArea } from '@/components/auth/LoginArea';
+import { buildProfileLinkPath } from '@/lib/profileLinks';
 import { cn } from '@/lib/utils';
 
 export interface MobileDrawerProps {
@@ -78,11 +90,11 @@ export function MobileDrawer({ open, onOpenChange }: MobileDrawerProps) {
     location.pathname === '/messages' || location.pathname.startsWith('/messages/');
 
   const profilePath = user?.pubkey
-    ? `/profile/${nip19.npubEncode(user.pubkey)}`
+    ? buildProfileLinkPath({ pubkey: user.pubkey, fallbackRoute: 'profile' })
     : null;
 
-  const navigateAndClose = (path: string) => {
-    navigate(path);
+  const navigateAndClose = (path: string, ownerPubkey?: string | null) => {
+    navigate(path, { ownerPubkey });
     onOpenChange(false);
   };
 
@@ -174,7 +186,7 @@ export function MobileDrawer({ open, onOpenChange }: MobileDrawerProps) {
             <DrawerNavItem
               icon={<User className="h-[18px] w-[18px]" />}
               label="Profile"
-              onClick={() => navigateAndClose(profilePath)}
+              onClick={() => navigateAndClose(profilePath, user.pubkey)}
               isActive={location.pathname === profilePath}
             />
           )}

--- a/src/components/MobileDrawer.tsx
+++ b/src/components/MobileDrawer.tsx
@@ -8,8 +8,6 @@ import {
   MagnifyingGlass as Search,
   Bell,
   User,
-  Sun,
-  Moon,
   ChatCircle as MessageCircle,
   ChartBar as BarChart3,
   SquaresFour as LayoutGrid,
@@ -33,7 +31,6 @@ import { useUnreadNotificationCount } from '@/hooks/useNotifications';
 import { useDmCapability, useUnreadDmCount } from '@/hooks/useDirectMessages';
 import { useSubdomainNavigate } from '@/hooks/useSubdomainNavigate';
 import { getSubdomainUser } from '@/hooks/useSubdomainUser';
-import { useTheme } from '@/hooks/useTheme';
 import { useCategories } from '@/hooks/useCategories';
 import { LoginArea } from '@/components/auth/LoginArea';
 import { buildProfileLinkPath } from '@/lib/profileLinks';
@@ -76,7 +73,6 @@ export function MobileDrawer({ open, onOpenChange }: MobileDrawerProps) {
   const location = useLocation();
   const { user } = useCurrentUser();
   const { canUseDirectMessages } = useDmCapability();
-  const { displayTheme, setTheme } = useTheme();
   const subdomainUser = getSubdomainUser();
   const { data: unreadCount } = useUnreadNotificationCount();
   const { data: unreadDmCount } = useUnreadDmCount();
@@ -96,10 +92,6 @@ export function MobileDrawer({ open, onOpenChange }: MobileDrawerProps) {
   const navigateAndClose = (path: string, ownerPubkey?: string | null) => {
     navigate(path, { ownerPubkey });
     onOpenChange(false);
-  };
-
-  const toggleTheme = () => {
-    setTheme(displayTheme === 'dark' ? 'light' : 'dark');
   };
 
   return (
@@ -241,23 +233,6 @@ export function MobileDrawer({ open, onOpenChange }: MobileDrawerProps) {
             </Collapsible>
           </div>
         )}
-
-        {/* Theme Toggle */}
-        <div className="mt-4 px-3">
-          <button
-            onClick={toggleTheme}
-            className="group flex w-full items-center gap-3 rounded-lg px-3 py-2.5 text-[15px] font-normal text-muted-foreground transition-all duration-150 hover:bg-muted hover:text-foreground hover:font-medium"
-          >
-            <span className="transition-transform duration-150 group-hover:scale-105">
-              {displayTheme === 'dark' ? (
-                <Sun className="h-[18px] w-[18px]" />
-              ) : (
-                <Moon className="h-[18px] w-[18px]" />
-              )}
-            </span>
-            <span>{displayTheme === 'dark' ? 'Light mode' : 'Dark mode'}</span>
-          </button>
-        </div>
 
         {/* Auth / Login */}
         <div className="mt-6 px-4 pb-6">

--- a/src/components/MobileFeedView.test.tsx
+++ b/src/components/MobileFeedView.test.tsx
@@ -1,0 +1,87 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import type { ParsedVideoData } from '@/types/video';
+import { MobileFeedView } from './MobileFeedView';
+
+vi.mock('@/components/MobileVideoItem', () => ({
+  MobileVideoItem: ({
+    video,
+    isActive,
+    onOpenComments,
+  }: {
+    video: ParsedVideoData;
+    isActive: boolean;
+    onOpenComments?: (video: ParsedVideoData) => void;
+  }) => (
+    <section data-active={isActive}>
+      <p>{video.title}</p>
+      <button type="button" onClick={() => onOpenComments?.(video)}>
+        Comments for {video.title}
+      </button>
+    </section>
+  ),
+}));
+
+function makeVideo(id: string): ParsedVideoData {
+  return {
+    id,
+    pubkey: `${id}pubkey`,
+    title: `Video ${id}`,
+    content: '',
+    videoUrl: `https://example.com/${id}.mp4`,
+    thumbnailUrl: '',
+    hashtags: [],
+    vineId: null,
+    isVineMigrated: false,
+    reposts: [],
+    createdAt: 1,
+    kind: 34236,
+  };
+}
+
+describe('MobileFeedView', () => {
+  it('opens comments for the selected mobile video', () => {
+    const onOpenComments = vi.fn();
+    const video = makeVideo('one');
+
+    render(<MobileFeedView videos={[video]} onOpenComments={onOpenComments} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Comments for Video one' }));
+
+    expect(onOpenComments).toHaveBeenCalledWith(video);
+  });
+
+  it('uses feed keyboard shortcuts outside editable controls', () => {
+    const scrollIntoView = vi.fn();
+    Object.defineProperty(HTMLElement.prototype, 'scrollIntoView', {
+      configurable: true,
+      value: scrollIntoView,
+    });
+
+    render(<MobileFeedView videos={[makeVideo('one'), makeVideo('two')]} />);
+
+    fireEvent.keyDown(window, { key: 'j' });
+
+    expect(scrollIntoView).toHaveBeenCalledWith({ behavior: 'smooth' });
+  });
+
+  it('ignores feed keyboard shortcuts from editable controls', () => {
+    const scrollIntoView = vi.fn();
+    Object.defineProperty(HTMLElement.prototype, 'scrollIntoView', {
+      configurable: true,
+      value: scrollIntoView,
+    });
+
+    render(
+      <>
+        <input aria-label="Comment" />
+        <MobileFeedView videos={[makeVideo('one'), makeVideo('two')]} />
+      </>
+    );
+
+    fireEvent.keyDown(screen.getByLabelText('Comment'), { key: 'j' });
+
+    expect(scrollIntoView).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/MobileFeedView.test.tsx
+++ b/src/components/MobileFeedView.test.tsx
@@ -14,7 +14,7 @@ vi.mock('@/components/MobileVideoItem', () => ({
     isActive: boolean;
     onOpenComments?: (video: ParsedVideoData) => void;
   }) => (
-    <section data-active={isActive}>
+    <section data-testid="mobile-video-item" data-active={isActive}>
       <p>{video.title}</p>
       <button type="button" onClick={() => onOpenComments?.(video)}>
         Comments for {video.title}
@@ -50,6 +50,15 @@ describe('MobileFeedView', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Comments for Video one' }));
 
     expect(onOpenComments).toHaveBeenCalledWith(video);
+  });
+
+  it('mounts only nearby video items while preserving snap positions', () => {
+    const videos = Array.from({ length: 12 }, (_, index) => makeVideo(`${index}`));
+
+    render(<MobileFeedView videos={videos} />);
+
+    expect(screen.getAllByTestId('mobile-video-item')).toHaveLength(4);
+    expect(screen.queryByText('Video 4')).not.toBeInTheDocument();
   });
 
   it('uses feed keyboard shortcuts outside editable controls', () => {

--- a/src/components/MobileFeedView.tsx
+++ b/src/components/MobileFeedView.tsx
@@ -1,0 +1,80 @@
+// ABOUTME: Snap-scroll mobile video feed for inline display below top bar and above bottom nav
+// ABOUTME: Renders one video per viewport height with CSS scroll-snap for native momentum scrolling
+
+import { useRef, useEffect, useState, useCallback } from 'react';
+import { MobileVideoItem } from '@/components/MobileVideoItem';
+import type { ParsedVideoData } from '@/types/video';
+
+interface MobileFeedViewProps {
+  videos: ParsedVideoData[];
+  onLoadMore?: () => void;
+  hasMore?: boolean;
+  onOpenComments?: (video: ParsedVideoData) => void;
+}
+
+export function MobileFeedView({
+  videos,
+  onLoadMore,
+  hasMore,
+  onOpenComments,
+}: MobileFeedViewProps) {
+  const [currentIndex, setCurrentIndex] = useState(0);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  // Track which video is most visible based on scroll position
+  const handleScroll = useCallback(() => {
+    const container = containerRef.current;
+    if (!container) return;
+
+    const scrollTop = container.scrollTop;
+    const itemHeight = container.clientHeight;
+    const newIndex = Math.round(scrollTop / itemHeight);
+
+    if (newIndex !== currentIndex && newIndex >= 0 && newIndex < videos.length) {
+      setCurrentIndex(newIndex);
+
+      // Load more when near end
+      if (hasMore && onLoadMore && newIndex >= videos.length - 3) {
+        onLoadMore();
+      }
+    }
+  }, [currentIndex, videos.length, hasMore, onLoadMore]);
+
+  // Keyboard navigation: ArrowDown/j = next, ArrowUp/k = previous
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'ArrowDown' || e.key === 'j') {
+        if (currentIndex < videos.length - 1) {
+          const target = containerRef.current?.children[currentIndex + 1] as HTMLElement;
+          target?.scrollIntoView({ behavior: 'smooth' });
+        }
+      } else if (e.key === 'ArrowUp' || e.key === 'k') {
+        if (currentIndex > 0) {
+          const target = containerRef.current?.children[currentIndex - 1] as HTMLElement;
+          target?.scrollIntoView({ behavior: 'smooth' });
+        }
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [currentIndex, videos.length]);
+
+  return (
+    <div
+      ref={containerRef}
+      className="h-[var(--feed-height)] w-full overflow-y-scroll snap-y snap-mandatory scrollbar-hide"
+      onScroll={handleScroll}
+    >
+      {videos.map((video, index) => (
+        <MobileVideoItem
+          key={video.id}
+          video={video}
+          isActive={index === currentIndex}
+          onOpenComments={onOpenComments}
+          videoIndex={index}
+        />
+      ))}
+    </div>
+  );
+}

--- a/src/components/MobileFeedView.tsx
+++ b/src/components/MobileFeedView.tsx
@@ -12,6 +12,12 @@ interface MobileFeedViewProps {
   onOpenComments?: (video: ParsedVideoData) => void;
 }
 
+function isEditableTarget(target: EventTarget | null) {
+  if (!(target instanceof HTMLElement)) return false;
+
+  return Boolean(target.closest('input, textarea, select, [contenteditable="true"], [role="textbox"]'));
+}
+
 export function MobileFeedView({
   videos,
   onLoadMore,
@@ -43,13 +49,17 @@ export function MobileFeedView({
   // Keyboard navigation: ArrowDown/j = next, ArrowUp/k = previous
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
+      if (isEditableTarget(e.target)) return;
+
       if (e.key === 'ArrowDown' || e.key === 'j') {
         if (currentIndex < videos.length - 1) {
+          e.preventDefault();
           const target = containerRef.current?.children[currentIndex + 1] as HTMLElement;
           target?.scrollIntoView({ behavior: 'smooth' });
         }
       } else if (e.key === 'ArrowUp' || e.key === 'k') {
         if (currentIndex > 0) {
+          e.preventDefault();
           const target = containerRef.current?.children[currentIndex - 1] as HTMLElement;
           target?.scrollIntoView({ behavior: 'smooth' });
         }

--- a/src/components/MobileFeedView.tsx
+++ b/src/components/MobileFeedView.tsx
@@ -1,8 +1,10 @@
 // ABOUTME: Snap-scroll mobile video feed for inline display below top bar and above bottom nav
 // ABOUTME: Renders one video per viewport height with CSS scroll-snap for native momentum scrolling
 
-import { useRef, useEffect, useState, useCallback } from 'react';
+import { useRef, useEffect, useState, useCallback, type CSSProperties } from 'react';
+import { createPortal } from 'react-dom';
 import { MobileVideoItem } from '@/components/MobileVideoItem';
+import { cn } from '@/lib/utils';
 import type { ParsedVideoData } from '@/types/video';
 
 interface MobileFeedViewProps {
@@ -10,7 +12,11 @@ interface MobileFeedViewProps {
   onLoadMore?: () => void;
   hasMore?: boolean;
   onOpenComments?: (video: ParsedVideoData) => void;
+  transparentTopBar?: boolean;
 }
+
+const WINDOW_BACK = 2;
+const WINDOW_FORWARD = 3;
 
 function isEditableTarget(target: EventTarget | null) {
   if (!(target instanceof HTMLElement)) return false;
@@ -23,9 +29,17 @@ export function MobileFeedView({
   onLoadMore,
   hasMore,
   onOpenComments,
+  transparentTopBar = false,
 }: MobileFeedViewProps) {
   const [currentIndex, setCurrentIndex] = useState(0);
   const containerRef = useRef<HTMLDivElement>(null);
+  const feedStyle = transparentTopBar
+    ? ({ '--feed-height': 'calc(100dvh - var(--bottom-nav-height))' } as CSSProperties)
+    : undefined;
+
+  const shouldRenderVideo = useCallback((index: number) => {
+    return index >= currentIndex - WINDOW_BACK && index <= currentIndex + WINDOW_FORWARD;
+  }, [currentIndex]);
 
   // Track which video is most visible based on scroll position
   const handleScroll = useCallback(() => {
@@ -70,21 +84,38 @@ export function MobileFeedView({
     return () => window.removeEventListener('keydown', handleKeyDown);
   }, [currentIndex, videos.length]);
 
-  return (
+  const feed = (
     <div
       ref={containerRef}
-      className="h-[var(--feed-height)] w-full overflow-y-scroll snap-y snap-mandatory scrollbar-hide"
+      className={cn(
+        'lg:hidden fixed inset-x-0 bottom-[var(--bottom-nav-height)] z-30 w-full overflow-y-scroll snap-y snap-mandatory scrollbar-hide bg-black',
+        transparentTopBar ? 'top-0' : 'top-[var(--top-bar-height)]'
+      )}
+      style={feedStyle}
       onScroll={handleScroll}
     >
       {videos.map((video, index) => (
-        <MobileVideoItem
+        <div
           key={video.id}
-          video={video}
-          isActive={index === currentIndex}
-          onOpenComments={onOpenComments}
-          videoIndex={index}
-        />
+          className="h-[var(--feed-height)] w-full snap-start snap-always bg-black"
+          aria-hidden={!shouldRenderVideo(index) ? true : undefined}
+        >
+          {shouldRenderVideo(index) && (
+            <MobileVideoItem
+              video={video}
+              isActive={index === currentIndex}
+              onOpenComments={onOpenComments}
+              videoIndex={index}
+            />
+          )}
+        </div>
       ))}
     </div>
   );
+
+  if (typeof document === 'undefined') {
+    return feed;
+  }
+
+  return createPortal(feed, document.body);
 }

--- a/src/components/MobileVideoItem.tsx
+++ b/src/components/MobileVideoItem.tsx
@@ -1,0 +1,388 @@
+// ABOUTME: Full-viewport mobile video component with Figma-matched overlaid UI
+// ABOUTME: Renders a single video in the mobile swipe feed with action column, author overlay, and heart animation
+
+import { useState, useEffect, useCallback } from 'react';
+import { Heart, MessageCircle, Repeat2, Share2, ChevronDown } from 'lucide-react';
+import { nip19 } from 'nostr-tools';
+import { VideoPlayer } from '@/components/VideoPlayer';
+import { VideoCommentsModal } from '@/components/VideoCommentsModal';
+import { SmartLink } from '@/components/SmartLink';
+import { NoteContent } from '@/components/NoteContent';
+import { VideoVerificationBadgeRow } from '@/components/VideoVerificationBadgeRow';
+import { InlineBadges } from '@/components/InlineBadges';
+import { useAuthor } from '@/hooks/useAuthor';
+import { useVideoPlayback } from '@/hooks/useVideoPlayback';
+import { useDeferredVideoMetrics } from '@/hooks/useDeferredVideoMetrics';
+import { useOptimisticLike } from '@/hooks/useOptimisticLike';
+import { useOptimisticRepost } from '@/hooks/useOptimisticRepost';
+import { useCurrentUser } from '@/hooks/useCurrentUser';
+import { useLoginDialog } from '@/contexts/LoginDialogContext';
+import { useShare } from '@/hooks/useShare';
+import { useToast } from '@/hooks/useToast';
+import { useBadges } from '@/hooks/useBadges';
+import { useBandwidthTier } from '@/hooks/useBandwidthTier';
+import { useSubtitles } from '@/hooks/useSubtitles';
+import { enhanceAuthorData } from '@/lib/generateProfile';
+import { genUserName } from '@/lib/genUserName';
+import { getSafeProfileImage } from '@/lib/imageUtils';
+import { getOptimalVideoUrl } from '@/lib/bandwidthTracker';
+import { getVideoShareData } from '@/lib/shareUtils';
+import { formatCount } from '@/lib/formatUtils';
+import { cn } from '@/lib/utils';
+import { debugLog } from '@/lib/debug';
+import type { ParsedVideoData } from '@/types/video';
+import type { VideoNavigationContext } from '@/hooks/useVideoNavigation';
+
+interface MobileVideoItemProps {
+  video: ParsedVideoData;
+  isActive: boolean;
+  onOpenComments?: (video: ParsedVideoData) => void;
+  navigationContext?: VideoNavigationContext;
+  videoIndex?: number;
+}
+
+export function MobileVideoItem({
+  video,
+  isActive,
+  onOpenComments,
+  navigationContext: _navigationContext,
+  videoIndex = 0,
+}: MobileVideoItemProps) {
+  // --- Video playback ---
+  const _bandwidthTier = useBandwidthTier();
+  const optimalHlsUrl = getOptimalVideoUrl(video.videoUrl);
+  const effectiveHlsUrl = video.hlsUrl || (optimalHlsUrl !== video.videoUrl ? optimalHlsUrl : undefined);
+  const { setActiveVideo } = useVideoPlayback();
+  const { cues: subtitleCues, hasSubtitles } = useSubtitles(video);
+  const [subtitlesVisible, setSubtitlesVisible] = useState(true);
+  const showSubtitles = subtitlesVisible && hasSubtitles;
+
+  const [videoError, setVideoError] = useState(false);
+  const [showHeartAnimation, setShowHeartAnimation] = useState(false);
+  const [showComments, setShowComments] = useState(false);
+  const [showMoreMenu, setShowMoreMenu] = useState(false);
+
+  // --- Auth & social ---
+  const { user } = useCurrentUser();
+  const { openLoginDialog } = useLoginDialog();
+  const { toggleLike } = useOptimisticLike();
+  const { toggleRepost } = useOptimisticRepost();
+  const { share } = useShare();
+  const { toast } = useToast();
+
+  // Deferred metrics loading
+  const delay = videoIndex < 3 ? 0 : Math.min(videoIndex * 50, 500);
+  const { socialMetrics, userInteractions } = useDeferredVideoMetrics({
+    videoId: video.id,
+    videoPubkey: video.pubkey,
+    vineId: video.vineId,
+    userPubkey: user?.pubkey,
+    delay,
+    immediate: videoIndex < 3,
+  });
+
+  // Compute counts from video embedded + deferred delta
+  const likeCount = (video.likeCount ?? 0) + (socialMetrics.data?.likeCount ?? 0);
+  const repostCount = (video.repostCount ?? 0) + (socialMetrics.data?.repostCount ?? 0);
+  const commentCount = (video.commentCount ?? 0) + (socialMetrics.data?.commentCount ?? 0);
+  const isLiked = userInteractions.data?.hasLiked || false;
+  const isReposted = userInteractions.data?.hasReposted || false;
+
+  // --- Author data ---
+  const authorData = useAuthor(video.pubkey, {
+    initialName: video.authorName,
+    initialAvatar: video.authorAvatar,
+  });
+  const author = enhanceAuthorData(authorData.data, video.pubkey);
+  const badgesQuery = useBadges(video.pubkey);
+  const rawMetadata = authorData.data?.metadata;
+  const hasRealName = rawMetadata?.display_name || rawMetadata?.name;
+  const displayName = hasRealName
+    ? (rawMetadata.display_name || rawMetadata.name!)
+    : (video.authorName || genUserName(video.pubkey));
+  const profileImage = getSafeProfileImage(
+    rawMetadata?.picture || video.authorAvatar || author.metadata.picture
+  );
+  const npub = nip19.npubEncode(video.pubkey);
+  const profileUrl = `/${npub}`;
+
+  // --- Detect classic Vine ---
+  const isClassicVine = !!video.loopCount || video.isVineMigrated ||
+    (video.originalVineTimestamp !== undefined && video.originalVineTimestamp < 1484611200);
+
+  // --- Set active video ---
+  useEffect(() => {
+    if (isActive) {
+      setActiveVideo(video.id);
+    }
+  }, [isActive, video.id, setActiveVideo]);
+
+  // --- Action handlers ---
+  const handleLike = useCallback(async () => {
+    if (!user) {
+      openLoginDialog();
+      return;
+    }
+    debugLog('Toggle like for video:', video.id);
+    await toggleLike({
+      videoId: video.id,
+      videoPubkey: video.pubkey,
+      vineId: video.vineId,
+      userPubkey: user.pubkey,
+      isCurrentlyLiked: isLiked,
+      currentLikeEventId: userInteractions.data?.likeEventId || null,
+    });
+  }, [user, video.id, video.pubkey, video.vineId, isLiked, userInteractions.data?.likeEventId, openLoginDialog, toggleLike]);
+
+  const handleRepost = useCallback(async () => {
+    if (!user) {
+      openLoginDialog();
+      return;
+    }
+    if (!video.vineId) {
+      toast({ title: 'Error', description: 'Cannot repost this video', variant: 'destructive' });
+      return;
+    }
+    debugLog('Toggle repost for video:', video.id);
+    await toggleRepost({
+      videoId: video.id,
+      videoPubkey: video.pubkey,
+      vineId: video.vineId,
+      userPubkey: user.pubkey,
+      isCurrentlyReposted: isReposted,
+      currentRepostEventId: userInteractions.data?.repostEventId || null,
+    });
+  }, [user, video.id, video.pubkey, video.vineId, isReposted, userInteractions.data?.repostEventId, openLoginDialog, toast, toggleRepost]);
+
+  const handleShare = useCallback(() => {
+    share(getVideoShareData(video));
+  }, [share, video]);
+
+  const handleDoubleTap = useCallback(() => {
+    handleLike();
+    setShowHeartAnimation(true);
+    setTimeout(() => setShowHeartAnimation(false), 800);
+  }, [handleLike]);
+
+  const handleOpenComments = useCallback(() => {
+    if (onOpenComments) {
+      onOpenComments(video);
+    } else {
+      setShowComments(true);
+    }
+  }, [onOpenComments, video]);
+
+  // --- Build badge text ---
+  const badgeTexts: string[] = [];
+  if (video.proofMode?.level === 'verified_mobile' || video.proofMode?.level === 'verified_web') {
+    badgeTexts.push('Human-made');
+  }
+  if (!video.origin) {
+    badgeTexts.push('Original');
+  }
+  if (isClassicVine) {
+    badgeTexts.push('Classic Viner');
+  }
+
+  // Location from author profile (if available)
+  const location = rawMetadata?.about ? undefined : undefined; // Location not reliably available
+
+  return (
+    <div
+      className="h-[var(--feed-height)] w-full snap-start snap-always relative bg-black overflow-hidden"
+    >
+      {/* Video layer (z-0) */}
+      <div className="absolute inset-0 z-0">
+        {!videoError ? (
+          <VideoPlayer
+            videoId={video.id}
+            src={video.videoUrl}
+            hlsUrl={effectiveHlsUrl}
+            fallbackUrls={video.fallbackVideoUrls}
+            poster={video.thumbnailUrl}
+            blurhash={video.blurhash}
+            className="absolute inset-0 w-full h-full object-contain"
+            onError={() => setVideoError(true)}
+            onDoubleTap={handleDoubleTap}
+            subtitleCues={subtitleCues}
+            subtitlesVisible={showSubtitles}
+            videoData={video}
+          />
+        ) : (
+          <div className="flex items-center justify-center h-full text-white">
+            <p>Failed to load video</p>
+          </div>
+        )}
+      </div>
+
+      {/* Gradient overlay */}
+      <div className="absolute bottom-0 left-0 right-0 h-[40%] bg-gradient-to-t from-black/40 via-black/20 via-[18%] to-transparent pointer-events-none z-[5]" />
+
+      {/* Heart animation (z-20) */}
+      {showHeartAnimation && (
+        <div className="absolute inset-0 z-20 flex items-center justify-center pointer-events-none">
+          <Heart
+            className="h-24 w-24 text-red-500 fill-current animate-ping"
+            style={{ animationDuration: '0.6s' }}
+          />
+        </div>
+      )}
+
+      {/* Action column (right side, z-10) */}
+      <div className="absolute right-2 bottom-[120px] z-10 flex flex-col items-center gap-4">
+        {/* Like */}
+        <button
+          className="flex flex-col items-center gap-1"
+          onClick={(e) => { e.stopPropagation(); handleLike(); }}
+          aria-label={isLiked ? 'Unlike' : 'Like'}
+        >
+          <Heart className={cn(
+            'w-8 h-8 text-white drop-shadow-lg',
+            isLiked && 'text-red-500 fill-current'
+          )} />
+          <span className={cn(
+            'text-[11px] font-semibold text-white drop-shadow-lg',
+            isLiked && 'text-red-500'
+          )}>
+            {formatCount(likeCount)}
+          </span>
+        </button>
+
+        {/* Comment */}
+        <button
+          className="flex flex-col items-center gap-1"
+          onClick={(e) => { e.stopPropagation(); handleOpenComments(); }}
+          aria-label="Comments"
+        >
+          <MessageCircle className="w-8 h-8 text-white drop-shadow-lg" />
+          <span className="text-[11px] font-semibold text-white drop-shadow-lg">
+            {formatCount(commentCount)}
+          </span>
+        </button>
+
+        {/* Repost */}
+        <button
+          className="flex flex-col items-center gap-1"
+          onClick={(e) => { e.stopPropagation(); handleRepost(); }}
+          aria-label={isReposted ? 'Remove repost' : 'Repost'}
+        >
+          <Repeat2 className={cn(
+            'w-8 h-8 text-white drop-shadow-lg',
+            isReposted && 'text-green-500'
+          )} />
+          <span className={cn(
+            'text-[11px] font-semibold text-white drop-shadow-lg',
+            isReposted && 'text-green-500'
+          )}>
+            {formatCount(repostCount)}
+          </span>
+        </button>
+
+        {/* Share */}
+        <button
+          className="flex flex-col items-center gap-1 p-2 rounded-[20px]"
+          onClick={(e) => { e.stopPropagation(); handleShare(); }}
+          aria-label="Share"
+        >
+          <Share2 className="w-8 h-8 text-white drop-shadow-lg" />
+        </button>
+
+        {/* More */}
+        <button
+          className="flex flex-col items-center gap-1 p-2 rounded-[20px]"
+          onClick={(e) => { e.stopPropagation(); setShowMoreMenu(!showMoreMenu); }}
+          aria-label="More options"
+        >
+          <ChevronDown className="w-8 h-8 text-white drop-shadow-lg" />
+        </button>
+      </div>
+
+      {/* Author overlay (bottom-left, z-10) */}
+      <div className="absolute bottom-4 left-4 right-16 z-10 flex flex-col gap-2">
+        {/* Avatar + Username row */}
+        <SmartLink
+          to={profileUrl}
+          ownerPubkey={video.pubkey}
+          className="flex items-center gap-3"
+          onClick={(e) => e.stopPropagation()}
+        >
+          <div className="w-12 h-12 rounded-[16px] border border-white/25 overflow-hidden flex-shrink-0">
+            <img
+              src={profileImage}
+              alt={displayName}
+              className="w-full h-full object-cover"
+              loading="lazy"
+            />
+          </div>
+          <div className="flex items-center gap-2 min-w-0">
+            <span className="font-['Bricolage_Grotesque'] font-extrabold text-sm text-white drop-shadow-lg truncate">
+              {displayName}
+            </span>
+            {badgesQuery.data && badgesQuery.data.length > 0 && (
+              <InlineBadges badges={badgesQuery.data} />
+            )}
+            <VideoVerificationBadgeRow video={video} />
+          </div>
+        </SmartLink>
+
+        {/* Location byline */}
+        {location && (
+          <span className="text-[11px] font-semibold text-white/75 drop-shadow-lg">
+            {location}
+          </span>
+        )}
+
+        {/* Caption */}
+        {(video.title || video.content) && (
+          <div className="text-xs text-white leading-4 line-clamp-2 drop-shadow-lg">
+            <NoteContent
+              event={{
+                id: video.id,
+                pubkey: video.pubkey,
+                created_at: video.createdAt,
+                kind: 1,
+                content: video.title || video.content || '',
+                tags: [],
+                sig: '',
+              }}
+              className="text-xs text-white"
+            />
+          </div>
+        )}
+
+        {/* Hashtags */}
+        {video.hashtags.length > 0 && (
+          <div className="flex flex-wrap gap-1">
+            {video.hashtags.slice(0, 3).map((tag) => (
+              <SmartLink
+                key={tag}
+                to={`/hashtag/${tag}`}
+                className="text-xs text-[#00bf8f] drop-shadow-lg"
+                onClick={(e) => e.stopPropagation()}
+              >
+                #{tag}
+              </SmartLink>
+            ))}
+            {video.hashtags.length > 3 && (
+              <span className="text-xs text-white/60">+{video.hashtags.length - 3}</span>
+            )}
+          </div>
+        )}
+
+        {/* Badges row */}
+        {badgeTexts.length > 0 && (
+          <span className="text-[11px] font-semibold text-white/75 drop-shadow-lg">
+            {badgeTexts.join(' \u00B7 ')}
+          </span>
+        )}
+      </div>
+
+      {/* Comments modal (fallback when no onOpenComments prop) */}
+      <VideoCommentsModal
+        video={video}
+        open={showComments}
+        onOpenChange={setShowComments}
+      />
+    </div>
+  );
+}

--- a/src/components/MobileVideoItem.tsx
+++ b/src/components/MobileVideoItem.tsx
@@ -7,7 +7,6 @@ import {
   ChatCircle as MessageCircle,
   Repeat as Repeat2,
   ShareNetwork as Share2,
-  CaretDown as ChevronDown,
 } from '@phosphor-icons/react';
 import { VideoPlayer } from '@/components/VideoPlayer';
 import { VideoCommentsModal } from '@/components/VideoCommentsModal';
@@ -66,7 +65,6 @@ export function MobileVideoItem({
   const [videoError, setVideoError] = useState(false);
   const [showHeartAnimation, setShowHeartAnimation] = useState(false);
   const [showComments, setShowComments] = useState(false);
-  const [showMoreMenu, setShowMoreMenu] = useState(false);
 
   // --- Auth & social ---
   const { user } = useCurrentUser();
@@ -192,9 +190,6 @@ export function MobileVideoItem({
     badgeTexts.push('Classic Viner');
   }
 
-  // Location from author profile (if available)
-  const location = rawMetadata?.about ? undefined : undefined; // Location not reliably available
-
   return (
     <div
       className="h-[var(--feed-height)] w-full snap-start snap-always relative bg-black overflow-hidden"
@@ -295,14 +290,6 @@ export function MobileVideoItem({
           <Share2 className="w-8 h-8 text-white drop-shadow-lg" />
         </button>
 
-        {/* More */}
-        <button
-          className="flex flex-col items-center gap-1 p-2 rounded-[20px]"
-          onClick={(e) => { e.stopPropagation(); setShowMoreMenu(!showMoreMenu); }}
-          aria-label="More options"
-        >
-          <ChevronDown className="w-8 h-8 text-white drop-shadow-lg" />
-        </button>
       </div>
 
       {/* Author overlay (bottom-left, z-10) */}
@@ -332,13 +319,6 @@ export function MobileVideoItem({
             <VideoVerificationBadgeRow video={video} />
           </div>
         </SmartLink>
-
-        {/* Location byline */}
-        {location && (
-          <span className="text-[11px] font-semibold text-white/75 drop-shadow-lg">
-            {location}
-          </span>
-        )}
 
         {/* Caption */}
         {(video.title || video.content) && (

--- a/src/components/MobileVideoItem.tsx
+++ b/src/components/MobileVideoItem.tsx
@@ -60,7 +60,7 @@ export function MobileVideoItem({
   const effectiveHlsUrl = video.hlsUrl || (optimalHlsUrl !== video.videoUrl ? optimalHlsUrl : undefined);
   const { setActiveVideo } = useVideoPlayback();
   const { cues: subtitleCues, hasSubtitles } = useSubtitles(video);
-  const [subtitlesVisible, setSubtitlesVisible] = useState(true);
+  const [subtitlesVisible] = useState(true);
   const showSubtitles = subtitlesVisible && hasSubtitles;
 
   const [videoError, setVideoError] = useState(false);
@@ -223,8 +223,8 @@ export function MobileVideoItem({
         )}
       </div>
 
-      {/* Gradient overlay */}
-      <div className="absolute bottom-0 left-0 right-0 h-[40%] bg-gradient-to-t from-black/40 via-black/20 via-[18%] to-transparent pointer-events-none z-[5]" />
+      {/* Flat scrim keeps overlay text readable without violating brand gradient rules. */}
+      <div className="absolute bottom-0 left-0 right-0 h-[40%] bg-black/25 pointer-events-none z-[5]" />
 
       {/* Heart animation (z-20) */}
       {showHeartAnimation && (

--- a/src/components/MobileVideoItem.tsx
+++ b/src/components/MobileVideoItem.tsx
@@ -2,8 +2,13 @@
 // ABOUTME: Renders a single video in the mobile swipe feed with action column, author overlay, and heart animation
 
 import { useState, useEffect, useCallback } from 'react';
-import { Heart, MessageCircle, Repeat2, Share2, ChevronDown } from 'lucide-react';
-import { nip19 } from 'nostr-tools';
+import {
+  Heart,
+  ChatCircle as MessageCircle,
+  Repeat as Repeat2,
+  ShareNetwork as Share2,
+  CaretDown as ChevronDown,
+} from '@phosphor-icons/react';
 import { VideoPlayer } from '@/components/VideoPlayer';
 import { VideoCommentsModal } from '@/components/VideoCommentsModal';
 import { SmartLink } from '@/components/SmartLink';
@@ -28,6 +33,7 @@ import { getSafeProfileImage } from '@/lib/imageUtils';
 import { getOptimalVideoUrl } from '@/lib/bandwidthTracker';
 import { getVideoShareData } from '@/lib/shareUtils';
 import { formatCount } from '@/lib/formatUtils';
+import { buildProfileLinkPath } from '@/lib/profileLinks';
 import { cn } from '@/lib/utils';
 import { debugLog } from '@/lib/debug';
 import type { ParsedVideoData } from '@/types/video';
@@ -103,8 +109,10 @@ export function MobileVideoItem({
   const profileImage = getSafeProfileImage(
     rawMetadata?.picture || video.authorAvatar || author.metadata.picture
   );
-  const npub = nip19.npubEncode(video.pubkey);
-  const profileUrl = `/${npub}`;
+  const profileUrl = buildProfileLinkPath({
+    pubkey: video.pubkey,
+    nip05: rawMetadata?.nip05,
+  });
 
   // --- Detect classic Vine ---
   const isClassicVine = !!video.loopCount || video.isVineMigrated ||

--- a/src/components/VideoFeed.tsx
+++ b/src/components/VideoFeed.tsx
@@ -469,6 +469,7 @@ export function VideoFeed({
   // Mobile/tablet snap-scroll feed (< 1024px, feed mode only)
   if (isMobileFeed && viewMode === 'feed') {
     const commentsVideo = filteredVideos.find(video => video.id === showCommentsForVideo);
+    const usesTransparentTopBar = feedType === 'home' && (location.pathname === '/' || location.pathname === '/home');
 
     return (
       <>
@@ -477,6 +478,7 @@ export function VideoFeed({
           onLoadMore={fetchNextPage}
           hasMore={hasNextPage}
           onOpenComments={handleOpenComments}
+          transparentTopBar={usesTransparentTopBar}
         />
         {commentsVideo && (
           <VideoCommentsModal

--- a/src/components/VideoFeed.tsx
+++ b/src/components/VideoFeed.tsx
@@ -7,6 +7,7 @@ import { useLocation } from 'react-router-dom';
 import { performanceMonitor } from '@/lib/performanceMonitoring';
 import { VideoCamera as Video, CircleNotch as Loader2, Play } from '@phosphor-icons/react';
 import { VideoCardWithMetrics } from '@/components/VideoCardWithMetrics';
+import { VideoCommentsModal } from '@/components/VideoCommentsModal';
 import { VideoGrid } from '@/components/VideoGrid';
 import { AddToListDialog } from '@/components/AddToListDialog';
 import { useVideoProvider } from '@/hooks/useVideoProvider';
@@ -467,13 +468,28 @@ export function VideoFeed({
 
   // Mobile/tablet snap-scroll feed (< 1024px, feed mode only)
   if (isMobileFeed && viewMode === 'feed') {
+    const commentsVideo = filteredVideos.find(video => video.id === showCommentsForVideo);
+
     return (
-      <MobileFeedView
-        videos={filteredVideos}
-        onLoadMore={fetchNextPage}
-        hasMore={hasNextPage}
-        onOpenComments={handleOpenComments}
-      />
+      <>
+        <MobileFeedView
+          videos={filteredVideos}
+          onLoadMore={fetchNextPage}
+          hasMore={hasNextPage}
+          onOpenComments={handleOpenComments}
+        />
+        {commentsVideo && (
+          <VideoCommentsModal
+            video={commentsVideo}
+            open={true}
+            onOpenChange={(open) => {
+              if (!open) {
+                handleCloseComments();
+              }
+            }}
+          />
+        )}
+      </>
     );
   }
 

--- a/src/components/VideoFeed.tsx
+++ b/src/components/VideoFeed.tsx
@@ -28,6 +28,23 @@ import { useVideoPrefetch } from '@/hooks/useVideoPrefetch';
 import { useCompilationFullscreen } from '@/hooks/useCompilationFullscreen';
 import { buildCompilationPlaybackUrl } from '@/lib/compilationPlayback';
 import type { PopularPeriod, PopularSource } from '@/hooks/useInfiniteVideosFunnelcake';
+import { MobileFeedView } from '@/components/MobileFeedView';
+
+const MOBILE_FEED_BREAKPOINT = 1024;
+
+function useIsMobileFeed() {
+  const [isMobile, setIsMobile] = useState(
+    typeof window !== 'undefined' ? window.innerWidth < MOBILE_FEED_BREAKPOINT : false
+  );
+
+  useEffect(() => {
+    const handler = () => setIsMobile(window.innerWidth < MOBILE_FEED_BREAKPOINT);
+    window.addEventListener('resize', handler);
+    return () => window.removeEventListener('resize', handler);
+  }, []);
+
+  return isMobile;
+}
 
 type ViewMode = 'feed' | 'grid';
 
@@ -209,6 +226,9 @@ export function VideoFeed({
   // Prefetch upcoming media after the first video is actually playing.
   const { activeVideoId } = useVideoPlayback();
   useVideoPrefetch(activeVideoId, filteredVideos, { prefetchVideos: hasFirstPlayback });
+
+  // Detect mobile/tablet viewport for snap-scroll feed
+  const isMobileFeed = useIsMobileFeed();
 
   // Auto-navigate to discovery if home feed is empty
   useEffect(() => {
@@ -442,6 +462,18 @@ export function VideoFeed({
           </CardContent>
         </Card>
       </div>
+    );
+  }
+
+  // Mobile/tablet snap-scroll feed (< 1024px, feed mode only)
+  if (isMobileFeed && viewMode === 'feed') {
+    return (
+      <MobileFeedView
+        videos={filteredVideos}
+        onLoadMore={fetchNextPage}
+        hasMore={hasNextPage}
+        onOpenComments={handleOpenComments}
+      />
     );
   }
 

--- a/src/components/comments/Comment.tsx
+++ b/src/components/comments/Comment.tsx
@@ -125,14 +125,14 @@ export function Comment({ root, comment, depth = 0, maxDepth = 3, limit, parentC
 
   return (
     <div className={`space-y-3 ${depth > 0 ? 'ml-6 border-l-2 border-muted pl-4' : ''}`}>
-      <Card className={`transition-all ${isOptimistic ? 'bg-orange-500/10 dark:bg-orange-500/20 opacity-70' : 'bg-muted/50 dark:bg-muted'}`}>
+      <Card className={`transition-all ${isOptimistic ? 'bg-orange-500/10 dark:bg-orange-500/20 max-lg:bg-orange-500/20 opacity-70' : 'bg-muted/50 dark:bg-muted max-lg:bg-muted'}`}>
         <CardContent className="p-4">
           <div className="space-y-3">
             {/* Comment Header */}
             <div className="flex items-start justify-between">
               <div className="flex items-center space-x-3">
                 <SmartLink to={`/${nip19.npubEncode(comment.pubkey)}`} ownerPubkey={comment.pubkey}>
-                  <Avatar size="sm" className="cursor-pointer transition-all hover:ring-2 hover:ring-brand-light-green dark:ring-brand-green">
+                  <Avatar size="sm" className="cursor-pointer transition-all hover:ring-2 hover:ring-brand-light-green dark:ring-brand-green max-lg:ring-brand-green">
                     <AvatarImage src={metadata?.picture} />
                     <AvatarFallback className="text-xs">
                       {displayName.charAt(0)}
@@ -157,7 +157,7 @@ export function Comment({ root, comment, depth = 0, maxDepth = 3, limit, parentC
 
             {/* Reply Preview - Show what comment this is replying to */}
             {parentComment && (
-              <div className="flex items-start gap-2 px-3 py-2 bg-brand-light-green dark:bg-brand-dark-green rounded-md border-l-2 border-brand-light-green dark:border-brand-dark-green">
+              <div className="flex items-start gap-2 px-3 py-2 bg-brand-light-green dark:bg-brand-dark-green max-lg:bg-brand-dark-green rounded-md border-l-2 border-brand-light-green dark:border-brand-dark-green max-lg:border-brand-dark-green">
                 <CornerDownRight className="h-3 w-3 text-muted-foreground shrink-0 mt-0.5" />
                 <div className="flex items-center gap-2 min-w-0 flex-1">
                   <Avatar size="2xs" className="shrink-0">

--- a/src/index.css
+++ b/src/index.css
@@ -102,7 +102,7 @@
     --sidebar-ring: 158 67% 46%;
 
     /* Mobile layout tokens */
-    --top-bar-height: calc(56px + env(safe-area-inset-top, 0px));
+    --top-bar-height: calc(56px + var(--sat));
     --bottom-nav-height: calc(73px + env(safe-area-inset-bottom, 0px));
     --feed-height: calc(100dvh - var(--top-bar-height) - var(--bottom-nav-height));
   }
@@ -189,7 +189,7 @@
     --sidebar-ring: 158 67% 46%;
 
     /* Mobile layout tokens */
-    --top-bar-height: calc(56px + env(safe-area-inset-top, 0px));
+    --top-bar-height: calc(56px + var(--sat));
     --bottom-nav-height: calc(73px + env(safe-area-inset-bottom, 0px));
     --feed-height: calc(100dvh - var(--top-bar-height) - var(--bottom-nav-height));
   }
@@ -272,7 +272,7 @@
       --sidebar-ring: 158 67% 46%;
 
       /* Mobile layout tokens */
-      --top-bar-height: calc(56px + env(safe-area-inset-top, 0px));
+      --top-bar-height: calc(56px + var(--sat));
       --bottom-nav-height: calc(73px + env(safe-area-inset-bottom, 0px));
       --feed-height: calc(100dvh - var(--top-bar-height) - var(--bottom-nav-height));
     }

--- a/src/index.css
+++ b/src/index.css
@@ -288,6 +288,15 @@
   }
 }
 
+/* Hide scrollbar for snap-scroll mobile feed */
+.scrollbar-hide {
+  -ms-overflow-style: none;
+  scrollbar-width: none;
+}
+.scrollbar-hide::-webkit-scrollbar {
+  display: none;
+}
+
 /* Prevent browser overflow anchoring from shifting feed on dynamic updates */
 .feed-root {
   overflow-anchor: none;

--- a/src/index.css
+++ b/src/index.css
@@ -102,11 +102,8 @@
     --sidebar-ring: 158 67% 46%;
 
     /* Mobile layout tokens */
-    --fg-on-surface-variant: 0 0% 100% / 0.75;
-    --fg-on-surface-disabled: 0 0% 100% / 0.25;
-    --bg-scrim: 0 0% 0% / 0.65;
-    --top-bar-height: 60px;
-    --bottom-nav-height: 68px;
+    --top-bar-height: calc(56px + env(safe-area-inset-top, 0px));
+    --bottom-nav-height: calc(73px + env(safe-area-inset-bottom, 0px));
     --feed-height: calc(100dvh - var(--top-bar-height) - var(--bottom-nav-height));
   }
 
@@ -192,11 +189,8 @@
     --sidebar-ring: 158 67% 46%;
 
     /* Mobile layout tokens */
-    --fg-on-surface-variant: 0 0% 100% / 0.75;
-    --fg-on-surface-disabled: 0 0% 100% / 0.25;
-    --bg-scrim: 0 0% 0% / 0.65;
-    --top-bar-height: 60px;
-    --bottom-nav-height: 68px;
+    --top-bar-height: calc(56px + env(safe-area-inset-top, 0px));
+    --bottom-nav-height: calc(73px + env(safe-area-inset-bottom, 0px));
     --feed-height: calc(100dvh - var(--top-bar-height) - var(--bottom-nav-height));
   }
 
@@ -278,11 +272,8 @@
       --sidebar-ring: 158 67% 46%;
 
       /* Mobile layout tokens */
-      --fg-on-surface-variant: 0 0% 100% / 0.75;
-      --fg-on-surface-disabled: 0 0% 100% / 0.25;
-      --bg-scrim: 0 0% 0% / 0.65;
-      --top-bar-height: 60px;
-      --bottom-nav-height: 68px;
+      --top-bar-height: calc(56px + env(safe-area-inset-top, 0px));
+      --bottom-nav-height: calc(73px + env(safe-area-inset-bottom, 0px));
       --feed-height: calc(100dvh - var(--top-bar-height) - var(--bottom-nav-height));
     }
   }

--- a/src/index.css
+++ b/src/index.css
@@ -100,6 +100,14 @@
     --sidebar-accent-foreground: 158 67% 8%;
     --sidebar-border: 30 18% 90%;
     --sidebar-ring: 158 67% 46%;
+
+    /* Mobile layout tokens */
+    --fg-on-surface-variant: 0 0% 100% / 0.75;
+    --fg-on-surface-disabled: 0 0% 100% / 0.25;
+    --bg-scrim: 0 0% 0% / 0.65;
+    --top-bar-height: 60px;
+    --bottom-nav-height: 68px;
+    --feed-height: calc(100dvh - var(--top-bar-height) - var(--bottom-nav-height));
   }
 
   .dark {
@@ -182,6 +190,101 @@
     --sidebar-border: 158 40% 18%;
 
     --sidebar-ring: 158 67% 46%;
+
+    /* Mobile layout tokens */
+    --fg-on-surface-variant: 0 0% 100% / 0.75;
+    --fg-on-surface-disabled: 0 0% 100% / 0.25;
+    --bg-scrim: 0 0% 0% / 0.65;
+    --top-bar-height: 60px;
+    --bottom-nav-height: 68px;
+    --feed-height: calc(100dvh - var(--top-bar-height) - var(--bottom-nav-height));
+  }
+
+  /* Force dark theme on mobile/tablet for immersive video experience */
+  @media (max-width: 1023px) {
+    :root {
+      /* Brand: Dark Green #07241B for dark mode background */
+      --background: 158 67% 8%;
+      /* Brand: Off White #F9F7F6 for dark mode text */
+      --foreground: 30 18% 97%;
+
+      --card: 158 67% 8%;
+      --card-foreground: 30 18% 97%;
+
+      --popover: 158 67% 8%;
+      --popover-foreground: 30 18% 97%;
+
+      /* Brand primary: #27C58B -> hsl(158 67% 46%) - same in dark mode */
+      --primary: 158 67% 46%;
+      /* Brand Dark Green for text on green buttons */
+      --primary-foreground: 158 67% 8%;
+
+      /* Brand palette (same values, adjusted for dark mode visibility where needed) */
+      --brand-green: 158 67% 46%;
+      --brand-dark-green: 158 67% 8%;
+      --brand-light-green: 114 88% 90%;
+      --brand-off-white: 30 18% 97%;
+
+      /* Secondary palette for accents */
+      --brand-yellow: 56 100% 62%;
+      --brand-yellow-light: 56 100% 86%;
+      --brand-yellow-dark: 53 50% 14%;
+      --brand-lime: 79 100% 63%;
+      --brand-lime-light: 79 100% 89%;
+      --brand-lime-dark: 79 50% 12%;
+      --brand-pink: 338 100% 75%;
+      --brand-pink-light: 338 100% 93%;
+      --brand-pink-dark: 338 70% 15%;
+      --brand-orange: 20 100% 63%;
+      --brand-orange-light: 20 100% 89%;
+      --brand-orange-dark: 20 64% 17%;
+      --brand-violet: 236 100% 82%;
+      --brand-violet-light: 236 100% 94%;
+      --brand-violet-dark: 254 40% 22%;
+      --brand-purple: 254 100% 70%;
+      --brand-purple-light: 254 100% 91%;
+      --brand-purple-dark: 254 72% 21%;
+      --brand-blue: 196 86% 57%;
+      --brand-blue-light: 196 95% 90%;
+      --brand-blue-dark: 207 72% 14%;
+
+      /* Slightly lighter dark green for secondary/muted backgrounds */
+      --secondary: 158 50% 12%;
+      --secondary-foreground: 30 18% 97%;
+
+      --muted: 158 50% 12%;
+      /* Dimmed off-white for secondary text */
+      --muted-foreground: 30 15% 70%;
+
+      --accent: 158 50% 12%;
+      --accent-foreground: 30 18% 97%;
+
+      --destructive: 0 62.8% 30.6%;
+      --destructive-foreground: 30 18% 97%;
+
+      /* Lighter green for borders in dark mode */
+      --border: 158 40% 18%;
+      --input: 158 40% 18%;
+      --ring: 158 67% 46%;
+
+      /* Sidebar uses brand dark green */
+      --sidebar-background: 158 67% 8%;
+      --sidebar-foreground: 30 18% 97%;
+      --sidebar-primary: 30 18% 97%;
+      --sidebar-primary-foreground: 158 67% 8%;
+      --sidebar-accent: 158 50% 12%;
+      --sidebar-accent-foreground: 30 18% 97%;
+      --sidebar-border: 158 40% 18%;
+      --sidebar-ring: 158 67% 46%;
+
+      /* Mobile layout tokens */
+      --fg-on-surface-variant: 0 0% 100% / 0.75;
+      --fg-on-surface-disabled: 0 0% 100% / 0.25;
+      --bg-scrim: 0 0% 0% / 0.65;
+      --top-bar-height: 60px;
+      --bottom-nav-height: 68px;
+      --feed-height: calc(100dvh - var(--top-bar-height) - var(--bottom-nav-height));
+    }
   }
 }
 


### PR DESCRIPTION
## Summary

Mobile/tablet responsive redesign for viewports below 1024px. The PR keeps desktop behavior intact while adding an immersive mobile shell, dark mobile theme, bottom navigation, drawer navigation, and a snap-scroll video feed.

Closes #500

### Mobile shell

- Forces the mobile/tablet color tokens to dark theme below 1024px.
- Moves sidebar/header/bottom-nav breakpoints from `md` to `lg` so tablets use the mobile shell.
- Adds `ImmersiveTopBar` with fixed-width menu/search controls that stay inside the viewport.
- Adds `MobileDrawer` with sidebar-style navigation and category links.
- Updates bottom nav to Home, Discover, Camera, Notifications, and Profile with viewport-safe spacing.
- The Camera action does not route to web upload. It opens the same "Why no upload?" explainer language used by the mobile app camera upload tab.

### Mobile feed

- Adds `MobileFeedView` with CSS snap scrolling and keyboard navigation.
- Keyboard navigation ignores editable controls so comments/search input are not hijacked.
- Mounts the snap feed in a viewport-anchored portal so page headers/tabs do not push it out from between fixed chrome.
- Windows mounted `MobileVideoItem` instances around the active index while preserving lightweight snap positions for the full list.
- Adds `MobileVideoItem` with overlaid actions, author metadata, captions, tags, badges, double-tap like, share, repost, and comments.
- Mobile comments open the shared comments modal correctly.
- Removes unfinished mobile More/location placeholders.

### Layout and polish

- Uses shared top/bottom chrome height tokens with safe-area insets.
- Adds top padding for solid top-bar routes so content is not hidden under fixed chrome.
- Aligns `ImmersiveTopBar` with the shared top-bar height token.
- Removes the drawer theme toggle because mobile/tablet intentionally force dark theme.
- Removes unused mobile surface tokens.

### What is not changed

- Desktop layout and card feed behavior.
- Data fetching, Nostr publishing, routing contracts, and business logic.
- Existing fullscreen feed overlay.

## Verification

- `npm run test` passed locally on `79fa5de8`.
- Focused `npm exec vitest run src/components/MobileFeedView.test.tsx src/components/BottomNav.test.tsx` passed locally.
- Manual 390x844 Playwright geometry check on `/discovery/classics`: top bar bottom 56px, mobile snap feed 56px-771px, bottom nav 771px-844px, document height 844px.
- Manual 390x844 screenshot captured for `/discovery/classics` after the takeover fix.
