### PR TITLE
fix(auth): treat NIP-46 auth challenges as prompts, not failures

### DIFF
--- a/src/components/auth/LoginDialog.test.tsx
+++ b/src/components/auth/LoginDialog.test.tsx
@@ -395,6 +395,56 @@ describe('LoginDialog', () => {
       expect(onClose).not.toHaveBeenCalled();
     });
 
+    // divine-web#485: a NIP-46 signer can answer with an auth challenge instead
+    // of a result. We open it in a tab, but that fires after an await so popup
+    // blockers routinely eat it — the dialog has to offer the link.
+    it('shows the auth challenge link when the browser blocks the popup', async () => {
+      const user = userEvent.setup();
+      mockLoginActions.bunker.mockImplementation(
+        async (_uri: string, options?: { onAuthChallenge?: (c: { url: string; opened: boolean }) => void }) => {
+          options?.onAuthChallenge?.({ url: 'https://signer.example/approve', opened: false });
+          return new Promise(() => {}); // still waiting on the signer
+        }
+      );
+
+      render(<LoginDialog isOpen onClose={vi.fn()} onLogin={vi.fn()} />);
+
+      await user.click(await screen.findByRole('tab', { name: /^Sign in$/i }));
+      await user.click(screen.getByRole('button', { name: /Use Nostr instead/i }));
+      await user.click(await screen.findByRole('tab', { name: /Bunker/i }));
+      fireEvent.change(screen.getByLabelText(/Bunker URI/i), {
+        target: { value: 'bunker://remote-signer.example?relay=wss%3A%2F%2Frelay.example' },
+      });
+      await user.click(screen.getByRole('button', { name: /Login with Bunker/i }));
+
+      const link = await screen.findByRole('link', { name: /Approve in your signer/i });
+      expect(link).toHaveAttribute('href', 'https://signer.example/approve');
+      expect(link).toHaveAttribute('target', '_blank');
+      expect(link).toHaveAttribute('rel', expect.stringContaining('noopener'));
+    });
+
+    it('stays quiet when the challenge tab opened successfully', async () => {
+      const user = userEvent.setup();
+      mockLoginActions.bunker.mockImplementation(
+        async (_uri: string, options?: { onAuthChallenge?: (c: { url: string; opened: boolean }) => void }) => {
+          options?.onAuthChallenge?.({ url: 'https://signer.example/approve', opened: true });
+          return new Promise(() => {});
+        }
+      );
+
+      render(<LoginDialog isOpen onClose={vi.fn()} onLogin={vi.fn()} />);
+
+      await user.click(await screen.findByRole('tab', { name: /^Sign in$/i }));
+      await user.click(screen.getByRole('button', { name: /Use Nostr instead/i }));
+      await user.click(await screen.findByRole('tab', { name: /Bunker/i }));
+      fireEvent.change(screen.getByLabelText(/Bunker URI/i), {
+        target: { value: 'bunker://remote-signer.example?relay=wss%3A%2F%2Frelay.example' },
+      });
+      await user.click(screen.getByRole('button', { name: /Login with Bunker/i }));
+
+      expect(screen.queryByRole('link', { name: /Approve in your signer/i })).toBeNull();
+    });
+
     // fireEvent (not userEvent) so the local clipboard spy stays attached;
     // userEvent.setup() installs its own navigator.clipboard stub.
     it('aborts an in-flight nsec backup when the restriction engages mid-flight (real parent path)', async () => {

--- a/src/components/auth/LoginDialog.test.tsx
+++ b/src/components/auth/LoginDialog.test.tsx
@@ -479,6 +479,14 @@ describe('LoginDialog', () => {
       rerender(<LoginDialog isOpen={false} onClose={vi.fn()} onLogin={vi.fn()} />);
 
       expect(capturedBeforeCommit?.()).toBe(false);
+
+      // Reopening must not re-arm the guard. Anything that calls
+      // openLoginDialog() later, a like button for instance, reopens this same
+      // mounted instance, and the abandoned approval can still be in flight
+      // because nothing bounds how long the signer takes.
+      rerender(<LoginDialog isOpen onClose={vi.fn()} onLogin={vi.fn()} />);
+
+      expect(capturedBeforeCommit?.()).toBe(false);
     });
 
     // fireEvent (not userEvent) so the local clipboard spy stays attached;

--- a/src/components/auth/LoginDialog.test.tsx
+++ b/src/components/auth/LoginDialog.test.tsx
@@ -419,6 +419,9 @@ describe('LoginDialog', () => {
 
       const link = await screen.findByRole('link', { name: /Approve in your signer/i });
       expect(link).toHaveAttribute('href', 'https://signer.example/approve');
+      // The signer picks this URL, so the destination must be visible rather
+      // than hidden behind our own localized label.
+      expect(screen.getByText('(signer.example)')).toBeInTheDocument();
       expect(link).toHaveAttribute('target', '_blank');
       expect(link).toHaveAttribute('rel', expect.stringContaining('noopener'));
     });

--- a/src/components/auth/LoginDialog.test.tsx
+++ b/src/components/auth/LoginDialog.test.tsx
@@ -445,6 +445,39 @@ describe('LoginDialog', () => {
       expect(screen.queryByRole('link', { name: /Approve in your signer/i })).toBeNull();
     });
 
+    // LoginArea renders this dialog unconditionally and only toggles `isOpen`,
+    // so dismissing it leaves the NIP-46 handshake running. A signer approval
+    // that lands afterwards must not log the user in behind their back.
+    it('refuses to commit a bunker login the user dismissed while it was pending', async () => {
+      const user = userEvent.setup();
+      let capturedBeforeCommit: (() => boolean) | undefined;
+      mockLoginActions.bunker.mockImplementation(
+        async (_uri: string, options?: { beforeCommit?: () => boolean }) => {
+          capturedBeforeCommit = options?.beforeCommit;
+          return new Promise(() => {}); // signer still waiting on out-of-band approval
+        }
+      );
+
+      const { rerender } = render(
+        <LoginDialog isOpen onClose={vi.fn()} onLogin={vi.fn()} />
+      );
+
+      await user.click(await screen.findByRole('tab', { name: /^Sign in$/i }));
+      await user.click(screen.getByRole('button', { name: /Use Nostr instead/i }));
+      await user.click(await screen.findByRole('tab', { name: /Bunker/i }));
+      fireEvent.change(screen.getByLabelText(/Bunker URI/i), {
+        target: { value: 'bunker://remote-signer.example?relay=wss%3A%2F%2Frelay.example' },
+      });
+      await user.click(screen.getByRole('button', { name: /Login with Bunker/i }));
+
+      expect(capturedBeforeCommit?.()).toBe(true);
+
+      // User gives up and closes the dialog; the component stays mounted.
+      rerender(<LoginDialog isOpen={false} onClose={vi.fn()} onLogin={vi.fn()} />);
+
+      expect(capturedBeforeCommit?.()).toBe(false);
+    });
+
     // fireEvent (not userEvent) so the local clipboard spy stays attached;
     // userEvent.setup() installs its own navigator.clipboard stub.
     it('aborts an in-flight nsec backup when the restriction engages mid-flight (real parent path)', async () => {

--- a/src/components/auth/LoginDialog.tsx
+++ b/src/components/auth/LoginDialog.tsx
@@ -109,6 +109,13 @@ const LoginDialog: React.FC<LoginDialogProps> = ({ isOpen, onClose, onLogin }) =
 
   useEffect(() => {
     if (!isOpen) {
+      // Retire any in-flight bunker attempt on close. Checking `isOpenRef`
+      // alone is not enough: this effect re-arms it when the dialog is reopened
+      // later, so an approval the user abandoned would land against a guard
+      // that passes again. Bumping the counter means a superseded attempt can
+      // never become current, whatever happens to `isOpen` afterwards, and it
+      // also stops a stale challenge writing into the fresh dialog's state.
+      bunkerAttemptRef.current++;
       return;
     }
 

--- a/src/components/auth/LoginDialog.tsx
+++ b/src/components/auth/LoginDialog.tsx
@@ -40,6 +40,7 @@ const LoginDialog: React.FC<LoginDialogProps> = ({ isOpen, onClose, onLogin }) =
   const [advancedOpen, setAdvancedOpen] = useState(false);
   const [bunkerError, setBunkerError] = useState<string | null>(null);
   const [bunkerUri, setBunkerUri] = useState('');
+  const [bunkerAuthUrl, setBunkerAuthUrl] = useState<string | null>(null);
   const [generalError, setGeneralError] = useState<string | null>(null);
   const [inviteConfigError, setInviteConfigError] = useState<string | null>(null);
   const [inviteCode, setInviteCode] = useState('');
@@ -94,6 +95,7 @@ const LoginDialog: React.FC<LoginDialogProps> = ({ isOpen, onClose, onLogin }) =
     setAdvancedOpen(false);
     setBunkerError(null);
     setBunkerUri('');
+    setBunkerAuthUrl(null);
     setGeneralError(null);
     setInviteConfigError(null);
     setInviteCode('');
@@ -212,17 +214,24 @@ const LoginDialog: React.FC<LoginDialogProps> = ({ isOpen, onClose, onLogin }) =
     if (keyHandoverRestrictedRef.current) return;
     setIsLoginLoading(true);
     setBunkerError(null);
+    setBunkerAuthUrl(null);
 
     try {
       // Same commit-boundary re-check as the extension path: the pre-click
       // check goes stale while the bunker connect is pending.
       const committed = await login.bunker(bunkerUri, {
         beforeCommit: () => !keyHandoverRestrictedRef.current,
+        // The signer wants the user to approve in its own UI. We open a tab
+        // for them; keep the URL around in case the popup was blocked.
+        onAuthChallenge: ({ url, opened }) => {
+          if (url && !opened) setBunkerAuthUrl(url);
+        },
       });
       if (!committed) return;
       onLogin();
       onClose();
       setBunkerUri('');
+      setBunkerAuthUrl(null);
     } catch {
       setBunkerError(t('loginDialog.errorBunkerConnectFailed'));
     } finally {
@@ -496,6 +505,19 @@ const LoginDialog: React.FC<LoginDialogProps> = ({ isOpen, onClose, onLogin }) =
                           value={bunkerUri}
                         />
                         {bunkerError ? <p className="text-sm text-red-500">{bunkerError}</p> : null}
+                        {bunkerAuthUrl ? (
+                          <div className="space-y-1 text-sm">
+                            <p className="text-muted-foreground">{t('loginDialog.bunkerAuthPrompt')}</p>
+                            <a
+                              className="font-medium underline underline-offset-2"
+                              href={bunkerAuthUrl}
+                              rel="noopener noreferrer"
+                              target="_blank"
+                            >
+                              {t('loginDialog.bunkerAuthLink')}
+                            </a>
+                          </div>
+                        ) : null}
                       </div>
 
                       <Button

--- a/src/components/auth/LoginDialog.tsx
+++ b/src/components/auth/LoginDialog.tsx
@@ -35,6 +35,16 @@ type RegisterView = 'invite' | 'waitlist';
 const validateNsec = (nsec: string) => /^nsec1[a-zA-Z0-9]{58}$/.test(nsec);
 const validateBunkerUri = (uri: string) => uri.startsWith('bunker://');
 
+/** Host of a NIP-46 challenge URL, so the user can see where a link they were
+ *  handed by a remote signer actually leads. Null if it will not parse. */
+const getChallengeHost = (url: string): string | null => {
+  try {
+    return new URL(url).host;
+  } catch {
+    return null;
+  }
+};
+
 const LoginDialog: React.FC<LoginDialogProps> = ({ isOpen, onClose, onLogin }) => {
   const { t } = useTranslation();
   const [advancedOpen, setAdvancedOpen] = useState(false);
@@ -536,6 +546,16 @@ const LoginDialog: React.FC<LoginDialogProps> = ({ isOpen, onClose, onLogin }) =
                             >
                               {t('loginDialog.bunkerAuthLink')}
                             </a>
+                            {/* The remote signer chooses this URL, so show where
+                                the link actually goes rather than hiding an
+                                arbitrary destination behind our own wording.
+                                A hostname is data, not copy, so no locale
+                                needs updating. */}
+                            {getChallengeHost(bunkerAuthUrl) ? (
+                              <span className="ml-1 text-muted-foreground break-all">
+                                ({getChallengeHost(bunkerAuthUrl)})
+                              </span>
+                            ) : null}
                           </div>
                         ) : null}
                       </div>

--- a/src/components/auth/LoginDialog.tsx
+++ b/src/components/auth/LoginDialog.tsx
@@ -76,6 +76,16 @@ const LoginDialog: React.FC<LoginDialogProps> = ({ isOpen, onClose, onLogin }) =
   // check can resolve `protected` mid-interaction. The ref always holds the
   // latest verdict so each signer-swap re-checks when it actually runs.
   const keyHandoverRestrictedRef = useRef(false);
+  // LoginArea renders this dialog unconditionally and only toggles `isOpen`, so
+  // dismissing it never unmounts the component and never settles an in-flight
+  // bunker handshake. These track whether the attempt that is resolving is
+  // still the one the user is waiting on.
+  const isOpenRef = useRef(isOpen);
+  const bunkerAttemptRef = useRef(0);
+
+  useEffect(() => {
+    isOpenRef.current = isOpen;
+  }, [isOpen]);
   keyHandoverRestrictedRef.current = keyHandoverRestricted;
 
   // The render-side gates below stay closed synchronously; this only clears the
@@ -216,15 +226,23 @@ const LoginDialog: React.FC<LoginDialogProps> = ({ isOpen, onClose, onLogin }) =
     setBunkerError(null);
     setBunkerAuthUrl(null);
 
+    const attempt = ++bunkerAttemptRef.current;
+    const isCurrentAttempt = () => attempt === bunkerAttemptRef.current;
+
     try {
       // Same commit-boundary re-check as the extension path: the pre-click
       // check goes stale while the bunker connect is pending.
       const committed = await login.bunker(bunkerUri, {
-        beforeCommit: () => !keyHandoverRestrictedRef.current,
+        // A NIP-46 handshake can sit unresolved indefinitely while the user
+        // approves out of band, and the dialog stays mounted the whole time. If
+        // they gave up and closed it, or started a fresh attempt, this one must
+        // not silently log them in and set the cross-subdomain cookie.
+        beforeCommit: () =>
+          !keyHandoverRestrictedRef.current && isOpenRef.current && isCurrentAttempt(),
         // The signer wants the user to approve in its own UI. We open a tab
         // for them; keep the URL around in case the popup was blocked.
         onAuthChallenge: ({ url, opened }) => {
-          if (url && !opened) setBunkerAuthUrl(url);
+          if (url && !opened && isCurrentAttempt()) setBunkerAuthUrl(url);
         },
       });
       if (!committed) return;
@@ -233,9 +251,11 @@ const LoginDialog: React.FC<LoginDialogProps> = ({ isOpen, onClose, onLogin }) =
       setBunkerUri('');
       setBunkerAuthUrl(null);
     } catch {
-      setBunkerError(t('loginDialog.errorBunkerConnectFailed'));
+      if (isCurrentAttempt()) setBunkerError(t('loginDialog.errorBunkerConnectFailed'));
     } finally {
-      setIsLoginLoading(false);
+      // A superseded attempt settling must not clear the spinner belonging to
+      // the attempt the user is actually waiting on.
+      if (isCurrentAttempt()) setIsLoginLoading(false);
     }
   };
 

--- a/src/hooks/useCurrentUser.test.ts
+++ b/src/hooks/useCurrentUser.test.ts
@@ -8,6 +8,7 @@ const {
   mockGetValidToken,
   mockJwtSigner,
   mockLogins,
+  mockReleaseBunkerSignersExcept,
   mockUseAuthor,
 } = vi.hoisted(() => ({
   mockGetValidToken: vi.fn<() => string | null>(() => null),
@@ -16,7 +17,13 @@ const {
     signEvent: vi.fn(),
   },
   mockLogins: [] as NLoginType[],
+  mockReleaseBunkerSignersExcept: vi.fn<(ids: Iterable<string>) => void>(),
   mockUseAuthor: vi.fn<(pubkey?: string) => { data: Record<string, never> }>(() => ({ data: {} })),
+}));
+
+vi.mock('@/lib/bunkerSignerRegistry', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/lib/bunkerSignerRegistry')>()),
+  releaseBunkerSignersExcept: (ids: Iterable<string>) => mockReleaseBunkerSignersExcept(ids),
 }));
 
 vi.mock('@nostrify/react', () => ({
@@ -74,7 +81,38 @@ describe('useCurrentUser', () => {
     mockJwtSigner.getPublicKey.mockReset();
     mockJwtSigner.signEvent.mockReset();
     mockUseAuthor.mockClear();
+    mockReleaseBunkerSignersExcept.mockClear();
     resetNostrProvider();
+  });
+
+  // A removed login's signer is the last thing holding its sockets open, and
+  // nothing else releases it.
+  describe('bunker signer release', () => {
+    const bunkerLogin = (id: string): NLoginType => ({
+      id,
+      type: 'bunker',
+      pubkey: id.slice(-64).padStart(64, 'd'),
+      createdAt: '2026-03-10T00:00:00.000Z',
+      data: {
+        bunkerPubkey: 'b'.repeat(64),
+        clientNsec: 'nsec1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq',
+        relays: ['wss://relay.example'],
+      },
+    });
+
+    it('keeps the signers of every surviving login', () => {
+      mockLogins.push(bunkerLogin('bunker:one'), bunkerLogin('bunker:two'));
+
+      renderHook(() => useCurrentUser());
+
+      expect(mockReleaseBunkerSignersExcept).toHaveBeenCalledWith(['bunker:one', 'bunker:two']);
+    });
+
+    it('releases everything once the last login is gone', () => {
+      renderHook(() => useCurrentUser());
+
+      expect(mockReleaseBunkerSignersExcept).toHaveBeenCalledWith([]);
+    });
   });
 
   afterEach(() => {

--- a/src/hooks/useCurrentUser.ts
+++ b/src/hooks/useCurrentUser.ts
@@ -1,5 +1,4 @@
 import { type NLoginType, NUser, useNostrLogin } from '@nostrify/react/login';
-import { useNostr } from '@nostrify/react';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import type { NostrSigner } from '@nostrify/nostrify';
 import { DivineJWTSigner } from '@/lib/DivineJWTSigner';
@@ -23,7 +22,6 @@ type JwtResolution =
   | { token: string; error: true };
 
 export function useCurrentUser() {
-  const { nostr } = useNostr();
   const { logins } = useNostrLogin();
   const { getValidToken } = useDivineSession();
   const token = getValidToken();
@@ -33,8 +31,8 @@ export function useCurrentUser() {
   ), [token]);
 
   const loginToUser = useCallback((login: NLoginType): NUser  => {
-    return createUserFromLogin(login, nostr);
-  }, [nostr]);
+    return createUserFromLogin(login);
+  }, []);
 
   useEffect(() => {
     let isCancelled = false;

--- a/src/hooks/useCurrentUser.ts
+++ b/src/hooks/useCurrentUser.ts
@@ -3,6 +3,7 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 import type { NostrSigner } from '@nostrify/nostrify';
 import { DivineJWTSigner } from '@/lib/DivineJWTSigner';
 import { createUserFromLogin, getSafeUserSigner } from '@/lib/nostrLogin';
+import { releaseBunkerSignersExcept } from '@/lib/bunkerSignerRegistry';
 import { selectCurrentUsers, isJwtResolving } from '@/lib/selectCurrentUsers';
 
 import { useAuthor } from './useAuthor.ts';
@@ -71,6 +72,15 @@ export function useCurrentUser() {
 
   const hasExtensionLogin = logins.some((login) => login.type === 'extension');
   const nip07Status = useNip07Availability(hasExtensionLogin);
+
+  const loginIds = logins.map((login) => login.id).join(';');
+
+  // A removed login's signer is the last thing holding its sockets open.
+  // Reconciling against the surviving ids covers every logout path, including
+  // account switching and a login dropped as invalid.
+  useEffect(() => {
+    releaseBunkerSignersExcept(loginIds ? loginIds.split(';') : []);
+  }, [loginIds]);
 
   const manualUsers = useMemo(() => {
     const users: CurrentUser[] = [];

--- a/src/hooks/useLoggedInAccounts.ts
+++ b/src/hooks/useLoggedInAccounts.ts
@@ -32,13 +32,13 @@ export function useLoggedInAccounts() {
       }
 
       try {
-        createUserFromLogin(login, nostr);
+        createUserFromLogin(login);
         return true;
       } catch {
         return false;
       }
     }),
-    [logins, nostr, nip07Status],
+    [logins, nip07Status],
   );
 
   const jwtCurrentUser = useMemo<Account | undefined>(() => {

--- a/src/hooks/useLoggedInAccounts.ts
+++ b/src/hooks/useLoggedInAccounts.ts
@@ -3,7 +3,7 @@ import { useNostrLogin } from '@nostrify/react/login';
 import { useQuery } from '@tanstack/react-query';
 import { useMemo } from 'react';
 import { NSchema as n, NostrEvent, NostrMetadata } from '@nostrify/nostrify';
-import { createUserFromLogin } from '@/lib/nostrLogin';
+import { canCreateUserFromLogin } from '@/lib/nostrLogin';
 import { useCurrentUser } from './useCurrentUser';
 import { useDivineSession } from './useDivineSession';
 import { useNip07Availability } from './useNip07Availability';
@@ -31,12 +31,9 @@ export function useLoggedInAccounts() {
         return false;
       }
 
-      try {
-        createUserFromLogin(login);
-        return true;
-      } catch {
-        return false;
-      }
+      // Validity check only — the built user was always discarded here, and
+      // for a bunker login building one opens a connection.
+      return canCreateUserFromLogin(login);
     }),
     [logins, nip07Status],
   );

--- a/src/hooks/useLoginActions.test.ts
+++ b/src/hooks/useLoginActions.test.ts
@@ -24,7 +24,6 @@ vi.mock('@nostrify/react', () => ({
 
 vi.mock('@nostrify/react/login', () => ({
   NLogin: {
-    fromBunker: mockFromBunker,
     fromExtension: mockFromExtension,
   },
   useNostrLogin: () => ({
@@ -32,6 +31,12 @@ vi.mock('@nostrify/react/login', () => ({
     addLogin: mockAddLogin,
     removeLogin: vi.fn(),
   }),
+}));
+
+// Bunker logins go through our own NIP-46 client so auth challenges stay
+// non-terminal (#485); the commit guard below is unaffected by that swap.
+vi.mock('@/lib/bunkerSigner', () => ({
+  loginWithBunker: mockFromBunker,
 }));
 
 vi.mock('@/lib/crossSubdomainAuth', () => ({
@@ -116,7 +121,7 @@ describe('useLoginActions commit-time guard (#182)', () => {
       const { result } = renderHook(() => useLoginActions());
 
       const pending = result.current.bunker(BUNKER_URI, { beforeCommit });
-      expect(mockFromBunker).toHaveBeenCalledWith(BUNKER_URI, expect.anything());
+      expect(mockFromBunker).toHaveBeenCalledWith(BUNKER_URI, undefined);
       expect(beforeCommit).not.toHaveBeenCalled();
 
       resolveConnect(BUNKER_LOGIN);

--- a/src/hooks/useLoginActions.ts
+++ b/src/hooks/useLoginActions.ts
@@ -1,14 +1,22 @@
-import { useNostr } from '@nostrify/react';
 import { NLogin, useNostrLogin } from '@nostrify/react/login';
 import { followListCache } from '@/lib/followListCache';
 import { setLoginCookie, clearLoginCookie } from '@/lib/crossSubdomainAuth';
 import { debugLog } from '@/lib/debug';
+import { loginWithBunker } from '@/lib/bunkerSigner';
+import type { AuthChallengePresentation } from '@/lib/bunkerAuthChallenge';
 import { nip19 } from 'nostr-tools';
 
 // NOTE: This file should not be edited except for adding new login methods.
 // Policy stays out of this file: async login methods accept an optional
 // beforeCommit guard so the caller can re-check its own policy at the moment
 // the signer is committed (#182); the policy predicate lives with the caller.
+
+interface BunkerLoginOptions extends CommitGuardOptions {
+  /** Called when the remote signer asks the user to approve out of band.
+   *  The challenge URL is opened in a new tab; `opened: false` means the
+   *  popup was blocked and the caller should render the URL as a link. */
+  onAuthChallenge?: (challenge: AuthChallengePresentation) => void;
+}
 
 interface CommitGuardOptions {
   /** Last-chance policy re-check, run after the handshake resolves and before
@@ -20,7 +28,6 @@ interface CommitGuardOptions {
 }
 
 export function useLoginActions() {
-  const { nostr } = useNostr();
   const { logins, addLogin, removeLogin } = useNostrLogin();
 
   return {
@@ -31,8 +38,8 @@ export function useLoginActions() {
       setLoginCookie({ type: 'nsec', pubkey: login.pubkey });
     },
     // Login with a NIP-46 "bunker://" URI; resolves whether the signer was committed
-    async bunker(uri: string, options?: CommitGuardOptions): Promise<boolean> {
-      const login = await NLogin.fromBunker(uri, nostr);
+    async bunker(uri: string, options?: BunkerLoginOptions): Promise<boolean> {
+      const login = await loginWithBunker(uri, options?.onAuthChallenge);
       if (options?.beforeCommit && !options.beforeCommit()) return false;
       addLogin(login);
       setLoginCookie({ type: 'bunker', pubkey: login.pubkey, bunkerData: login.data });

--- a/src/lib/bunkerAuthChallenge.test.ts
+++ b/src/lib/bunkerAuthChallenge.test.ts
@@ -18,12 +18,29 @@ describe('presentAuthChallenge', () => {
   it('opens the challenge in a new tab', () => {
     const result = presentAuthChallenge('https://signer.example/auth?token=abc');
 
-    expect(openSpy).toHaveBeenCalledWith(
-      'https://signer.example/auth?token=abc',
-      '_blank',
-      'noopener,noreferrer'
-    );
+    expect(openSpy).toHaveBeenCalledWith('https://signer.example/auth?token=abc', '_blank');
     expect(result).toEqual({ url: 'https://signer.example/auth?token=abc', opened: true });
+  });
+
+  // Regression guard. `window.open` returns null whenever the feature string
+  // sets `noopener`, and `noreferrer` implies `noopener`. Passing either makes
+  // `opened` permanently false in real browsers, so the dialog claims the popup
+  // was blocked every single time. The jsdom mock cannot reproduce that, so
+  // pin the call shape instead.
+  it('opens without noopener/noreferrer so the return value stays meaningful', () => {
+    presentAuthChallenge('https://signer.example/auth');
+
+    const features = openSpy.mock.calls[0][2];
+    expect(features).toBeUndefined();
+  });
+
+  it('severs the opener reference on the tab it opened', () => {
+    const popup = {} as Window;
+    openSpy.mockReturnValue(popup);
+
+    presentAuthChallenge('https://signer.example/auth');
+
+    expect(popup.opener).toBeNull();
   });
 
   it('reports the URL for a link fallback when the popup is blocked', () => {

--- a/src/lib/bunkerAuthChallenge.test.ts
+++ b/src/lib/bunkerAuthChallenge.test.ts
@@ -1,0 +1,61 @@
+// ABOUTME: Tests for NIP-46 auth challenge presentation
+// ABOUTME: divine-web#485 — challenges must open a tab, with a link fallback
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { presentAuthChallenge } from './bunkerAuthChallenge';
+
+describe('presentAuthChallenge', () => {
+  let openSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    openSpy = vi.spyOn(window, 'open').mockReturnValue({} as Window);
+  });
+
+  afterEach(() => {
+    openSpy.mockRestore();
+  });
+
+  it('opens the challenge in a new tab', () => {
+    const result = presentAuthChallenge('https://signer.example/auth?token=abc');
+
+    expect(openSpy).toHaveBeenCalledWith(
+      'https://signer.example/auth?token=abc',
+      '_blank',
+      'noopener,noreferrer'
+    );
+    expect(result).toEqual({ url: 'https://signer.example/auth?token=abc', opened: true });
+  });
+
+  it('reports the URL for a link fallback when the popup is blocked', () => {
+    openSpy.mockReturnValue(null);
+
+    const result = presentAuthChallenge('https://signer.example/auth');
+
+    expect(result).toEqual({ url: 'https://signer.example/auth', opened: false });
+  });
+
+  it('accepts http as well as https', () => {
+    expect(presentAuthChallenge('http://localhost:8080/auth').opened).toBe(true);
+  });
+
+  // The URL arrives from the remote signer over the wire. Handing an arbitrary
+  // scheme to window.open would let a hostile signer trigger javascript: or
+  // data: navigation in the user's browser.
+  it.each([
+    'javascript:alert(1)',
+    'data:text/html,<script>alert(1)</script>',
+    'file:///etc/passwd',
+    'chrome://settings',
+  ])('refuses to open %s', (hostile) => {
+    const result = presentAuthChallenge(hostile);
+
+    expect(openSpy).not.toHaveBeenCalled();
+    expect(result).toEqual({ url: null, opened: false });
+  });
+
+  it('refuses unparseable input', () => {
+    expect(presentAuthChallenge('not a url')).toEqual({ url: null, opened: false });
+    expect(presentAuthChallenge('')).toEqual({ url: null, opened: false });
+    expect(openSpy).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/bunkerAuthChallenge.ts
+++ b/src/lib/bunkerAuthChallenge.ts
@@ -33,7 +33,22 @@ export function presentAuthChallenge(rawUrl: string): AuthChallengePresentation 
     return { url: null, opened: false };
   }
 
-  const opened = window.open(rawUrl, '_blank', 'noopener,noreferrer');
+  // `window.open` returns null whenever the feature string sets `noopener`,
+  // and `noreferrer` implies `noopener`. That happens whether or not the tab
+  // actually opened. Passing either made `opened` permanently false, so every user was
+  // told their popup had been blocked even when it had not. Open with no
+  // features so the return value means something, then sever the opener
+  // reference by hand: `opener` is settable cross-origin, so a hostile signer's
+  // page still cannot reach back into this one.
+  //
+  // The cost of dropping `noreferrer` is that the signer sees this page's URL
+  // in the Referer header. That is a party the user is deliberately
+  // authenticating against, so it is preferred over lying about the outcome.
+  const popup = window.open(rawUrl, '_blank');
 
-  return { url: rawUrl, opened: !!opened };
+  if (popup) {
+    popup.opener = null;
+  }
+
+  return { url: rawUrl, opened: !!popup };
 }

--- a/src/lib/bunkerAuthChallenge.ts
+++ b/src/lib/bunkerAuthChallenge.ts
@@ -1,0 +1,39 @@
+// ABOUTME: Presents NIP-46 auth challenges sent by a remote signer
+// ABOUTME: Opens the challenge URL in a new tab and reports a link fallback
+
+/** Schemes a signer is allowed to send us for an auth challenge. */
+const ALLOWED_PROTOCOLS = new Set(['http:', 'https:']);
+
+export interface AuthChallengePresentation {
+  /** The challenge URL, or null when the signer sent something unusable. */
+  url: string | null;
+  /** Whether a tab was actually opened. False means show the link instead. */
+  opened: boolean;
+}
+
+/**
+ * Show the user a NIP-46 `auth_url` challenge.
+ *
+ * The URL arrives from the remote signer, so only web schemes are honoured —
+ * handing `javascript:` or `data:` to `window.open` would let a hostile signer
+ * run navigation in the user's browser. Popup blockers routinely swallow the
+ * tab because this fires after an await, so callers must render the returned
+ * URL as a link whenever `opened` is false.
+ */
+export function presentAuthChallenge(rawUrl: string): AuthChallengePresentation {
+  let url: URL;
+
+  try {
+    url = new URL(rawUrl);
+  } catch {
+    return { url: null, opened: false };
+  }
+
+  if (!ALLOWED_PROTOCOLS.has(url.protocol)) {
+    return { url: null, opened: false };
+  }
+
+  const opened = window.open(rawUrl, '_blank', 'noopener,noreferrer');
+
+  return { url: rawUrl, opened: !!opened };
+}

--- a/src/lib/bunkerSigner.test.ts
+++ b/src/lib/bunkerSigner.test.ts
@@ -1,0 +1,156 @@
+// ABOUTME: Tests the NIP-46 bunker signer built on nostr-tools BunkerSigner
+// ABOUTME: divine-web#485 — auth challenges must be surfaced, not fatal
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { generateSecretKey, getPublicKey, nip19 } from 'nostr-tools';
+
+const REMOTE_PUBKEY = 'b'.repeat(64);
+const USER_PUBKEY = 'c'.repeat(64);
+const RELAY = 'wss://relay.example';
+
+const bunkerInstance = {
+  connect: vi.fn(async () => {}),
+  getPublicKey: vi.fn(async () => USER_PUBKEY),
+  signEvent: vi.fn(async (t: Record<string, unknown>) => ({ ...t, id: 'signed', pubkey: USER_PUBKEY, sig: 'sig' })),
+  nip04Encrypt: vi.fn(async () => 'nip04-ct'),
+  nip04Decrypt: vi.fn(async () => 'nip04-pt'),
+  nip44Encrypt: vi.fn(async () => 'nip44-ct'),
+  nip44Decrypt: vi.fn(async () => 'nip44-pt'),
+  close: vi.fn(async () => {}),
+};
+
+const fromBunker = vi.fn(() => bunkerInstance);
+
+vi.mock('nostr-tools/nip46', () => ({
+  BunkerSigner: { fromBunker: (...args: unknown[]) => fromBunker(...(args as [])) },
+}));
+
+const presentAuthChallenge = vi.fn(() => ({ url: 'https://signer.example/auth', opened: true }));
+vi.mock('./bunkerAuthChallenge', () => ({
+  presentAuthChallenge: (...args: unknown[]) => presentAuthChallenge(...(args as [])),
+}));
+
+describe('createBunkerSigner', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    presentAuthChallenge.mockReturnValue({ url: 'https://signer.example/auth', opened: true });
+  });
+
+  it('exposes a signer that satisfies the app signer interface', async () => {
+    const { createBunkerSigner } = await import('./bunkerSigner');
+    const signer = createBunkerSigner({
+      clientSecretKey: generateSecretKey(),
+      bunkerPubkey: REMOTE_PUBKEY,
+      relays: [RELAY],
+    });
+
+    await expect(signer.getPublicKey()).resolves.toBe(USER_PUBKEY);
+    await expect(signer.signEvent({ kind: 1, content: 'hi', created_at: 1, tags: [] })).resolves.toMatchObject({ sig: 'sig' });
+    await expect(signer.nip44!.encrypt('p', 'text')).resolves.toBe('nip44-ct');
+    await expect(signer.nip44!.decrypt('p', 'ct')).resolves.toBe('nip44-pt');
+    await expect(signer.nip04!.encrypt('p', 'text')).resolves.toBe('nip04-ct');
+    await expect(signer.nip04!.decrypt('p', 'ct')).resolves.toBe('nip04-pt');
+  });
+
+  it('passes the bunker pointer through untouched', async () => {
+    const { createBunkerSigner } = await import('./bunkerSigner');
+    const clientSecretKey = generateSecretKey();
+
+    createBunkerSigner({
+      clientSecretKey,
+      bunkerPubkey: REMOTE_PUBKEY,
+      relays: [RELAY],
+      secret: 'connect-token',
+    });
+
+    expect(fromBunker).toHaveBeenCalledTimes(1);
+    const [sk, bp] = fromBunker.mock.calls[0] as [Uint8Array, Record<string, unknown>];
+    expect(sk).toBe(clientSecretKey);
+    expect(bp).toEqual({ pubkey: REMOTE_PUBKEY, relays: [RELAY], secret: 'connect-token' });
+  });
+
+  // The whole point of divine-web#485: an auth challenge is a prompt, not a
+  // failure. nostr-tools keeps waiting on the same request id after calling
+  // `onauth`, so we must hand it a handler rather than let the error surface.
+  it('routes auth challenges to the presenter instead of failing', async () => {
+    const { createBunkerSigner } = await import('./bunkerSigner');
+    const onAuthChallenge = vi.fn();
+
+    createBunkerSigner({
+      clientSecretKey: generateSecretKey(),
+      bunkerPubkey: REMOTE_PUBKEY,
+      relays: [RELAY],
+      onAuthChallenge,
+    });
+
+    const params = (fromBunker.mock.calls[0] as [Uint8Array, unknown, { onauth?: (u: string) => void }])[2];
+    expect(typeof params.onauth).toBe('function');
+
+    params.onauth!('https://signer.example/auth');
+
+    expect(presentAuthChallenge).toHaveBeenCalledWith('https://signer.example/auth');
+    expect(onAuthChallenge).toHaveBeenCalledWith({ url: 'https://signer.example/auth', opened: true });
+  });
+
+  it('still notifies the caller when the popup was blocked, so a link can be shown', async () => {
+    presentAuthChallenge.mockReturnValue({ url: 'https://signer.example/auth', opened: false });
+    const { createBunkerSigner } = await import('./bunkerSigner');
+    const onAuthChallenge = vi.fn();
+
+    createBunkerSigner({
+      clientSecretKey: generateSecretKey(),
+      bunkerPubkey: REMOTE_PUBKEY,
+      relays: [RELAY],
+      onAuthChallenge,
+    });
+
+    const params = (fromBunker.mock.calls[0] as [Uint8Array, unknown, { onauth?: (u: string) => void }])[2];
+    params.onauth!('https://signer.example/auth');
+
+    expect(onAuthChallenge).toHaveBeenCalledWith({ url: 'https://signer.example/auth', opened: false });
+  });
+});
+
+describe('loginWithBunker', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('connects, resolves the user pubkey, and returns reusable login data', async () => {
+    const { loginWithBunker } = await import('./bunkerSigner');
+
+    const login = await loginWithBunker(
+      `bunker://${REMOTE_PUBKEY}?relay=${encodeURIComponent(RELAY)}&secret=tok`
+    );
+
+    expect(bunkerInstance.connect).toHaveBeenCalled();
+    expect(login.type).toBe('bunker');
+    expect(login.pubkey).toBe(USER_PUBKEY);
+    expect(login.data.bunkerPubkey).toBe(REMOTE_PUBKEY);
+    expect(login.data.relays).toEqual([RELAY]);
+    // The client key must be persisted, or the next session looks like a new
+    // client to the bunker and needs re-approval.
+    expect(login.data.clientNsec).toMatch(/^nsec1/);
+    expect(() => nip19.decode(login.data.clientNsec)).not.toThrow();
+  });
+
+  it('rejects a URI with no relay', async () => {
+    const { loginWithBunker } = await import('./bunkerSigner');
+    await expect(loginWithBunker(`bunker://${REMOTE_PUBKEY}?secret=tok`)).rejects.toThrow();
+  });
+
+  it('rebuilds the same client identity from stored login data', async () => {
+    const { bunkerSignerFromLogin } = await import('./bunkerSigner');
+    const sk = generateSecretKey();
+    const clientNsec = nip19.nsecEncode(sk);
+
+    bunkerSignerFromLogin({
+      bunkerPubkey: REMOTE_PUBKEY,
+      clientNsec,
+      relays: [RELAY],
+    });
+
+    const [passedSk] = fromBunker.mock.calls[0] as [Uint8Array];
+    expect(getPublicKey(passedSk)).toBe(getPublicKey(sk));
+  });
+});

--- a/src/lib/bunkerSigner.test.ts
+++ b/src/lib/bunkerSigner.test.ts
@@ -1,8 +1,16 @@
 // ABOUTME: Tests the NIP-46 bunker signer built on nostr-tools BunkerSigner
 // ABOUTME: divine-web#485 — auth challenges must be surfaced, not fatal
 
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { generateSecretKey, getPublicKey, nip19 } from 'nostr-tools';
+import type { NostrEvent } from '@nostrify/nostrify';
+
+/** Just the surface the deadline cases exercise. */
+interface BunkerNostrSignerLike {
+  connect(): Promise<void>;
+  getPublicKey(): Promise<string>;
+  signEvent(event: { kind: number; content: string; created_at: number; tags: string[][] }): Promise<NostrEvent>;
+}
 
 const REMOTE_PUBKEY = 'b'.repeat(64);
 const USER_PUBKEY = 'c'.repeat(64);
@@ -103,6 +111,131 @@ describe('createBunkerSigner', () => {
     expect(onAuthChallenge).toHaveBeenCalledWith({ url: 'https://signer.example/auth', opened: true });
   });
 
+  // `BunkerSigner.sendRequest` settles only when a matching response arrives.
+  // A signer that is unreachable behind a relay that still accepts the publish
+  // therefore hangs forever, which is what left the dialog on "Connecting…".
+  describe('request deadline', () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    // Stall only the method under test: an unconsumed `mockImplementationOnce`
+    // survives `clearAllMocks` and would strand a later test instead.
+    async function neverAnswers(method: 'connect' | 'getPublicKey' | 'signEvent') {
+      const { createBunkerSigner, BUNKER_REQUEST_TIMEOUT_MS } = await import('./bunkerSigner');
+      bunkerInstance[method].mockImplementationOnce((() => new Promise(() => {})) as never);
+
+      return {
+        timeout: BUNKER_REQUEST_TIMEOUT_MS,
+        signer: createBunkerSigner({
+          clientSecretKey: generateSecretKey(),
+          bunkerPubkey: REMOTE_PUBKEY,
+          relays: [RELAY],
+        }),
+      };
+    }
+
+    it('rejects a request the signer never answers', async () => {
+      const { signer, timeout } = await neverAnswers('connect');
+      const pending = expect(signer.connect()).rejects.toThrow('Bunker request timed out: connect');
+
+      await vi.advanceTimersByTimeAsync(timeout);
+      await pending;
+    });
+
+    it.each([
+      ['getPublicKey', (s: BunkerNostrSignerLike) => s.getPublicKey()],
+      ['signEvent', (s: BunkerNostrSignerLike) => s.signEvent({ kind: 1, content: '', created_at: 1, tags: [] })],
+    ] as const)('bounds %s too, so a mid-session request cannot hang', async (label, call) => {
+      const { signer, timeout } = await neverAnswers(label);
+      const pending = expect(call(signer)).rejects.toThrow('Bunker request timed out');
+
+      await vi.advanceTimersByTimeAsync(timeout);
+      await pending;
+    });
+
+    it('does not reject a request that answers in time', async () => {
+      const { createBunkerSigner, BUNKER_REQUEST_TIMEOUT_MS } = await import('./bunkerSigner');
+      const signer = createBunkerSigner({
+        clientSecretKey: generateSecretKey(),
+        bunkerPubkey: REMOTE_PUBKEY,
+        relays: [RELAY],
+      });
+
+      await expect(signer.getPublicKey()).resolves.toBe(USER_PUBKEY);
+      // The deadline must not fire after the request already settled.
+      await vi.advanceTimersByTimeAsync(BUNKER_REQUEST_TIMEOUT_MS * 2);
+    });
+
+    // Approval happens on a human's schedule. An `auth_url` proves the signer
+    // is alive, so it restarts the clock rather than expiring while the
+    // approval tab is still open.
+    it('restarts the clock when the signer asks for approval', async () => {
+      const { createBunkerSigner, BUNKER_REQUEST_TIMEOUT_MS } = await import('./bunkerSigner');
+      let approve: (pubkey: string) => void = () => {};
+      bunkerInstance.getPublicKey.mockImplementationOnce(
+        () => new Promise<string>((resolve) => { approve = resolve; })
+      );
+
+      const signer = createBunkerSigner({
+        clientSecretKey: generateSecretKey(),
+        bunkerPubkey: REMOTE_PUBKEY,
+        relays: [RELAY],
+      });
+      const pending = signer.getPublicKey();
+      const onauth = fromBunker.mock.calls[0][2].onauth!;
+
+      // Challenge lands just before the original deadline would have fired.
+      await vi.advanceTimersByTimeAsync(BUNKER_REQUEST_TIMEOUT_MS - 1_000);
+      onauth('https://signer.example/auth');
+
+      // Past the original deadline, still waiting on the user.
+      await vi.advanceTimersByTimeAsync(BUNKER_REQUEST_TIMEOUT_MS - 1_000);
+      approve(USER_PUBKEY);
+      await expect(pending).resolves.toBe(USER_PUBKEY);
+    });
+
+    // Without this the restarted clock would never fire, trading a hang on a
+    // dead signer for a hang on an abandoned approval.
+    it('still expires once the restarted clock runs out', async () => {
+      const { createBunkerSigner, BUNKER_REQUEST_TIMEOUT_MS } = await import('./bunkerSigner');
+      bunkerInstance.getPublicKey.mockImplementationOnce(() => new Promise<string>(() => {}));
+
+      const signer = createBunkerSigner({
+        clientSecretKey: generateSecretKey(),
+        bunkerPubkey: REMOTE_PUBKEY,
+        relays: [RELAY],
+      });
+      const pending = expect(signer.getPublicKey()).rejects.toThrow('Bunker request timed out');
+
+      fromBunker.mock.calls[0][2].onauth!('https://signer.example/auth');
+      await vi.advanceTimersByTimeAsync(BUNKER_REQUEST_TIMEOUT_MS);
+      await pending;
+    });
+
+    it('waits indefinitely when the deadline is disabled', async () => {
+      const { createBunkerSigner, BUNKER_REQUEST_TIMEOUT_MS } = await import('./bunkerSigner');
+      bunkerInstance.getPublicKey.mockImplementationOnce(
+        () => new Promise<string>((resolve) => setTimeout(() => resolve(USER_PUBKEY), BUNKER_REQUEST_TIMEOUT_MS * 3))
+      );
+
+      const signer = createBunkerSigner({
+        clientSecretKey: generateSecretKey(),
+        bunkerPubkey: REMOTE_PUBKEY,
+        relays: [RELAY],
+        requestTimeoutMs: 0,
+      });
+      const pending = signer.getPublicKey();
+
+      await vi.advanceTimersByTimeAsync(BUNKER_REQUEST_TIMEOUT_MS * 3);
+      await expect(pending).resolves.toBe(USER_PUBKEY);
+    });
+  });
+
   it('still notifies the caller when the popup was blocked, so a link can be shown', async () => {
     presentAuthChallenge.mockReturnValue({ url: 'https://signer.example/auth', opened: false });
     const { createBunkerSigner } = await import('./bunkerSigner');
@@ -190,6 +323,29 @@ describe('loginWithBunker', () => {
       loginWithBunker(`bunker://${REMOTE_PUBKEY}?relay=${encodeURIComponent(RELAY)}`)
     ).rejects.toThrow('signer unreachable');
     expect(bunkerInstance.close).toHaveBeenCalledTimes(1);
+  });
+
+  // The dialog's `finally` only runs when this settles. Left pending, the
+  // relay having accepted the publish is enough to strand it on "Connecting…"
+  // with `isLoginLoading` stuck true and no error ever rendered.
+  it('fails the login rather than hanging when the signer never answers', async () => {
+    vi.useFakeTimers();
+
+    try {
+      const { loginWithBunker, BUNKER_REQUEST_TIMEOUT_MS } = await import('./bunkerSigner');
+      bunkerInstance.connect.mockImplementationOnce(() => new Promise<void>(() => {}));
+
+      const pending = expect(
+        loginWithBunker(`bunker://${REMOTE_PUBKEY}?relay=${encodeURIComponent(RELAY)}`)
+      ).rejects.toThrow('Bunker request timed out');
+
+      await vi.advanceTimersByTimeAsync(BUNKER_REQUEST_TIMEOUT_MS);
+      await pending;
+      // The handshake pool still has to come down on this path.
+      expect(bunkerInstance.close).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it('rebuilds the same client identity from stored login data', async () => {

--- a/src/lib/bunkerSigner.test.ts
+++ b/src/lib/bunkerSigner.test.ts
@@ -19,10 +19,21 @@ const bunkerInstance = {
   close: vi.fn(async () => {}),
 };
 
-const fromBunker = vi.fn(() => bunkerInstance);
+interface BunkerPointerArg {
+  pubkey: string;
+  relays: string[];
+  secret: string | null;
+}
+interface BunkerParamsArg {
+  onauth?: (url: string) => void;
+}
+
+const fromBunker = vi.fn(
+  (_sk: Uint8Array, _bp: BunkerPointerArg, _params: BunkerParamsArg) => bunkerInstance
+);
 
 vi.mock('nostr-tools/nip46', () => ({
-  BunkerSigner: { fromBunker: (...args: unknown[]) => fromBunker(...(args as [])) },
+  BunkerSigner: { fromBunker },
 }));
 
 const presentAuthChallenge = vi.fn(() => ({ url: 'https://signer.example/auth', opened: true }));
@@ -64,7 +75,7 @@ describe('createBunkerSigner', () => {
     });
 
     expect(fromBunker).toHaveBeenCalledTimes(1);
-    const [sk, bp] = fromBunker.mock.calls[0] as [Uint8Array, Record<string, unknown>];
+    const [sk, bp] = fromBunker.mock.calls[0];
     expect(sk).toBe(clientSecretKey);
     expect(bp).toEqual({ pubkey: REMOTE_PUBKEY, relays: [RELAY], secret: 'connect-token' });
   });
@@ -83,7 +94,7 @@ describe('createBunkerSigner', () => {
       onAuthChallenge,
     });
 
-    const params = (fromBunker.mock.calls[0] as [Uint8Array, unknown, { onauth?: (u: string) => void }])[2];
+    const params = fromBunker.mock.calls[0][2];
     expect(typeof params.onauth).toBe('function');
 
     params.onauth!('https://signer.example/auth');
@@ -104,7 +115,7 @@ describe('createBunkerSigner', () => {
       onAuthChallenge,
     });
 
-    const params = (fromBunker.mock.calls[0] as [Uint8Array, unknown, { onauth?: (u: string) => void }])[2];
+    const params = fromBunker.mock.calls[0][2];
     params.onauth!('https://signer.example/auth');
 
     expect(onAuthChallenge).toHaveBeenCalledWith({ url: 'https://signer.example/auth', opened: false });
@@ -150,7 +161,7 @@ describe('loginWithBunker', () => {
       relays: [RELAY],
     });
 
-    const [passedSk] = fromBunker.mock.calls[0] as [Uint8Array];
+    const [passedSk] = fromBunker.mock.calls[0];
     expect(getPublicKey(passedSk)).toBe(getPublicKey(sk));
   });
 });

--- a/src/lib/bunkerSigner.test.ts
+++ b/src/lib/bunkerSigner.test.ts
@@ -379,6 +379,43 @@ describe('loginWithBunker', () => {
     }
   });
 
+  // `BunkerSigner` keeps its pool private and `close()` only drops the
+  // subscription, so a pool it creates internally can never be released. A
+  // session signer closed on logout would otherwise leave a socket per bunker
+  // relay connected for the life of the tab.
+  it('destroys the pool it created when the signer is closed', async () => {
+    const { bunkerSignerFromLogin } = await import('./bunkerSigner');
+    const signer = bunkerSignerFromLogin({
+      bunkerPubkey: REMOTE_PUBKEY,
+      clientNsec: nip19.nsecEncode(generateSecretKey()),
+      relays: [RELAY],
+    });
+
+    expect(fromBunker.mock.calls[0][2].pool).toBe(poolInstance);
+
+    await signer.close();
+
+    expect(bunkerInstance.close).toHaveBeenCalledTimes(1);
+    expect(poolInstance.destroy).toHaveBeenCalledTimes(1);
+  });
+
+  it('leaves a pool the caller supplied alone, since the caller still owns it', async () => {
+    const { createBunkerSigner } = await import('./bunkerSigner');
+    const callerPool = { destroy: vi.fn(), close: vi.fn() };
+
+    const signer = createBunkerSigner({
+      clientSecretKey: generateSecretKey(),
+      bunkerPubkey: REMOTE_PUBKEY,
+      relays: [RELAY],
+      pool: callerPool as unknown as Parameters<typeof createBunkerSigner>[0]['pool'],
+    });
+
+    await signer.close();
+
+    expect(callerPool.destroy).not.toHaveBeenCalled();
+    expect(poolInstance.destroy).not.toHaveBeenCalled();
+  });
+
   it('rebuilds the same client identity from stored login data', async () => {
     const { bunkerSignerFromLogin } = await import('./bunkerSigner');
     const sk = generateSecretKey();

--- a/src/lib/bunkerSigner.test.ts
+++ b/src/lib/bunkerSigner.test.ts
@@ -34,6 +34,7 @@ interface BunkerPointerArg {
 }
 interface BunkerParamsArg {
   onauth?: (url: string) => void;
+  pool?: unknown;
 }
 
 const fromBunker = vi.fn(
@@ -42,6 +43,14 @@ const fromBunker = vi.fn(
 
 vi.mock('nostr-tools/nip46', () => ({
   BunkerSigner: { fromBunker },
+}));
+
+// `close()` drops the subscription but leaves the pool's sockets connected, so
+// releasing them is a separate call. Mock the pool to make that observable.
+const poolInstance = { destroy: vi.fn(), close: vi.fn() };
+const SimplePoolMock = vi.fn(() => poolInstance);
+vi.mock('nostr-tools/pool', () => ({
+  SimplePool: SimplePoolMock,
 }));
 
 const presentAuthChallenge = vi.fn(() => ({ url: 'https://signer.example/auth', opened: true }));
@@ -313,6 +322,28 @@ describe('loginWithBunker', () => {
     await loginWithBunker(`bunker://${REMOTE_PUBKEY}?relay=${encodeURIComponent(RELAY)}`);
 
     expect(bunkerInstance.close).toHaveBeenCalledTimes(1);
+  });
+
+  // Closing the signer is not enough on its own: the sockets belong to the
+  // pool, so the leak this commit exists to prevent only closes if the pool is
+  // destroyed too, on both paths.
+  it('destroys the pool it owns once the handshake completes', async () => {
+    const { loginWithBunker } = await import('./bunkerSigner');
+
+    await loginWithBunker(`bunker://${REMOTE_PUBKEY}?relay=${encodeURIComponent(RELAY)}`);
+
+    expect(fromBunker.mock.calls[0][2].pool).toBe(poolInstance);
+    expect(poolInstance.destroy).toHaveBeenCalledTimes(1);
+  });
+
+  it('destroys the pool it owns when the handshake fails', async () => {
+    bunkerInstance.connect.mockRejectedValueOnce(new Error('signer unreachable'));
+    const { loginWithBunker } = await import('./bunkerSigner');
+
+    await expect(
+      loginWithBunker(`bunker://${REMOTE_PUBKEY}?relay=${encodeURIComponent(RELAY)}`)
+    ).rejects.toThrow('signer unreachable');
+    expect(poolInstance.destroy).toHaveBeenCalledTimes(1);
   });
 
   it('closes the handshake signer when the handshake fails', async () => {

--- a/src/lib/bunkerSigner.test.ts
+++ b/src/lib/bunkerSigner.test.ts
@@ -150,6 +150,27 @@ describe('loginWithBunker', () => {
     await expect(loginWithBunker(`bunker://${REMOTE_PUBKEY}?secret=tok`)).rejects.toThrow();
   });
 
+  // The URI is pasted by the user and the pubkey it carries decides who every
+  // later request is encrypted to, so both halves are validated. Neither guard
+  // had a test holding it.
+  it('rejects a URI that is not a bunker: URI', async () => {
+    const { loginWithBunker } = await import('./bunkerSigner');
+    await expect(
+      loginWithBunker(`https://${REMOTE_PUBKEY}?relay=${encodeURIComponent(RELAY)}`)
+    ).rejects.toThrow('Invalid bunker URI');
+  });
+
+  it.each([
+    ['too short', 'abc'],
+    ['non-hex characters', 'z'.repeat(64)],
+    ['too long', 'b'.repeat(65)],
+  ])('rejects a remote-signer pubkey that is %s', async (_label, pubkey) => {
+    const { loginWithBunker } = await import('./bunkerSigner');
+    await expect(
+      loginWithBunker(`bunker://${pubkey}?relay=${encodeURIComponent(RELAY)}`)
+    ).rejects.toThrow('Invalid bunker URI');
+  });
+
   // The handshake signer opens sockets when it is constructed and the session
   // builds its own signer from the persisted data, so this one must not be left
   // running, on the failure path either.
@@ -186,4 +207,19 @@ describe('loginWithBunker', () => {
     expect(getPublicKey(passedSk)).toBe(getPublicKey(sk));
   });
 
+  // Stored login data is attacker-reachable if anything ever writes to
+  // localStorage; a non-nsec bech32 would otherwise reach generateSecretKey's
+  // consumer as a hex string instead of key bytes.
+  it('refuses stored login data whose client key is not an nsec', async () => {
+    const { bunkerSignerFromLogin } = await import('./bunkerSigner');
+    const npub = nip19.npubEncode(REMOTE_PUBKEY);
+
+    expect(() =>
+      bunkerSignerFromLogin({
+        bunkerPubkey: REMOTE_PUBKEY,
+        clientNsec: npub as `nsec1${string}`,
+        relays: [RELAY],
+      })
+    ).toThrow('Invalid client key for bunker login');
+  });
 });

--- a/src/lib/bunkerSigner.test.ts
+++ b/src/lib/bunkerSigner.test.ts
@@ -150,6 +150,27 @@ describe('loginWithBunker', () => {
     await expect(loginWithBunker(`bunker://${REMOTE_PUBKEY}?secret=tok`)).rejects.toThrow();
   });
 
+  // The handshake signer opens sockets when it is constructed and the session
+  // builds its own signer from the persisted data, so this one must not be left
+  // running, on the failure path either.
+  it('closes the handshake signer once the login data is captured', async () => {
+    const { loginWithBunker } = await import('./bunkerSigner');
+
+    await loginWithBunker(`bunker://${REMOTE_PUBKEY}?relay=${encodeURIComponent(RELAY)}`);
+
+    expect(bunkerInstance.close).toHaveBeenCalledTimes(1);
+  });
+
+  it('closes the handshake signer when the handshake fails', async () => {
+    bunkerInstance.connect.mockRejectedValueOnce(new Error('signer unreachable'));
+    const { loginWithBunker } = await import('./bunkerSigner');
+
+    await expect(
+      loginWithBunker(`bunker://${REMOTE_PUBKEY}?relay=${encodeURIComponent(RELAY)}`)
+    ).rejects.toThrow('signer unreachable');
+    expect(bunkerInstance.close).toHaveBeenCalledTimes(1);
+  });
+
   it('rebuilds the same client identity from stored login data', async () => {
     const { bunkerSignerFromLogin } = await import('./bunkerSigner');
     const sk = generateSecretKey();
@@ -164,4 +185,5 @@ describe('loginWithBunker', () => {
     const [passedSk] = fromBunker.mock.calls[0];
     expect(getPublicKey(passedSk)).toBe(getPublicKey(sk));
   });
+
 });

--- a/src/lib/bunkerSigner.ts
+++ b/src/lib/bunkerSigner.ts
@@ -258,19 +258,30 @@ export async function loginWithBunker(
   };
 }
 
-/** Rebuild a signer for an already-established bunker login. */
-export function bunkerSignerFromLogin(
-  data: BunkerLoginData,
-  onAuthChallenge?: (challenge: AuthChallengePresentation) => void
-): BunkerNostrSigner {
+/**
+ * Decode the client key out of stored login data.
+ *
+ * Separate from {@link bunkerSignerFromLogin} so a caller that only needs to
+ * know whether a stored login is usable can check it without building a
+ * signer — constructing one opens a socket to every relay in the login.
+ */
+export function clientSecretKeyFromLogin(data: BunkerLoginData): Uint8Array {
   const decoded = nip19.decode(data.clientNsec);
 
   if (decoded.type !== 'nsec') {
     throw new Error('Invalid client key for bunker login');
   }
 
+  return decoded.data;
+}
+
+/** Rebuild a signer for an already-established bunker login. */
+export function bunkerSignerFromLogin(
+  data: BunkerLoginData,
+  onAuthChallenge?: (challenge: AuthChallengePresentation) => void
+): BunkerNostrSigner {
   return createBunkerSigner({
-    clientSecretKey: decoded.data,
+    clientSecretKey: clientSecretKeyFromLogin(data),
     bunkerPubkey: data.bunkerPubkey,
     relays: data.relays,
     onAuthChallenge,

--- a/src/lib/bunkerSigner.ts
+++ b/src/lib/bunkerSigner.ts
@@ -1,0 +1,171 @@
+// ABOUTME: NIP-46 remote signer built on nostr-tools BunkerSigner
+// ABOUTME: Treats auth_url challenges as prompts to surface, not terminal errors
+
+import { BunkerSigner } from 'nostr-tools/nip46';
+import { generateSecretKey, nip19 } from 'nostr-tools';
+import type { NostrEvent, NostrSigner } from '@nostrify/nostrify';
+import { presentAuthChallenge, type AuthChallengePresentation } from '@/lib/bunkerAuthChallenge';
+
+/** Login payload shape shared with `@nostrify/react` bunker logins. */
+export interface BunkerLoginData {
+  bunkerPubkey: string;
+  clientNsec: `nsec1${string}`;
+  relays: string[];
+}
+
+export interface BunkerLogin {
+  id: string;
+  type: 'bunker';
+  pubkey: string;
+  createdAt: string;
+  data: BunkerLoginData;
+}
+
+export interface CreateBunkerSignerOptions {
+  /** Our half of the NIP-46 conversation. Stable across sessions. */
+  clientSecretKey: Uint8Array;
+  bunkerPubkey: string;
+  relays: string[];
+  /** Connection token from the bunker URI, when the signer issued one. */
+  secret?: string | null;
+  /** Called when the signer asks the user to approve out of band. */
+  onAuthChallenge?: (challenge: AuthChallengePresentation) => void;
+}
+
+export interface BunkerNostrSigner extends NostrSigner {
+  connect(): Promise<void>;
+  close(): Promise<void>;
+}
+
+/**
+ * Build a signer for a NIP-46 remote signer ("bunker").
+ *
+ * NIP-46 lets a signer answer a request with `{result: "auth_url", error: <url>}`,
+ * meaning "the user has to approve this out of band; keep listening on the same
+ * request id". `nostr-tools` models that with an `onauth` hook and continues
+ * waiting for the real response, which is why this is built on it: an
+ * implementation that treats every non-empty `error` field as terminal both
+ * fails the call and drops the subscription that the answer arrives on.
+ */
+export function createBunkerSigner(options: CreateBunkerSignerOptions): BunkerNostrSigner {
+  const { clientSecretKey, bunkerPubkey, relays, secret = null, onAuthChallenge } = options;
+
+  const bunker = BunkerSigner.fromBunker(
+    clientSecretKey,
+    { pubkey: bunkerPubkey, relays, secret },
+    {
+      onauth: (url: string) => {
+        onAuthChallenge?.(presentAuthChallenge(url));
+      },
+    }
+  );
+
+  return {
+    connect: () => bunker.connect(),
+    close: () => bunker.close(),
+    getPublicKey: () => bunker.getPublicKey(),
+    signEvent: (event) => bunker.signEvent(event) as Promise<NostrEvent>,
+    nip04: {
+      encrypt: (pubkey, plaintext) => bunker.nip04Encrypt(pubkey, plaintext),
+      decrypt: (pubkey, ciphertext) => bunker.nip04Decrypt(pubkey, ciphertext),
+    },
+    nip44: {
+      encrypt: (pubkey, plaintext) => bunker.nip44Encrypt(pubkey, plaintext),
+      decrypt: (pubkey, ciphertext) => bunker.nip44Decrypt(pubkey, ciphertext),
+    },
+  };
+}
+
+interface ParsedBunkerUri {
+  bunkerPubkey: string;
+  relays: string[];
+  secret: string | null;
+}
+
+/** Parse a `bunker://` URI into its pubkey, relays, and optional secret. */
+export function parseBunkerUri(uri: string): ParsedBunkerUri {
+  let parsed: URL;
+
+  try {
+    parsed = new URL(uri);
+  } catch {
+    throw new Error('Invalid bunker URI');
+  }
+
+  if (parsed.protocol !== 'bunker:') {
+    throw new Error('Invalid bunker URI');
+  }
+
+  // `bunker://<pubkey>?...` puts the pubkey in the host slot, but URL
+  // lowercases the host and some signers emit it as the pathname instead.
+  const bunkerPubkey = (parsed.hostname || parsed.pathname.replace(/^\/+/, '')).toLowerCase();
+
+  if (!/^[0-9a-f]{64}$/.test(bunkerPubkey)) {
+    throw new Error('Invalid bunker URI');
+  }
+
+  const relays = parsed.searchParams.getAll('relay').filter(Boolean);
+
+  if (!relays.length) {
+    throw new Error('No relay provided');
+  }
+
+  return { bunkerPubkey, relays, secret: parsed.searchParams.get('secret') };
+}
+
+/**
+ * Complete a bunker handshake and return persistable login data.
+ *
+ * The generated client key is returned so it can be stored: reusing it keeps
+ * the same NIP-46 identity, and a fresh key on every session would read as a
+ * new client to the bunker and demand approval each time.
+ */
+export async function loginWithBunker(
+  uri: string,
+  onAuthChallenge?: (challenge: AuthChallengePresentation) => void
+): Promise<BunkerLogin> {
+  const { bunkerPubkey, relays, secret } = parseBunkerUri(uri);
+
+  const clientSecretKey = generateSecretKey();
+  const signer = createBunkerSigner({
+    clientSecretKey,
+    bunkerPubkey,
+    relays,
+    secret,
+    onAuthChallenge,
+  });
+
+  await signer.connect();
+  const pubkey = await signer.getPublicKey();
+
+  return {
+    id: `bunker:${pubkey}`,
+    type: 'bunker',
+    pubkey,
+    createdAt: new Date().toISOString(),
+    data: {
+      bunkerPubkey,
+      clientNsec: nip19.nsecEncode(clientSecretKey),
+      relays,
+    },
+  };
+}
+
+/** Rebuild a signer for an already-established bunker login. */
+export function bunkerSignerFromLogin(
+  data: BunkerLoginData,
+  onAuthChallenge?: (challenge: AuthChallengePresentation) => void
+): BunkerNostrSigner {
+  const decoded = nip19.decode(data.clientNsec);
+
+  if (decoded.type !== 'nsec') {
+    throw new Error('Invalid client key for bunker login');
+  }
+
+  return createBunkerSigner({
+    clientSecretKey: decoded.data,
+    bunkerPubkey: data.bunkerPubkey,
+    relays: data.relays,
+    onAuthChallenge,
+  });
+}

--- a/src/lib/bunkerSigner.ts
+++ b/src/lib/bunkerSigner.ts
@@ -3,6 +3,7 @@
 
 import { BunkerSigner } from 'nostr-tools/nip46';
 import { generateSecretKey, nip19 } from 'nostr-tools';
+import { SimplePool, type AbstractSimplePool } from 'nostr-tools/pool';
 import type { NostrEvent, NostrSigner } from '@nostrify/nostrify';
 import { presentAuthChallenge, type AuthChallengePresentation } from '@/lib/bunkerAuthChallenge';
 
@@ -30,6 +31,13 @@ export interface CreateBunkerSignerOptions {
   secret?: string | null;
   /** Called when the signer asks the user to approve out of band. */
   onAuthChallenge?: (challenge: AuthChallengePresentation) => void;
+  /**
+   * Relay pool to run this signer on. `BunkerSigner` opens sockets during
+   * construction, so a caller that only needs a signer briefly should pass a
+   * pool it owns and destroy it afterwards. `close()` drops the subscription
+   * but leaves the pool's connections up.
+   */
+  pool?: AbstractSimplePool;
 }
 
 export interface BunkerNostrSigner extends NostrSigner {
@@ -48,12 +56,13 @@ export interface BunkerNostrSigner extends NostrSigner {
  * fails the call and drops the subscription that the answer arrives on.
  */
 export function createBunkerSigner(options: CreateBunkerSignerOptions): BunkerNostrSigner {
-  const { clientSecretKey, bunkerPubkey, relays, secret = null, onAuthChallenge } = options;
+  const { clientSecretKey, bunkerPubkey, relays, secret = null, onAuthChallenge, pool } = options;
 
   const bunker = BunkerSigner.fromBunker(
     clientSecretKey,
     { pubkey: bunkerPubkey, relays, secret },
     {
+      ...(pool ? { pool } : {}),
       onauth: (url: string) => {
         onAuthChallenge?.(presentAuthChallenge(url));
       },
@@ -127,16 +136,28 @@ export async function loginWithBunker(
   const { bunkerPubkey, relays, secret } = parseBunkerUri(uri);
 
   const clientSecretKey = generateSecretKey();
+  // This signer exists only to complete the handshake; the session builds its
+  // own from the persisted data. Give it a pool we own so the sockets it opens
+  // during construction can be released, whether or not the handshake succeeds.
+  const pool = new SimplePool();
   const signer = createBunkerSigner({
     clientSecretKey,
     bunkerPubkey,
     relays,
     secret,
     onAuthChallenge,
+    pool,
   });
 
-  await signer.connect();
-  const pubkey = await signer.getPublicKey();
+  let pubkey: string;
+
+  try {
+    await signer.connect();
+    pubkey = await signer.getPublicKey();
+  } finally {
+    await signer.close().catch(() => {});
+    pool.destroy();
+  }
 
   return {
     id: `bunker:${pubkey}`,

--- a/src/lib/bunkerSigner.ts
+++ b/src/lib/bunkerSigner.ts
@@ -88,11 +88,17 @@ export function createBunkerSigner(options: CreateBunkerSignerOptions): BunkerNo
   // auth challenge can extend them all at once.
   const restartDeadlines = new Set<() => void>();
 
+  // Own the pool whenever the caller did not supply one. `BunkerSigner` keeps
+  // its pool private and `close()` only drops the subscription, so a pool we
+  // let it create internally could never be released and its sockets would
+  // outlive the signer. Creating it here keeps a handle to destroy.
+  const ownedPool = pool ?? new SimplePool();
+
   const bunker = BunkerSigner.fromBunker(
     clientSecretKey,
     { pubkey: bunkerPubkey, relays, secret },
     {
-      ...(pool ? { pool } : {}),
+      pool: ownedPool,
       onauth: (url: string) => {
         // The signer answered, so it is reachable and the rest of the wait is
         // on a human approving out of band. Restart the clocks instead of
@@ -153,7 +159,15 @@ export function createBunkerSigner(options: CreateBunkerSignerOptions): BunkerNo
 
   return {
     connect: () => withDeadline('connect', () => bunker.connect()),
-    close: () => bunker.close(),
+    close: async () => {
+      await bunker.close();
+
+      // Only what we created. A caller that passed its own pool is responsible
+      // for that one, and may still be using it.
+      if (!pool) {
+        ownedPool.destroy();
+      }
+    },
     getPublicKey: () => withDeadline('get_public_key', () => bunker.getPublicKey()),
     signEvent: (event) => withDeadline('sign_event', () => bunker.signEvent(event) as Promise<NostrEvent>),
     nip04: {

--- a/src/lib/bunkerSigner.ts
+++ b/src/lib/bunkerSigner.ts
@@ -22,6 +22,19 @@ export interface BunkerLogin {
   data: BunkerLoginData;
 }
 
+/**
+ * How long a single NIP-46 request may wait for its response.
+ *
+ * `BunkerSigner.sendRequest` registers a listener and settles only when a
+ * matching response arrives, so without a bound a signer that is unreachable —
+ * but whose relay still accepts the publish — leaves the promise pending
+ * forever. `loginWithBunker` never returns, `LoginDialog`'s `finally` never
+ * runs, and the dialog sits on "Connecting…" with no error. The signer this
+ * replaced (`NConnectSigner`, via `NLogin.fromBunker`) bounded every request at
+ * the same 60s.
+ */
+export const BUNKER_REQUEST_TIMEOUT_MS = 60_000;
+
 export interface CreateBunkerSignerOptions {
   /** Our half of the NIP-46 conversation. Stable across sessions. */
   clientSecretKey: Uint8Array;
@@ -38,6 +51,11 @@ export interface CreateBunkerSignerOptions {
    * but leaves the pool's connections up.
    */
   pool?: AbstractSimplePool;
+  /**
+   * How long one request may wait for its response, in ms. Pass `0` to wait
+   * indefinitely. Defaults to {@link BUNKER_REQUEST_TIMEOUT_MS}.
+   */
+  requestTimeoutMs?: number;
 }
 
 export interface BunkerNostrSigner extends NostrSigner {
@@ -56,7 +74,19 @@ export interface BunkerNostrSigner extends NostrSigner {
  * fails the call and drops the subscription that the answer arrives on.
  */
 export function createBunkerSigner(options: CreateBunkerSignerOptions): BunkerNostrSigner {
-  const { clientSecretKey, bunkerPubkey, relays, secret = null, onAuthChallenge, pool } = options;
+  const {
+    clientSecretKey,
+    bunkerPubkey,
+    relays,
+    secret = null,
+    onAuthChallenge,
+    pool,
+    requestTimeoutMs = BUNKER_REQUEST_TIMEOUT_MS,
+  } = options;
+
+  // Every in-flight request parks a way to restart its own clock here, so an
+  // auth challenge can extend them all at once.
+  const restartDeadlines = new Set<() => void>();
 
   const bunker = BunkerSigner.fromBunker(
     clientSecretKey,
@@ -64,23 +94,79 @@ export function createBunkerSigner(options: CreateBunkerSignerOptions): BunkerNo
     {
       ...(pool ? { pool } : {}),
       onauth: (url: string) => {
+        // The signer answered, so it is reachable and the rest of the wait is
+        // on a human approving out of band. Restart the clocks instead of
+        // timing out with the approval tab still open.
+        for (const restart of [...restartDeadlines]) {
+          restart();
+        }
+
         onAuthChallenge?.(presentAuthChallenge(url));
       },
     }
   );
 
+  function withDeadline<T>(method: string, run: () => Promise<T>): Promise<T> {
+    if (!(requestTimeoutMs > 0)) {
+      return run();
+    }
+
+    return new Promise<T>((resolve, reject) => {
+      let settled = false;
+      let timer: ReturnType<typeof setTimeout>;
+
+      function restart() {
+        if (settled) return;
+        clearTimeout(timer);
+        timer = setTimeout(expire, requestTimeoutMs);
+      }
+
+      function release() {
+        settled = true;
+        clearTimeout(timer);
+        restartDeadlines.delete(restart);
+      }
+
+      function expire() {
+        if (settled) return;
+        release();
+        reject(new Error(`Bunker request timed out: ${method}`));
+      }
+
+      restartDeadlines.add(restart);
+      timer = setTimeout(expire, requestTimeoutMs);
+
+      run().then(
+        (value) => {
+          if (settled) return;
+          release();
+          resolve(value);
+        },
+        (error: unknown) => {
+          if (settled) return;
+          release();
+          reject(error);
+        }
+      );
+    });
+  }
+
   return {
-    connect: () => bunker.connect(),
+    connect: () => withDeadline('connect', () => bunker.connect()),
     close: () => bunker.close(),
-    getPublicKey: () => bunker.getPublicKey(),
-    signEvent: (event) => bunker.signEvent(event) as Promise<NostrEvent>,
+    getPublicKey: () => withDeadline('get_public_key', () => bunker.getPublicKey()),
+    signEvent: (event) => withDeadline('sign_event', () => bunker.signEvent(event) as Promise<NostrEvent>),
     nip04: {
-      encrypt: (pubkey, plaintext) => bunker.nip04Encrypt(pubkey, plaintext),
-      decrypt: (pubkey, ciphertext) => bunker.nip04Decrypt(pubkey, ciphertext),
+      encrypt: (pubkey, plaintext) =>
+        withDeadline('nip04_encrypt', () => bunker.nip04Encrypt(pubkey, plaintext)),
+      decrypt: (pubkey, ciphertext) =>
+        withDeadline('nip04_decrypt', () => bunker.nip04Decrypt(pubkey, ciphertext)),
     },
     nip44: {
-      encrypt: (pubkey, plaintext) => bunker.nip44Encrypt(pubkey, plaintext),
-      decrypt: (pubkey, ciphertext) => bunker.nip44Decrypt(pubkey, ciphertext),
+      encrypt: (pubkey, plaintext) =>
+        withDeadline('nip44_encrypt', () => bunker.nip44Encrypt(pubkey, plaintext)),
+      decrypt: (pubkey, ciphertext) =>
+        withDeadline('nip44_decrypt', () => bunker.nip44Decrypt(pubkey, ciphertext)),
     },
   };
 }

--- a/src/lib/bunkerSignerRegistry.test.ts
+++ b/src/lib/bunkerSignerRegistry.test.ts
@@ -1,0 +1,213 @@
+// ABOUTME: Tests that bunker logins share one signer and release it on logout
+// ABOUTME: divine-web#531 — a signer per consumer opened a socket set per mounted component
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { nip19, generateSecretKey } from 'nostr-tools';
+import type { BunkerLoginData } from '@/lib/bunkerSigner';
+
+const close = vi.fn(async () => {});
+const bunkerSignerFromLogin = vi.fn(() => ({
+  connect: vi.fn(async () => {}),
+  close,
+  getPublicKey: vi.fn(async () => 'd'.repeat(64)),
+  signEvent: vi.fn(async () => ({})),
+  nip04: { encrypt: vi.fn(async () => ''), decrypt: vi.fn(async () => '') },
+  nip44: { encrypt: vi.fn(async () => ''), decrypt: vi.fn(async () => '') },
+}));
+
+vi.mock('@/lib/bunkerSigner', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/lib/bunkerSigner')>()),
+  bunkerSignerFromLogin: (...args: unknown[]) => bunkerSignerFromLogin(...(args as [])),
+}));
+
+const RELAY = 'wss://relay.example';
+const LOGIN_ID = 'bunker:abc';
+
+function loginData(overrides: Partial<BunkerLoginData> = {}): BunkerLoginData {
+  return {
+    bunkerPubkey: 'b'.repeat(64),
+    clientNsec: nip19.nsecEncode(generateSecretKey()),
+    relays: [RELAY],
+    ...overrides,
+  };
+}
+
+async function registry() {
+  const mod = await import('./bunkerSignerRegistry');
+  mod.resetBunkerSignerRegistry();
+  return mod;
+}
+
+describe('getBunkerSigner', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // The defect: `createUserFromLogin` runs in a `useMemo` in `useCurrentUser`,
+  // so ten mounted components meant ten signers and ten sets of sockets.
+  it('hands every consumer of one login the same signer', async () => {
+    const { getBunkerSigner } = await registry();
+    const data = loginData();
+
+    const signers = Array.from({ length: 10 }, () => getBunkerSigner(LOGIN_ID, data));
+
+    expect(new Set(signers).size).toBe(1);
+  });
+
+  // Callers treat a throw as "skip this login". Deferring the connection must
+  // not defer this check with it.
+  it('rejects unusable login data up front, before anything is deferred', async () => {
+    const { getBunkerSigner } = await registry();
+    const npub = nip19.npubEncode('b'.repeat(64)) as `nsec1${string}`;
+
+    expect(() => getBunkerSigner(LOGIN_ID, loginData({ clientNsec: npub }))).toThrow(
+      'Invalid client key for bunker login'
+    );
+    expect(bunkerSignerFromLogin).not.toHaveBeenCalled();
+  });
+
+  it('keeps separate logins on separate signers', async () => {
+    const { getBunkerSigner } = await registry();
+
+    const first = getBunkerSigner('bunker:one', loginData());
+    const second = getBunkerSigner('bunker:two', loginData());
+
+    expect(first).not.toBe(second);
+  });
+
+  // Idle logins cost nothing under NConnectSigner, which opened a REQ per
+  // request. `BunkerSigner.fromBunker` subscribes eagerly, so the connection
+  // has to wait for a request that actually needs it.
+  it('opens no connection until a request needs one', async () => {
+    const { getBunkerSigner } = await registry();
+
+    getBunkerSigner(LOGIN_ID, loginData());
+
+    expect(bunkerSignerFromLogin).not.toHaveBeenCalled();
+  });
+
+  it('opens exactly one connection once requests start, however many callers', async () => {
+    const { getBunkerSigner } = await registry();
+    const data = loginData();
+
+    await getBunkerSigner(LOGIN_ID, data).getPublicKey();
+    await getBunkerSigner(LOGIN_ID, data).getPublicKey();
+    await getBunkerSigner(LOGIN_ID, data).signEvent({ kind: 1, content: '', created_at: 1, tags: [] });
+
+    expect(bunkerSignerFromLogin).toHaveBeenCalledTimes(1);
+  });
+
+  // A login id is derived from the user pubkey, so the same id can come back
+  // pointing at a different bunker or carrying a re-issued client key.
+  it('rebuilds when the connection details change under the same id', async () => {
+    const { getBunkerSigner } = await registry();
+
+    await getBunkerSigner(LOGIN_ID, loginData()).getPublicKey();
+    await getBunkerSigner(LOGIN_ID, loginData({ relays: ['wss://elsewhere.example'] })).getPublicKey();
+
+    expect(bunkerSignerFromLogin).toHaveBeenCalledTimes(2);
+    expect(close).toHaveBeenCalledTimes(1);
+  });
+
+  it('reuses the signer when only relay ordering differs', async () => {
+    const { getBunkerSigner } = await registry();
+    const nsec = nip19.nsecEncode(generateSecretKey());
+    const relays = ['wss://a.example', 'wss://b.example'];
+
+    const first = getBunkerSigner(LOGIN_ID, loginData({ clientNsec: nsec, relays }));
+    const second = getBunkerSigner(LOGIN_ID, loginData({ clientNsec: nsec, relays: [...relays].reverse() }));
+
+    expect(second).toBe(first);
+  });
+});
+
+describe('releasing signers', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('closes the connection a released login had opened', async () => {
+    const { getBunkerSigner, releaseBunkerSigner } = await registry();
+
+    await getBunkerSigner(LOGIN_ID, loginData()).getPublicKey();
+    releaseBunkerSigner(LOGIN_ID);
+
+    expect(close).toHaveBeenCalledTimes(1);
+  });
+
+  it('has nothing to close for a login that never issued a request', async () => {
+    const { getBunkerSigner, releaseBunkerSigner } = await registry();
+
+    getBunkerSigner(LOGIN_ID, loginData());
+    releaseBunkerSigner(LOGIN_ID);
+
+    expect(close).not.toHaveBeenCalled();
+  });
+
+  it('builds a fresh signer after release rather than reusing the closed one', async () => {
+    const { getBunkerSigner, releaseBunkerSigner } = await registry();
+    const data = loginData();
+
+    await getBunkerSigner(LOGIN_ID, data).getPublicKey();
+    releaseBunkerSigner(LOGIN_ID);
+    await getBunkerSigner(LOGIN_ID, data).getPublicKey();
+
+    expect(bunkerSignerFromLogin).toHaveBeenCalledTimes(2);
+  });
+
+  // Logout, account switching and dropping an invalid login all go through
+  // different call sites; reconciling covers them without touching each one.
+  it('releases only the logins that are gone', async () => {
+    const { getBunkerSigner, releaseBunkerSignersExcept } = await registry();
+    const kept = loginData();
+
+    await getBunkerSigner('bunker:kept', kept).getPublicKey();
+    await getBunkerSigner('bunker:gone', loginData()).getPublicKey();
+    expect(bunkerSignerFromLogin).toHaveBeenCalledTimes(2);
+
+    releaseBunkerSignersExcept(['bunker:kept']);
+
+    expect(close).toHaveBeenCalledTimes(1);
+    // The surviving login keeps the signer it already had.
+    await getBunkerSigner('bunker:kept', kept).getPublicKey();
+    expect(bunkerSignerFromLogin).toHaveBeenCalledTimes(2);
+  });
+
+  it('releases everything when the last login goes', async () => {
+    const { getBunkerSigner, releaseBunkerSignersExcept } = await registry();
+
+    await getBunkerSigner('bunker:one', loginData()).getPublicKey();
+    await getBunkerSigner('bunker:two', loginData()).getPublicKey();
+
+    releaseBunkerSignersExcept([]);
+
+    expect(close).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('isUsableBunkerLogin', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('accepts stored data whose client key is an nsec', async () => {
+    const { isUsableBunkerLogin } = await registry();
+    expect(isUsableBunkerLogin(loginData())).toBe(true);
+  });
+
+  it('rejects stored data whose client key is not an nsec', async () => {
+    const { isUsableBunkerLogin } = await registry();
+    const npub = nip19.npubEncode('b'.repeat(64)) as `nsec1${string}`;
+
+    expect(isUsableBunkerLogin(loginData({ clientNsec: npub }))).toBe(false);
+  });
+
+  // The whole point of the probe: answering must not open anything.
+  it('answers without building a signer', async () => {
+    const { isUsableBunkerLogin } = await registry();
+
+    isUsableBunkerLogin(loginData());
+
+    expect(bunkerSignerFromLogin).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/bunkerSignerRegistry.ts
+++ b/src/lib/bunkerSignerRegistry.ts
@@ -1,0 +1,139 @@
+// ABOUTME: One bunker signer per login, shared by every consumer and built on first use
+// ABOUTME: divine-web#531 — constructing a BunkerSigner opens sockets, so consumers must not each build their own
+
+import {
+  bunkerSignerFromLogin,
+  clientSecretKeyFromLogin,
+  type BunkerLoginData,
+  type BunkerNostrSigner,
+} from '@/lib/bunkerSigner';
+
+interface RegisteredSigner {
+  /** Connection details this signer was built for; a change invalidates it. */
+  fingerprint: string;
+  signer: BunkerNostrSigner;
+  /** Undefined until the first request actually needs the connection. */
+  connected?: BunkerNostrSigner;
+}
+
+const registry = new Map<string, RegisteredSigner>();
+
+function fingerprintOf(data: BunkerLoginData): string {
+  return JSON.stringify([data.bunkerPubkey, data.clientNsec, [...data.relays].sort()]);
+}
+
+/**
+ * Wrap a login so its sockets open on the first request rather than at
+ * construction.
+ *
+ * `createUserFromLogin` runs for every login in `useCurrentUser`, which is
+ * mounted all over the app, but most of those users are never asked to sign
+ * anything. `BunkerSigner.fromBunker` calls `setupSubscription` eagerly, so
+ * without this an idle login costs a socket per relay for the life of the tab.
+ * The signer this replaced (`NConnectSigner`) opened a REQ per request and tore
+ * it down afterwards, so idle logins cost nothing there either.
+ */
+function lazySigner(entry: RegisteredSigner, data: BunkerLoginData): BunkerNostrSigner {
+  const connect = () => (entry.connected ??= bunkerSignerFromLogin(data));
+
+  return {
+    connect: () => connect().connect(),
+    getPublicKey: () => connect().getPublicKey(),
+    signEvent: (event) => connect().signEvent(event),
+    // Nothing to close if no request ever came through.
+    close: async () => {
+      await entry.connected?.close();
+    },
+    nip04: {
+      encrypt: (pubkey, plaintext) => connect().nip04!.encrypt(pubkey, plaintext),
+      decrypt: (pubkey, ciphertext) => connect().nip04!.decrypt(pubkey, ciphertext),
+    },
+    nip44: {
+      encrypt: (pubkey, plaintext) => connect().nip44!.encrypt(pubkey, plaintext),
+      decrypt: (pubkey, ciphertext) => connect().nip44!.decrypt(pubkey, ciphertext),
+    },
+  };
+}
+
+/**
+ * The signer for a bunker login, built once and reused.
+ *
+ * Keyed by login id so every consumer of the same login shares one signer.
+ * Building one per caller opened a socket per relay per mounted component, and
+ * nothing ever closed them.
+ */
+export function getBunkerSigner(loginId: string, data: BunkerLoginData): BunkerNostrSigner {
+  // Validate here rather than leaving it to the deferred connection: callers
+  // treat a throw as "skip this login", and decoding the key opens nothing.
+  // Without this an unusable login would read as valid and fail every later
+  // request instead.
+  clientSecretKeyFromLogin(data);
+
+  const fingerprint = fingerprintOf(data);
+  const existing = registry.get(loginId);
+
+  if (existing) {
+    if (existing.fingerprint === fingerprint) {
+      return existing.signer;
+    }
+
+    // Same login id pointing at a different bunker or client key. The old
+    // signer's sockets are now unreachable, so release them here.
+    releaseBunkerSigner(loginId);
+  }
+
+  const entry: RegisteredSigner = { fingerprint } as RegisteredSigner;
+  entry.signer = lazySigner(entry, data);
+  registry.set(loginId, entry);
+
+  return entry.signer;
+}
+
+/** Drop a login's signer and close whatever connection it had opened. */
+export function releaseBunkerSigner(loginId: string): void {
+  const entry = registry.get(loginId);
+
+  if (!entry) {
+    return;
+  }
+
+  registry.delete(loginId);
+  // Nothing awaits a logout, and a failure to close is not actionable.
+  void entry.connected?.close().catch(() => {});
+}
+
+/**
+ * Release every signer whose login is no longer present.
+ *
+ * Reconciling against the surviving logins covers every removal path, rather
+ * than depending on each logout call site to remember to release.
+ */
+export function releaseBunkerSignersExcept(loginIds: Iterable<string>): void {
+  const keep = new Set(loginIds);
+
+  for (const loginId of [...registry.keys()]) {
+    if (!keep.has(loginId)) {
+      releaseBunkerSigner(loginId);
+    }
+  }
+}
+
+/** Whether stored login data can produce a signer, without building one. */
+export function isUsableBunkerLogin(data: BunkerLoginData): boolean {
+  try {
+    clientSecretKeyFromLogin(data);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** Test seam: forget every signer without closing anything. */
+export function resetBunkerSignerRegistry(): void {
+  registry.clear();
+}
+
+/** Test seam: how many logins currently hold a signer. */
+export function registeredBunkerSignerCount(): number {
+  return registry.size;
+}

--- a/src/lib/i18n/locales/ar/common.json
+++ b/src/lib/i18n/locales/ar/common.json
@@ -444,6 +444,8 @@
     "bunkerLabel": "رابط Bunker",
     "bunkerPlaceholder": "bunker://",
     "bunkerButton": "تسجيل الدخول عبر Bunker",
+    "bunkerAuthPrompt": "يحتاج موقّعك إلى موافقتك. حاولنا فتح صفحته لكن متصفحك منع ذلك — افتحها من هنا:",
+    "bunkerAuthLink": "الموافقة في الموقّع",
     "connecting": "جارٍ الاتصال...",
     "errorInviteServiceUnavailable": "خدمة الدعوات غير متاحة",
     "errorExtensionNotFound": "لم يتم العثور على إضافة Nostr. يرجى تثبيت إضافة NIP-07.",

--- a/src/lib/i18n/locales/de/common.json
+++ b/src/lib/i18n/locales/de/common.json
@@ -424,6 +424,8 @@
     "bunkerLabel": "Bunker-URI",
     "bunkerPlaceholder": "bunker://",
     "bunkerButton": "Mit Bunker anmelden",
+    "bunkerAuthPrompt": "Dein Signer braucht deine Freigabe. Wir wollten seine Seite öffnen, dein Browser hat das blockiert — hier öffnen:",
+    "bunkerAuthLink": "Im Signer freigeben",
     "connecting": "Wird verbunden...",
     "errorInviteServiceUnavailable": "Einladungsdienst nicht verfügbar",
     "errorExtensionNotFound": "Nostr-Erweiterung nicht gefunden. Bitte installiere eine NIP-07-Erweiterung.",

--- a/src/lib/i18n/locales/en/common.json
+++ b/src/lib/i18n/locales/en/common.json
@@ -424,6 +424,8 @@
     "bunkerLabel": "Bunker URI",
     "bunkerPlaceholder": "bunker://",
     "bunkerButton": "Login with Bunker",
+    "bunkerAuthPrompt": "Your signer needs you to approve this. We tried to open its page and your browser blocked it — open it here:",
+    "bunkerAuthLink": "Approve in your signer",
     "connecting": "Connecting...",
     "errorInviteServiceUnavailable": "Invite service unavailable",
     "errorExtensionNotFound": "Nostr extension not found. Please install a NIP-07 extension.",

--- a/src/lib/i18n/locales/es/common.json
+++ b/src/lib/i18n/locales/es/common.json
@@ -424,6 +424,8 @@
     "bunkerLabel": "URI de Bunker",
     "bunkerPlaceholder": "bunker://",
     "bunkerButton": "Iniciar sesión con Bunker",
+    "bunkerAuthPrompt": "Tu firmante necesita que lo apruebes. Intentamos abrir su página y tu navegador lo bloqueó: ábrela aquí:",
+    "bunkerAuthLink": "Aprobar en tu firmante",
     "connecting": "Conectando...",
     "errorInviteServiceUnavailable": "Servicio de invitaciones no disponible",
     "errorExtensionNotFound": "Extensión Nostr no encontrada. Instala una extensión NIP-07.",

--- a/src/lib/i18n/locales/fil/common.json
+++ b/src/lib/i18n/locales/fil/common.json
@@ -424,6 +424,8 @@
     "bunkerLabel": "Bunker URI",
     "bunkerPlaceholder": "bunker://",
     "bunkerButton": "Mag-log in gamit ang Bunker",
+    "bunkerAuthPrompt": "Kailangan ng iyong signer na aprubahan mo ito. Sinubukan naming buksan ang pahina nito pero hinarang ito ng browser mo — buksan dito:",
+    "bunkerAuthLink": "Aprubahan sa iyong signer",
     "connecting": "Kumokonekta...",
     "errorInviteServiceUnavailable": "Hindi available ang invite service",
     "errorExtensionNotFound": "Walang nakitang Nostr extension. Mag-install ng NIP-07 extension.",

--- a/src/lib/i18n/locales/fr/common.json
+++ b/src/lib/i18n/locales/fr/common.json
@@ -424,6 +424,8 @@
     "bunkerLabel": "URI Bunker",
     "bunkerPlaceholder": "bunker://",
     "bunkerButton": "Connexion avec Bunker",
+    "bunkerAuthPrompt": "Votre signataire attend votre approbation. Nous avons tenté d’ouvrir sa page et votre navigateur l’a bloquée — ouvrez-la ici :",
+    "bunkerAuthLink": "Approuver dans votre signataire",
     "connecting": "Connexion...",
     "errorInviteServiceUnavailable": "Service d'invitation indisponible",
     "errorExtensionNotFound": "Extension Nostr introuvable. Installe une extension NIP-07.",

--- a/src/lib/i18n/locales/id/common.json
+++ b/src/lib/i18n/locales/id/common.json
@@ -424,6 +424,8 @@
     "bunkerLabel": "URI Bunker",
     "bunkerPlaceholder": "bunker://",
     "bunkerButton": "Masuk dengan Bunker",
+    "bunkerAuthPrompt": "Penanda tangan Anda butuh persetujuan. Kami mencoba membuka halamannya tetapi diblokir peramban — buka di sini:",
+    "bunkerAuthLink": "Setujui di penanda tangan",
     "connecting": "Menghubungkan...",
     "errorInviteServiceUnavailable": "Layanan invite tidak tersedia",
     "errorExtensionNotFound": "Ekstensi Nostr tidak ditemukan. Silakan pasang ekstensi NIP-07.",

--- a/src/lib/i18n/locales/it/common.json
+++ b/src/lib/i18n/locales/it/common.json
@@ -424,6 +424,8 @@
     "bunkerLabel": "URI Bunker",
     "bunkerPlaceholder": "bunker://",
     "bunkerButton": "Accedi con Bunker",
+    "bunkerAuthPrompt": "Il tuo firmatario ha bisogno della tua approvazione. Abbiamo provato ad aprire la sua pagina e il browser l’ha bloccata: aprila qui:",
+    "bunkerAuthLink": "Approva nel firmatario",
     "connecting": "Connessione...",
     "errorInviteServiceUnavailable": "Servizio inviti non disponibile",
     "errorExtensionNotFound": "Estensione Nostr non trovata. Installa un'estensione NIP-07.",

--- a/src/lib/i18n/locales/ja/common.json
+++ b/src/lib/i18n/locales/ja/common.json
@@ -424,6 +424,8 @@
     "bunkerLabel": "Bunker URI",
     "bunkerPlaceholder": "bunker://",
     "bunkerButton": "Bunkerでログイン",
+    "bunkerAuthPrompt": "署名アプリの承認が必要です。ページを開こうとしましたがブラウザにブロックされました。こちらから開いてください:",
+    "bunkerAuthLink": "署名アプリで承認する",
     "connecting": "接続中...",
     "errorInviteServiceUnavailable": "招待サービスが利用できません",
     "errorExtensionNotFound": "Nostr拡張機能が見つかりません。NIP-07拡張機能をインストールしてください。",

--- a/src/lib/i18n/locales/ko/common.json
+++ b/src/lib/i18n/locales/ko/common.json
@@ -424,6 +424,8 @@
     "bunkerLabel": "Bunker URI",
     "bunkerPlaceholder": "bunker://",
     "bunkerButton": "Bunker로 로그인",
+    "bunkerAuthPrompt": "서명 앱의 승인이 필요합니다. 페이지를 열려고 했지만 브라우저가 차단했습니다 — 여기서 열어 주세요:",
+    "bunkerAuthLink": "서명 앱에서 승인하기",
     "connecting": "연결 중...",
     "errorInviteServiceUnavailable": "초대 서비스를 사용할 수 없음",
     "errorExtensionNotFound": "Nostr 확장을 찾을 수 없어요. NIP-07 확장을 설치하세요.",

--- a/src/lib/i18n/locales/ms/common.json
+++ b/src/lib/i18n/locales/ms/common.json
@@ -424,6 +424,8 @@
     "bunkerLabel": "URI Bunker",
     "bunkerPlaceholder": "bunker://",
     "bunkerButton": "Log masuk dengan Bunker",
+    "bunkerAuthPrompt": "Penandatangan anda perlukan kelulusan. Kami cuba buka halamannya tetapi pelayar anda menyekatnya — buka di sini:",
+    "bunkerAuthLink": "Luluskan dalam penandatangan",
     "connecting": "Menyambung...",
     "errorInviteServiceUnavailable": "Perkhidmatan jemputan tidak tersedia",
     "errorExtensionNotFound": "Ekstensi Nostr tidak ditemui. Sila pasang ekstensi NIP-07.",

--- a/src/lib/i18n/locales/nl/common.json
+++ b/src/lib/i18n/locales/nl/common.json
@@ -424,6 +424,8 @@
     "bunkerLabel": "Bunker-URI",
     "bunkerPlaceholder": "bunker://",
     "bunkerButton": "Inloggen met Bunker",
+    "bunkerAuthPrompt": "Je signer wacht op goedkeuring. We probeerden de pagina te openen, maar je browser blokkeerde dat — open hem hier:",
+    "bunkerAuthLink": "Goedkeuren in je signer",
     "connecting": "Verbinden...",
     "errorInviteServiceUnavailable": "Uitnodigingsservice niet beschikbaar",
     "errorExtensionNotFound": "Nostr-extensie niet gevonden. Installeer een NIP-07-extensie.",

--- a/src/lib/i18n/locales/pl/common.json
+++ b/src/lib/i18n/locales/pl/common.json
@@ -424,6 +424,8 @@
     "bunkerLabel": "URI Bunker",
     "bunkerPlaceholder": "bunker://",
     "bunkerButton": "Zaloguj przez Bunker",
+    "bunkerAuthPrompt": "Twój podpisujący czeka na zatwierdzenie. Próbowaliśmy otworzyć jego stronę, ale przeglądarka to zablokowała — otwórz ją tutaj:",
+    "bunkerAuthLink": "Zatwierdź w podpisującym",
     "connecting": "Łączenie...",
     "errorInviteServiceUnavailable": "Usługa zaproszeń niedostępna",
     "errorExtensionNotFound": "Nie znaleziono rozszerzenia Nostr. Zainstaluj rozszerzenie NIP-07.",

--- a/src/lib/i18n/locales/pt/common.json
+++ b/src/lib/i18n/locales/pt/common.json
@@ -424,6 +424,8 @@
     "bunkerLabel": "URI do Bunker",
     "bunkerPlaceholder": "bunker://",
     "bunkerButton": "Entrar com Bunker",
+    "bunkerAuthPrompt": "O seu assinador precisa da sua aprovação. Tentámos abrir a página dele e o navegador bloqueou — abra aqui:",
+    "bunkerAuthLink": "Aprovar no seu assinador",
     "connecting": "Conectando...",
     "errorInviteServiceUnavailable": "Serviço de convites indisponível",
     "errorExtensionNotFound": "Extensão Nostr não encontrada. Instale uma extensão NIP-07.",

--- a/src/lib/i18n/locales/ro/common.json
+++ b/src/lib/i18n/locales/ro/common.json
@@ -424,6 +424,8 @@
     "bunkerLabel": "URI Bunker",
     "bunkerPlaceholder": "bunker://",
     "bunkerButton": "Conectează-te cu Bunker",
+    "bunkerAuthPrompt": "Semnatarul tău are nevoie de aprobare. Am încercat să deschidem pagina lui, dar browserul a blocat-o — deschide-o aici:",
+    "bunkerAuthLink": "Aprobă în semnatar",
     "connecting": "Se conectează...",
     "errorInviteServiceUnavailable": "Serviciul de invitații e indisponibil",
     "errorExtensionNotFound": "Extensie Nostr negăsită. Te rugăm instalează o extensie NIP-07.",

--- a/src/lib/i18n/locales/sv/common.json
+++ b/src/lib/i18n/locales/sv/common.json
@@ -424,6 +424,8 @@
     "bunkerLabel": "Bunker-URI",
     "bunkerPlaceholder": "bunker://",
     "bunkerButton": "Logga in med Bunker",
+    "bunkerAuthPrompt": "Din signerare behöver ditt godkännande. Vi försökte öppna sidan men din webbläsare blockerade den — öppna den här:",
+    "bunkerAuthLink": "Godkänn i din signerare",
     "connecting": "Ansluter...",
     "errorInviteServiceUnavailable": "Inbjudningstjänsten är inte tillgänglig",
     "errorExtensionNotFound": "Hittade inget Nostr-tillägg. Installera ett NIP-07-tillägg.",

--- a/src/lib/i18n/locales/tr/common.json
+++ b/src/lib/i18n/locales/tr/common.json
@@ -424,6 +424,8 @@
     "bunkerLabel": "Bunker URI'si",
     "bunkerPlaceholder": "bunker://",
     "bunkerButton": "Bunker ile Giriş Yap",
+    "bunkerAuthPrompt": "İmzalayıcın onayını bekliyor. Sayfasını açmayı denedik ama tarayıcın engelledi — buradan aç:",
+    "bunkerAuthLink": "İmzalayıcında onayla",
     "connecting": "Bağlanıyor...",
     "errorInviteServiceUnavailable": "Davet servisi kullanılamıyor",
     "errorExtensionNotFound": "Nostr eklentisi bulunamadı. Lütfen bir NIP-07 eklentisi yükle.",

--- a/src/lib/i18n/locales/ur/common.json
+++ b/src/lib/i18n/locales/ur/common.json
@@ -424,6 +424,8 @@
     "bunkerLabel": "Bunker URI",
     "bunkerPlaceholder": "bunker://",
     "bunkerButton": "Bunker سے لاگ اِن",
+    "bunkerAuthPrompt": "آپ کے دستخط کنندہ کو آپ کی منظوری درکار ہے۔ ہم نے اس کا صفحہ کھولنے کی کوشش کی مگر براؤزر نے روک دیا — یہاں سے کھولیں:",
+    "bunkerAuthLink": "دستخط کنندہ میں منظوری دیں",
     "connecting": "جڑ رہا ہے...",
     "errorInviteServiceUnavailable": "دعوت نامہ سروس دستیاب نہیں",
     "errorExtensionNotFound": "Nostr ایکسٹینشن نہیں ملی۔ براہِ کرم NIP-07 ایکسٹینشن انسٹال کریں۔",

--- a/src/lib/i18n/locales/vi/common.json
+++ b/src/lib/i18n/locales/vi/common.json
@@ -424,6 +424,8 @@
     "bunkerLabel": "URI bunker",
     "bunkerPlaceholder": "bunker://",
     "bunkerButton": "Đăng nhập bằng Bunker",
+    "bunkerAuthPrompt": "Trình ký của bạn cần bạn phê duyệt. Chúng tôi đã thử mở trang của nó nhưng trình duyệt chặn — mở tại đây:",
+    "bunkerAuthLink": "Phê duyệt trong trình ký",
     "connecting": "Đang kết nối...",
     "errorInviteServiceUnavailable": "Dịch vụ thư mời không khả dụng",
     "errorExtensionNotFound": "Không tìm thấy tiện ích mở rộng Nostr. Vui lòng cài một tiện ích NIP-07.",

--- a/src/lib/i18n/locales/zh/common.json
+++ b/src/lib/i18n/locales/zh/common.json
@@ -424,6 +424,8 @@
     "bunkerLabel": "Bunker URI",
     "bunkerPlaceholder": "bunker://",
     "bunkerButton": "用 Bunker 登录",
+    "bunkerAuthPrompt": "你的签名器需要你确认。我们尝试打开它的页面但被浏览器拦截了——在这里打开：",
+    "bunkerAuthLink": "在签名器中确认",
     "connecting": "连接中…",
     "errorInviteServiceUnavailable": "邀请服务不可用",
     "errorExtensionNotFound": "没找到 Nostr 扩展。请安装一个 NIP-07 扩展。",

--- a/src/lib/nostrLogin.test.ts
+++ b/src/lib/nostrLogin.test.ts
@@ -1,0 +1,148 @@
+// ABOUTME: Tests that login -> user conversion shares bunker signers and probes without building them
+// ABOUTME: divine-web#531 — this runs in a useMemo in useCurrentUser, so a signer per call leaked sockets
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { nip19, generateSecretKey } from 'nostr-tools';
+import type { NLoginType } from '@nostrify/react/login';
+
+const bunkerSignerFromLogin = vi.fn(() => ({
+  connect: vi.fn(async () => {}),
+  close: vi.fn(async () => {}),
+  getPublicKey: vi.fn(async () => 'd'.repeat(64)),
+  signEvent: vi.fn(async () => ({})),
+  nip04: { encrypt: vi.fn(async () => ''), decrypt: vi.fn(async () => '') },
+  nip44: { encrypt: vi.fn(async () => ''), decrypt: vi.fn(async () => '') },
+}));
+
+vi.mock('@/lib/bunkerSigner', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/lib/bunkerSigner')>()),
+  bunkerSignerFromLogin: (...args: unknown[]) => bunkerSignerFromLogin(...(args as [])),
+}));
+
+const USER_PUBKEY = 'a'.repeat(64);
+
+function bunkerLogin(id = 'bunker:one'): NLoginType {
+  return {
+    id,
+    type: 'bunker',
+    pubkey: USER_PUBKEY,
+    createdAt: new Date(0).toISOString(),
+    data: {
+      bunkerPubkey: 'b'.repeat(64),
+      clientNsec: nip19.nsecEncode(generateSecretKey()),
+      relays: ['wss://relay.example'],
+    },
+  };
+}
+
+async function loadModules() {
+  const registry = await import('./bunkerSignerRegistry');
+  registry.resetBunkerSignerRegistry();
+  return { ...(await import('./nostrLogin')), registry };
+}
+
+describe('createUserFromLogin', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // useCurrentUser is mounted all over the app and rebuilds users in a memo, so
+  // a fresh signer per call meant a socket set per mounted component.
+  it('gives repeated calls for one bunker login the same signer', async () => {
+    const { createUserFromLogin } = await loadModules();
+    const login = bunkerLogin();
+
+    const first = createUserFromLogin(login);
+    const second = createUserFromLogin(login);
+
+    expect(second.signer).toBe(first.signer);
+  });
+
+  it('does not connect merely by building the user', async () => {
+    const { createUserFromLogin } = await loadModules();
+
+    createUserFromLogin(bunkerLogin());
+
+    expect(bunkerSignerFromLogin).not.toHaveBeenCalled();
+  });
+
+  it('connects once when the user actually signs', async () => {
+    const { createUserFromLogin } = await loadModules();
+    const login = bunkerLogin();
+
+    await createUserFromLogin(login).signer.getPublicKey();
+    await createUserFromLogin(login).signer.getPublicKey();
+
+    expect(bunkerSignerFromLogin).toHaveBeenCalledTimes(1);
+  });
+
+  // useCurrentUser skips logins whose conversion throws. Deferring the
+  // connection must not defer this check with it, or an unusable login reads
+  // as valid and fails every later request instead of being dropped.
+  it('still throws for a bunker login whose client key is not an nsec', async () => {
+    const { createUserFromLogin } = await loadModules();
+    const login = bunkerLogin();
+    login.data = {
+      ...(login.data as Record<string, unknown>),
+      clientNsec: nip19.npubEncode('b'.repeat(64)),
+    } as never;
+
+    expect(() => createUserFromLogin(login)).toThrow('Invalid client key for bunker login');
+  });
+});
+
+describe('canCreateUserFromLogin', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // useLoggedInAccounts only ever used this as a validity probe and threw the
+  // user away, so it must not register a signer for a login that may never
+  // sign anything — nor, obviously, open a connection.
+  it('validates a bunker login without registering a signer for it', async () => {
+    const { canCreateUserFromLogin, registry } = await loadModules();
+
+    expect(canCreateUserFromLogin(bunkerLogin())).toBe(true);
+    expect(registry.registeredBunkerSignerCount()).toBe(0);
+    expect(bunkerSignerFromLogin).not.toHaveBeenCalled();
+  });
+
+  it('rejects a bunker login whose client key is not an nsec', async () => {
+    const { canCreateUserFromLogin } = await loadModules();
+    const login = bunkerLogin();
+    login.data = {
+      ...(login.data as Record<string, unknown>),
+      clientNsec: nip19.npubEncode('b'.repeat(64)),
+    } as never;
+
+    expect(canCreateUserFromLogin(login)).toBe(false);
+  });
+
+  it('accepts an nsec login', async () => {
+    const { canCreateUserFromLogin } = await loadModules();
+
+    expect(
+      canCreateUserFromLogin({
+        id: 'nsec:one',
+        type: 'nsec',
+        pubkey: USER_PUBKEY,
+        createdAt: new Date(0).toISOString(),
+        data: { nsec: nip19.nsecEncode(generateSecretKey()) },
+      })
+    ).toBe(true);
+  });
+
+  it('rejects an unsupported login type', async () => {
+    const { canCreateUserFromLogin } = await loadModules();
+
+    expect(
+      canCreateUserFromLogin({
+        id: 'x-other:one',
+        type: 'x-other',
+        pubkey: USER_PUBKEY,
+        createdAt: new Date(0).toISOString(),
+        data: {},
+      })
+    ).toBe(false);
+  });
+});

--- a/src/lib/nostrLogin.ts
+++ b/src/lib/nostrLogin.ts
@@ -1,7 +1,6 @@
 import type { NostrSigner } from '@nostrify/nostrify';
 import { NUser, type NLoginType } from '@nostrify/react/login';
-
-type NostrClient = Parameters<typeof NUser.fromBunkerLogin>[1];
+import { bunkerSignerFromLogin } from '@/lib/bunkerSigner';
 
 export function hasNip07Provider(): boolean {
   if (typeof window === 'undefined') return false;
@@ -22,12 +21,15 @@ export function getSafeUserSigner(
   }
 }
 
-export function createUserFromLogin(login: NLoginType, nostr: NostrClient): NUser {
+export function createUserFromLogin(login: NLoginType): NUser {
   switch (login.type) {
     case 'nsec':
       return NUser.fromNsecLogin(login);
     case 'bunker':
-      return NUser.fromBunkerLogin(login, nostr);
+      // Not NUser.fromBunkerLogin: that builds a signer which treats a NIP-46
+      // auth challenge as a fatal error, so a signer that asks for approval
+      // mid-session breaks every subsequent request (divine-web#485).
+      return new NUser('bunker', login.pubkey, bunkerSignerFromLogin(login.data));
     case 'extension': {
       if (!hasNip07Provider()) {
         throw new Error('Browser extension not available');

--- a/src/lib/nostrLogin.ts
+++ b/src/lib/nostrLogin.ts
@@ -1,6 +1,6 @@
 import type { NostrSigner } from '@nostrify/nostrify';
 import { NUser, type NLoginType } from '@nostrify/react/login';
-import { bunkerSignerFromLogin } from '@/lib/bunkerSigner';
+import { getBunkerSigner, isUsableBunkerLogin } from '@/lib/bunkerSignerRegistry';
 
 export function hasNip07Provider(): boolean {
   if (typeof window === 'undefined') return false;
@@ -21,6 +21,27 @@ export function getSafeUserSigner(
   }
 }
 
+/**
+ * Whether `createUserFromLogin` would succeed, without building anything.
+ *
+ * A caller that only needs to know a login is usable must not go through
+ * `createUserFromLogin`: for a bunker login that reaches the registry and, on
+ * the first such call, opens the connection for a login that may never sign
+ * anything.
+ */
+export function canCreateUserFromLogin(login: NLoginType): boolean {
+  try {
+    if (login.type === 'bunker') {
+      return isUsableBunkerLogin(login.data);
+    }
+
+    createUserFromLogin(login);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 export function createUserFromLogin(login: NLoginType): NUser {
   switch (login.type) {
     case 'nsec':
@@ -29,7 +50,10 @@ export function createUserFromLogin(login: NLoginType): NUser {
       // Not NUser.fromBunkerLogin: that builds a signer which treats a NIP-46
       // auth challenge as a fatal error, so a signer that asks for approval
       // mid-session breaks every subsequent request (divine-web#485).
-      return new NUser('bunker', login.pubkey, bunkerSignerFromLogin(login.data));
+      // Registry rather than a fresh signer: this runs in a `useMemo` in
+      // `useCurrentUser`, so one per call meant one socket set per mounted
+      // component, none of them ever closed (divine-web#531).
+      return new NUser('bunker', login.pubkey, getBunkerSigner(login.id, login.data));
     case 'extension': {
       if (!hasNip07Provider()) {
         throw new Error('Browser extension not available');


### PR DESCRIPTION
Split: the pagination and scroll-restoration fixes moved to #536, which also carries the four scroll commits @mbradley and @realmeylisdev pushed here. This PR is now NIP-46 only.

Closes #485.

---

## Problem

Per NIP-46 a signer may answer `{result: "auth_url", error: <url>}`, meaning "the user must approve out of band, keep listening on this request id". `@nostrify`'s `NConnectSigner` has a two-part defect:

- `cmd()` throws on any non-empty `error`, so the challenge surfaces as an error whose message is literally a URL
- `send()` resolves on the first response matching the request id and `return`s out of the `for await`, tearing down the subscription the real answer arrives on

Both the login handshake (`NLogin.fromBunker`) and the ongoing session signer (`NUser.fromBunkerLogin`) went through it, so signers that ask for approval — nsecbunkerd admin approval, nsec.app manual confirmation — could not sign in, and a mid-session challenge would break every later request.

## Fix

Move both paths onto the `nostr-tools` NIP-46 client already in the dependency tree, which keeps waiting after a challenge and exposes it via `onauth`. The challenge opens in a new tab, with the link shown as a fallback. Only `http(s)` challenge URLs are opened, since the URL comes from the remote signer.

The client key is still generated per login and persisted as `clientNsec` in the same shape, so existing bunker sessions keep their NIP-46 identity and need no re-approval.

Incidental fix worth noting (@realmeylisdev spotted it): `bunkerSignerFromLogin` targets `data.bunkerPubkey` where `NUser.fromBunkerLogin` was p-tagging `login.pubkey`. NIP-46 requires those to be distinct, so this corrects a real bug for signers whose remote-signer key isn't the user key.

## Reviewer commits, preserved

`ab8cda08` `ca4ec381` `eb1494f5` `bfd496dc` `e07260d6` — all five of @mbradley's auth fixes, original authorship intact. The pre-split head is preserved at `backup/pre-split-531`.

## Still open — see the review threads

- **Logout doesn't end the signer session.** `BunkerSigner.fromBunker` subscribes during construction on a private `SimplePool`; nothing calls `close()`, and it isn't reachable through the `NostrSigner` type `NUser` stores. New on this branch.
- **A `SimplePool` and open sockets per `useCurrentUser()` consumer.** @realmeylisdev measured 10 mounted components on one login opening 20 sockets, versus zero on `main`. Same root as the above.
- **No per-request timeout.** `NConnectSigner` had 60s; the dialog can now sit on "Connecting…" indefinitely.
- **Mid-session challenges are dropped.** `bunkerSignerFromLogin` receives no `onAuthChallenge`, so a challenge outside login produces no tab and no link — the exact failure this PR exists to fix, relocated.
- **`ca4ec381` has a residual gap.** Nothing bumps `bunkerAttemptRef` when the dialog closes, and the reset effect re-arms `isOpenRef` on open, so an abandoned approval can still commit once the dialog is reopened.
- **`eb1494f5`'s `pool.destroy()` has no test holding it.**

The first four share one design decision — how the bunker signer's lifetime is owned. That's unresolved and is what this PR is waiting on.

## Resolved by the split

Both of @realmeylisdev's commit-hygiene findings are gone with the rewrite: `tests/visual/notifications-a11y.spec.ts` (unrelated, failing, swept in by a careless `git add -A`) is dropped entirely, and the `test-results/.last-run.json` churn never appears — so `3f4f5793`, which reverted it, is no longer needed. The `ProfilePage.infiniteScroll.test.tsx` work that rode on the auth commit moved to #536 as its own commit.

`git rm --cached test-results/.last-run.json` plus a gitignore entry is still the durable fix for that file and is not done here.

## Validation

`tsc -p tsconfig.app.json --noEmit` clean, eslint 0 errors / 17 warnings, and the four auth suites pass 50/50. Full-suite numbers from CI rather than local — this machine is currently flaky under load, with `origin/main` alone failing 8 tests across 5 files.