### PR TITLE
fix(faq): state the mobile half of the private-messaging answer

### DIFF
--- a/scripts/prerender-content/faq-content.html
+++ b/scripts/prerender-content/faq-content.html
@@ -572,12 +572,16 @@
           All videos posted to Divine are public by default. If you need true privacy for video content,
           don't post it on Divine.
         </p>
-        <p style="font-weight:600;">Private support messages</p>
+        <p style="font-weight:600;">Private messages</p>
         <p>
           On Divine Web, the current private messaging channel is for contacting Divine Support.
           Messages use encrypted NIP-17 delivery, and the support team can read and
           respond to messages sent to that channel. User-to-user DMs and private video
           sharing are not available on Divine Web right now.
+        </p>
+        <p>
+          In the Divine mobile app you can also message people directly and share vines
+          privately. Those messages are end-to-end encrypted, and we cannot read them.
         </p>
       </div>
     </details>

--- a/scripts/prerender-content/faq-content.html
+++ b/scripts/prerender-content/faq-content.html
@@ -581,7 +581,7 @@
         </p>
         <p>
           In the Divine mobile app you can also message people directly and share vines
-          privately. Those messages are end-to-end encrypted, and we cannot read them.
+          privately. Those messages are end-to-end encrypted and don't reach Divine Support.
         </p>
       </div>
     </details>

--- a/src/pages/FAQPage.test.tsx
+++ b/src/pages/FAQPage.test.tsx
@@ -38,6 +38,10 @@ describe('FAQPage', () => {
       .toBeInTheDocument();
     expect(screen.getByText(/in the Divine mobile app you can also message people directly/i))
       .toBeInTheDocument();
+    // Guard the privacy sentence on the SPA surface too, not just its first clause,
+    // so it can't silently diverge from the prerendered mirror.
+    expect(screen.getByText(/those messages are end-to-end encrypted and don't reach Divine Support/i))
+      .toBeInTheDocument();
     expect(screen.queryByText(/direct messages between users/i))
       .not.toBeInTheDocument();
   });

--- a/src/pages/FAQPage.test.tsx
+++ b/src/pages/FAQPage.test.tsx
@@ -24,7 +24,7 @@ describe('FAQPage', () => {
     expect(screen.getByRole('link', { name: 'DMCA policy' })).toHaveAttribute('href', '/dmca');
   });
 
-  it('describes the current private channel as Support-only', () => {
+  it('scopes the private messaging answer to each surface', () => {
     render(
       <MemoryRouter>
         <FAQPage />
@@ -33,8 +33,10 @@ describe('FAQPage', () => {
 
     fireEvent.click(screen.getByRole('button', { name: /can i block users\?/i }));
 
-    expect(screen.getByText('Private support messages')).toBeInTheDocument();
+    expect(screen.getByText('Private messages')).toBeInTheDocument();
     expect(screen.getByText(/on Divine Web, the current private messaging channel is for contacting Divine Support/i))
+      .toBeInTheDocument();
+    expect(screen.getByText(/in the Divine mobile app you can also message people directly/i))
       .toBeInTheDocument();
     expect(screen.queryByText(/direct messages between users/i))
       .not.toBeInTheDocument();

--- a/src/pages/FAQPage.tsx
+++ b/src/pages/FAQPage.tsx
@@ -765,13 +765,17 @@ export function FAQPage() {
                     don't post it on Divine.
                   </p>
                   <p className="font-semibold">
-                    Private support messages
+                    Private messages
                   </p>
                   <p>
                     On Divine Web, the current private messaging channel is for contacting Divine Support.
                     Messages use encrypted NIP-17 delivery, and the support team can read and
                     respond to messages sent to that channel. User-to-user DMs and private video
                     sharing are not available on Divine Web right now.
+                  </p>
+                  <p>
+                    In the Divine mobile app you can also message people directly and share vines
+                    privately. Those messages are end-to-end encrypted, and we cannot read them.
                   </p>
                 </div>
               </FAQQuestion>

--- a/src/pages/FAQPage.tsx
+++ b/src/pages/FAQPage.tsx
@@ -775,7 +775,7 @@ export function FAQPage() {
                   </p>
                   <p>
                     In the Divine mobile app you can also message people directly and share vines
-                    privately. Those messages are end-to-end encrypted, and we cannot read them.
+                    privately. Those messages are end-to-end encrypted and don't reach Divine Support.
                   </p>
                 </div>
               </FAQQuestion>

--- a/tests/support-only-messaging-entry-points.test.ts
+++ b/tests/support-only-messaging-entry-points.test.ts
@@ -39,7 +39,7 @@ describe('support-only messaging entry points', () => {
       'utf8',
     ).replace(/\s+/g, ' ');
 
-    expect(source).toContain('Private support messages');
+    expect(source).toContain('Private messages');
     expect(source).toContain(
       'On Divine Web, the current private messaging channel is for contacting Divine Support.',
     );
@@ -49,6 +49,17 @@ describe('support-only messaging entry points', () => {
     expect(source).toContain(
       'User-to-user DMs and private video sharing are not available on Divine Web right now.',
     );
+    // The answer is product-wide, so scoping the web half without stating the
+    // mobile half leaves the reader to conclude support can read any Divine DM.
+    expect(source).toContain(
+      'In the Divine mobile app you can also message people directly and share vines privately.',
+    );
+    expect(source).toContain(
+      'Those messages are end-to-end encrypted, and we cannot read them.',
+    );
+    // Still barred: the pre-PR copy's *unscoped* privacy promise. An E2E claim
+    // is accurate for mobile and wrong for web, so what these guard is the
+    // absence of a surface, not the words "end-to-end encrypted".
     expect(source).not.toContain('Direct messages ARE private');
     expect(source).not.toContain('direct messages between users are end-to-end encrypted');
   });

--- a/tests/support-only-messaging-entry-points.test.ts
+++ b/tests/support-only-messaging-entry-points.test.ts
@@ -55,7 +55,7 @@ describe('support-only messaging entry points', () => {
       'In the Divine mobile app you can also message people directly and share vines privately.',
     );
     expect(source).toContain(
-      'Those messages are end-to-end encrypted, and we cannot read them.',
+      'Those messages are end-to-end encrypted and don\'t reach Divine Support.',
     );
     // Still barred: the pre-PR copy's *unscoped* privacy promise. An E2E claim
     // is accurate for mobile and wrong for web, so what these guard is the


### PR DESCRIPTION
Follow-up to #516, closing the half of that review thread that was left open.

#516 correctly stopped the privacy FAQ from promising user-to-user E2E privacy that no longer applies on web. It scoped the DM copy to Divine Web, but left it inside an answer that is product-wide: the same answer talks about "our primary app" and about blocks following you across all Nostr clients. So the reader is told the only private channel is Support and that the support team can read it, with no cue that another surface behaves differently.

The conclusion a reader draws from that is that Divine staff can read any DM they send. On mobile that is false. `divine-mobile` ships user-to-user DMs and private vine sharing (`screens/inbox/`, `new_message_sheet.dart`, `blocs/dm/message_requests/`), those messages are end-to-end encrypted, and we cannot read them. This is the privacy FAQ, so a wrong belief about who can read your messages is the expensive kind of gap, and it is one Support ends up answering a ticket at a time.

This restores the second paragraph of the split originally proposed on #516. The web paragraph is untouched, since it is accurate and I would not reword it. The heading widens from "Private support messages" to "Private messages" because the section now covers both surfaces.

On the framing rabble raised when deferring this: I don't think it is advertising mobile DM capability. The question asked is whether your messages are private, and a good share of people reading the web FAQ are also mobile users, so answering for the surface they actually message on is the answer rather than a plug. I also checked the case that would have argued against it. Mobile DMs are not headed for the same support-only restriction, so this describes something durable rather than a feature about to be removed.

## Guards

The two suites pin exact strings, so they move in the same commit. Their negative assertions stay as they were: what those bar is the pre-PR promise of user-to-user privacy with no surface attached, not the phrase "end-to-end encrypted", which is accurate once it names mobile. I added a comment saying so, since that distinction is easy to re-derive as a contradiction and drop.

Both changed content files were reverted in turn to confirm the guards actually fail. Each one goes red on its own.

## Validation

- `tsc -p tsconfig.app.json --noEmit` clean
- `eslint` 0 errors (17 warnings, all pre-existing on `main`, none in touched files)
- `vitest run` 1833 passed across 242 files
- `vite build` clean
- `scripts/prerender-legal.mjs` run against the build, and `dist/faq/index.html` carries the new paragraph. That mirror is what crawlers and link unfurls see, which is why it is maintained by hand alongside the SPA.