### PR TITLE
fix(embed): serve the widget at /embed on Fastly

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -117,9 +117,10 @@ request in the visitor's console.
 
 Note the app-shell CSP is meta-only — the shell routes carry no CSP response
 header, so `report-uri` and `report-to` are ignored and violations are never
-reported back. (The `/embed` widget is the exception: it is a separate static
-document, and the worker sets a `frame-ancestors *` response header on it —
-see [`compute-js/src/embedWidget.js`](./compute-js/src/embedWidget.js).)
+reported back. (The embed routes are the exception: they are separate static documents, and
+the worker sets a `frame-ancestors *` response header on them — the `/embed`
+widget via [`compute-js/src/embedWidget.js`](./compute-js/src/embedWidget.js),
+the `/embed/:id` oEmbed player inline in `index.js`.)
 
 ## Key Dependencies
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -115,8 +115,11 @@ request in the visitor's console.
   separately: `fastly:deploy` publishes the Wasm worker carrying `SHELL_CSP`,
   `fastly:publish` pushes `index.html` to the KV store. Run **both**.
 
-Note the CSP is meta-only — there is no CSP response header, so `report-uri`
-and `report-to` are ignored and violations are never reported back.
+Note the app-shell CSP is meta-only — the shell routes carry no CSP response
+header, so `report-uri` and `report-to` are ignored and violations are never
+reported back. (The `/embed` widget is the exception: it is a separate static
+document, and the worker sets a `frame-ancestors *` response header on it —
+see [`compute-js/src/embedWidget.js`](./compute-js/src/embedWidget.js).)
 
 ## Key Dependencies
 

--- a/compute-js/src/embedWidget.js
+++ b/compute-js/src/embedWidget.js
@@ -1,0 +1,39 @@
+// ABOUTME: Path matching, asset marker, and header policy for the /embed profile widget.
+// ABOUTME: Split out of index.js so the rules are testable without the Fastly runtime.
+
+/** The static asset the clean `/embed` URL rewrites to. */
+export const EMBED_WIDGET_ASSET = '/embed.html';
+
+/**
+ * A string that appears in the widget and cannot appear in the SPA shell.
+ *
+ * The static publisher answers a missing asset with the SPA shell at HTTP 200,
+ * so the worker has no other way to tell "served the widget" from "served the
+ * 404 page". `tests/embed-route-parity.test.ts` pins this against the real file.
+ */
+export const EMBED_WIDGET_MARKER = 'embed-viewer.js';
+
+/**
+ * True for the bare widget path only.
+ *
+ * `/embed/:id` is the oEmbed video player, handled earlier in the worker; it
+ * must never match here.
+ */
+export function isEmbedWidgetPath(pathname) {
+  return pathname === '/embed' || pathname === '/embed/';
+}
+
+/**
+ * Applies the widget's framing and caching policy, mirroring what
+ * `public/_headers` gives the Cloudflare deploy.
+ *
+ * The shell is static — the viewer script fetches live data over its own relay
+ * connections — so it is cacheable, unlike the app HTML that
+ * `applyStaticResponseHeaders` marks `no-store`.
+ */
+export function applyEmbedWidgetHeaders(headers) {
+  headers.set('Content-Security-Policy', 'frame-ancestors *');
+  headers.set('Cache-Control', 'public, max-age=1800');
+  headers.set('Surrogate-Control', 'max-age=1800');
+  return headers;
+}

--- a/compute-js/src/index.js
+++ b/compute-js/src/index.js
@@ -25,6 +25,12 @@ import {
 import { transformVideoApiResponse } from './videoMetadata.js';
 import { compactVideoForHydration, normalizeFeedResponse } from './feedHydration.js';
 import { renderEmbedPage } from './embedPage.js';
+import {
+  EMBED_WIDGET_ASSET,
+  EMBED_WIDGET_MARKER,
+  applyEmbedWidgetHeaders,
+  isEmbedWidgetPath,
+} from './embedWidget.js';
 import { renderFeedPage, renderVideoPage, renderProfilePage, renderSearchPage } from './templates/pages.js';
 
 const publisherServer = PublisherServer.fromStaticPublishRc(rc);
@@ -391,21 +397,36 @@ async function handleRequest(event) {
   // matched `/:nip19` and rendered the 404 page inside the subscriber's iframe.
   // Note this is distinct from the `/embed/:id` video player handled above;
   // that check requires the trailing slash, so the two do not collide.
-  if (url.pathname === '/embed' || url.pathname === '/embed/') {
-    const widgetUrl = new URL('/embed.html', url.origin);
+  if (isEmbedWidgetPath(url.pathname)) {
+    const widgetUrl = new URL(EMBED_WIDGET_ASSET, url.origin);
     widgetUrl.search = url.search;
-    const widgetResponse = await publisherServer.serveRequest(new Request(widgetUrl, request));
-    if (widgetResponse != null) {
-      const headers = applyStaticResponseHeaders(widgetResponse.headers, { isHtml: true });
-      // The widget is meant to be framed by third parties; public/_headers sets
-      // this for the Cloudflare deploy and it has to be set here too.
-      headers.set('Content-Security-Policy', 'frame-ancestors *');
-      // Match the caching public/_headers asks for. The shell is static — the
-      // viewer script fetches live data — so the `no-store` that
-      // applyStaticResponseHeaders applies to app HTML is wrong here.
-      headers.set('Cache-Control', 'public, max-age=1800');
-      headers.set('Surrogate-Control', 'max-age=1800');
-      return new Response(widgetResponse.body, { status: widgetResponse.status, headers });
+    const widgetHeaders = new Headers(request.headers);
+    // The publisher hands back the br/gzip KV variant whenever the client
+    // accepts one, and those bytes are not text. Ask for identity so the body
+    // can be read; the shell is 1.1KB and the edge caches it for 30 minutes.
+    widgetHeaders.delete('Accept-Encoding');
+    // Reading the body back drops the publisher's ETag, so never let it answer
+    // a 304 from validators the response no longer issues.
+    widgetHeaders.delete('If-None-Match');
+    widgetHeaders.delete('If-Modified-Since');
+    const widgetResponse = await publisherServer.serveRequest(
+      new Request(widgetUrl, { method: request.method, headers: widgetHeaders }),
+    );
+    if (widgetResponse != null && widgetResponse.status === 200) {
+      // The publisher answers a missing asset with the SPA shell at HTTP 200,
+      // so a non-null response is not proof we got the widget. Framing and
+      // caching the 404 page for half an hour is the failure this route exists
+      // to prevent, so verify the body before committing to those headers.
+      const body = await widgetResponse.text();
+      if (body.includes(EMBED_WIDGET_MARKER)) {
+        return new Response(body, {
+          status: 200,
+          headers: applyEmbedWidgetHeaders(
+            applyStaticResponseHeaders(widgetResponse.headers, { decoded: true }),
+          ),
+        });
+      }
+      console.error('Embed widget missing from published assets; falling through to SPA');
     }
   }
 

--- a/compute-js/src/index.js
+++ b/compute-js/src/index.js
@@ -397,7 +397,10 @@ async function handleRequest(event) {
   // matched `/:nip19` and rendered the 404 page inside the subscriber's iframe.
   // Note this is distinct from the `/embed/:id` video player handled above;
   // that check requires the trailing slash, so the two do not collide.
-  if (isEmbedWidgetPath(url.pathname)) {
+  // GET only: the marker check below reads the body, which a HEAD response does
+  // not carry, so intercepting HEAD would log a false alarm and fall through to
+  // the SPA anyway — exactly what the normal static path does for it.
+  if (request.method === 'GET' && isEmbedWidgetPath(url.pathname)) {
     const widgetUrl = new URL(EMBED_WIDGET_ASSET, url.origin);
     widgetUrl.search = url.search;
     const widgetHeaders = new Headers(request.headers);

--- a/compute-js/src/index.js
+++ b/compute-js/src/index.js
@@ -383,6 +383,32 @@ async function handleRequest(event) {
     }
   }
 
+  // `/embed` is the clean URL for the profile widget that lives at
+  // public/embed.html, and it is what GetEmbedPage hands users. public/_redirects
+  // declares the rewrite, but that file is a Cloudflare Pages / Netlify
+  // convention this worker never reads, so on Fastly the path fell through to
+  // the SPA shell below. `embed` is a single segment, so the client router
+  // matched `/:nip19` and rendered the 404 page inside the subscriber's iframe.
+  // Note this is distinct from the `/embed/:id` video player handled above;
+  // that check requires the trailing slash, so the two do not collide.
+  if (url.pathname === '/embed' || url.pathname === '/embed/') {
+    const widgetUrl = new URL('/embed.html', url.origin);
+    widgetUrl.search = url.search;
+    const widgetResponse = await publisherServer.serveRequest(new Request(widgetUrl, request));
+    if (widgetResponse != null) {
+      const headers = applyStaticResponseHeaders(widgetResponse.headers, { isHtml: true });
+      // The widget is meant to be framed by third parties; public/_headers sets
+      // this for the Cloudflare deploy and it has to be set here too.
+      headers.set('Content-Security-Policy', 'frame-ancestors *');
+      // Match the caching public/_headers asks for. The shell is static — the
+      // viewer script fetches live data — so the `no-store` that
+      // applyStaticResponseHeaders applies to app HTML is wrong here.
+      headers.set('Cache-Control', 'public, max-age=1800');
+      headers.set('Surrogate-Control', 'max-age=1800');
+      return new Response(widgetResponse.body, { status: widgetResponse.status, headers });
+    }
+  }
+
   // Serve static content (JS, CSS, images, etc.) with SPA fallback
   const response = await publisherServer.serveRequest(request);
   if (response != null) {

--- a/public/_headers
+++ b/public/_headers
@@ -7,6 +7,10 @@
   Content-Security-Policy: frame-ancestors *
   Cache-Control: public, max-age=1800
 
+/embed/
+  Content-Security-Policy: frame-ancestors *
+  Cache-Control: public, max-age=1800
+
 # Apple App Site Association
 /.well-known/apple-app-site-association
   Content-Type: application/json

--- a/public/_redirects
+++ b/public/_redirects
@@ -1,5 +1,6 @@
 # Embed widget — rewrite clean URL to static HTML
 /embed /embed.html 200
+/embed/ /embed.html 200
 
 # Redirect old FAQ page to WordPress subdomain
 /faq  https://about.divine.video/faqs/  301

--- a/public/embed.html
+++ b/public/embed.html
@@ -4,8 +4,10 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Divine Video Widget</title>
-    <link rel="stylesheet" href="embed-styles.css">
-    <link rel="icon" type="image/x-icon" href="favicon.ico">
+    <!-- Root-absolute: this document is also served at /embed and /embed/, where
+         relative hrefs would resolve under /embed/ and hit the oEmbed player. -->
+    <link rel="stylesheet" href="/embed-styles.css">
+    <link rel="icon" type="image/x-icon" href="/favicon.ico">
     <script>
         // Apply theme immediately to prevent flash
         var t = new URLSearchParams(window.location.search).get('theme');
@@ -29,6 +31,6 @@
         </div>
     </div>
 
-    <script src="embed-viewer.js"></script>
+    <script src="/embed-viewer.js"></script>
 </body>
 </html>

--- a/public/embed.html
+++ b/public/embed.html
@@ -7,7 +7,7 @@
     <!-- Root-absolute: this document is also served at /embed and /embed/, where
          relative hrefs would resolve under /embed/ and hit the oEmbed player. -->
     <link rel="stylesheet" href="/embed-styles.css">
-    <link rel="icon" type="image/x-icon" href="/favicon.ico">
+    <link rel="icon" type="image/png" sizes="72x72" href="/favicon.png">
     <script>
         // Apply theme immediately to prevent flash
         var t = new URLSearchParams(window.location.search).get('theme');

--- a/tests/embed-route-parity.test.ts
+++ b/tests/embed-route-parity.test.ts
@@ -62,6 +62,25 @@ describe('embed route parity', () => {
     expect(widget).toContain('<title>Divine Video Widget</title>');
   });
 
+  it('loads its own assets from the site root, not relative to the request path', () => {
+    // The same document is served at three URLs — /embed.html, /embed and
+    // /embed/ — so a relative href resolves differently depending on which one
+    // the subscriber pasted. Under /embed/ it resolves to /embed/<asset>, and
+    // every path below /embed/ belongs to the oEmbed video player, which
+    // answers 404 for anything that is not a video id. The widget would render
+    // an unstyled, scriptless "Loading..." and the 30-minute Cache-Control
+    // below would keep it that way.
+    const widget = readFileSync(`public${EMBED_WIDGET_ASSET}`, 'utf8');
+    const refs = [...widget.matchAll(/(?:href|src)="([^"]*)"/g)].map((match) => match[1]);
+    const sameOrigin = refs.filter((ref) => !/^(?:[a-z][a-z0-9+.-]*:)?\/\//i.test(ref));
+
+    expect(sameOrigin.length).toBeGreaterThan(0);
+    for (const ref of sameOrigin) {
+      expect(ref, `"${ref}" must start with / or it breaks when /embed/ serves this file`)
+        .toMatch(/^\//);
+    }
+  });
+
   it('the widget carries the marker the worker verifies it by', () => {
     // The worker cannot distinguish the widget from the SPA fallback by status
     // or content type — both are HTML at 200 — so it greps for this string. If

--- a/tests/embed-route-parity.test.ts
+++ b/tests/embed-route-parity.test.ts
@@ -1,0 +1,58 @@
+// ABOUTME: Guards that the embed URL handed to users resolves on every deploy target
+// ABOUTME: GetEmbedPage, public/_redirects, and the Fastly worker must agree on one path
+
+import { readFileSync } from 'node:fs';
+import { describe, it, expect } from 'vitest';
+
+/**
+ * The embed widget lives at `public/embed.html`, but users are given the clean
+ * `/embed` URL. Three places have to agree on that mapping, one per surface:
+ *
+ *   1. `GetEmbedPage.tsx`        — generates the iframe users paste
+ *   2. `public/_redirects`       — rewrites it on Cloudflare Pages
+ *   3. `compute-js/src/index.js` — rewrites it on Fastly (production)
+ *
+ * Only the first two existed, so the widget resolved on preview deploys and
+ * fell through to the SPA shell on production, where `embed` matched the
+ * `/:nip19` route and rendered the 404 page inside the subscriber's iframe.
+ * Nothing failed loudly: the SPA returns HTTP 200 for every path.
+ */
+const GENERATOR = readFileSync('src/pages/GetEmbedPage.tsx', 'utf8');
+const REDIRECTS = readFileSync('public/_redirects', 'utf8');
+const FASTLY_WORKER = readFileSync('compute-js/src/index.js', 'utf8');
+
+describe('embed route parity', () => {
+  it('the generator points users at the clean /embed path', () => {
+    expect(GENERATOR).toContain('https://divine.video/embed?');
+  });
+
+  it('Cloudflare rewrites /embed to the widget', () => {
+    const rule = REDIRECTS.split('\n').find(
+      (line) => /^\/embed\s/.test(line.trim()),
+    );
+    expect(rule, 'public/_redirects has no /embed rule').toBeDefined();
+    expect(rule).toContain('/embed.html');
+  });
+
+  it('the Fastly worker rewrites /embed to the widget', () => {
+    // Fastly serves production and never reads _redirects, so the rewrite has
+    // to exist here independently.
+    expect(
+      FASTLY_WORKER,
+      'compute-js must special-case the bare /embed path',
+    ).toMatch(/pathname === '\/embed'/);
+    expect(FASTLY_WORKER).toContain("new URL('/embed.html'");
+  });
+
+  it('keeps the widget framable from third-party origins on both targets', () => {
+    // A widget browsers refuse to frame is as broken as a missing route.
+    expect(REDIRECTS.includes('/embed') && FASTLY_WORKER.includes('frame-ancestors *')).toBe(true);
+    expect(readFileSync('public/_headers', 'utf8')).toContain('frame-ancestors *');
+  });
+
+  it('does not collide with the /embed/:id video player', () => {
+    // The oEmbed player matches `startsWith('/embed/')`, which requires the
+    // trailing slash. If that ever loosens, the widget rewrite would swallow it.
+    expect(FASTLY_WORKER).toContain("startsWith('/embed/')");
+  });
+});

--- a/tests/embed-route-parity.test.ts
+++ b/tests/embed-route-parity.test.ts
@@ -43,6 +43,20 @@ describe('embed route parity', () => {
     expect(rule).toContain(EMBED_WIDGET_ASSET);
   });
 
+  it('Cloudflare serves the trailing-slash form too', () => {
+    // The Fastly worker accepts '/embed/' (see the collision test below), and
+    // the widget's assets are root-absolute precisely because this document is
+    // served under /embed/ as well. Both deploy targets must describe the same
+    // surface: on Cloudflare that takes a rewrite rule and the framing/caching
+    // headers, or /embed/ renders the 404-in-an-iframe on preview deploys.
+    const rule = REDIRECTS.split('\n').find(
+      (line) => /^\/embed\/\s/.test(line.trim()),
+    );
+    expect(rule, 'public/_redirects has no /embed/ rule').toBeDefined();
+    expect(rule).toContain(EMBED_WIDGET_ASSET);
+    expect(HEADERS).toMatch(/^\/embed\/$/m);
+  });
+
   it('the Fastly worker rewrites /embed to the widget', () => {
     // Fastly serves production and never reads _redirects, so the rewrite has
     // to exist here independently. Nothing executes this worker before it is

--- a/tests/embed-route-parity.test.ts
+++ b/tests/embed-route-parity.test.ts
@@ -4,6 +4,14 @@
 import { readFileSync } from 'node:fs';
 import { describe, it, expect } from 'vitest';
 
+// @ts-expect-error - plain JS module in the Fastly compute package, no type declarations
+import {
+  EMBED_WIDGET_ASSET,
+  EMBED_WIDGET_MARKER,
+  applyEmbedWidgetHeaders,
+  isEmbedWidgetPath,
+} from '../compute-js/src/embedWidget.js';
+
 /**
  * The embed widget lives at `public/embed.html`, but users are given the clean
  * `/embed` URL. Three places have to agree on that mapping, one per surface:
@@ -19,6 +27,7 @@ import { describe, it, expect } from 'vitest';
  */
 const GENERATOR = readFileSync('src/pages/GetEmbedPage.tsx', 'utf8');
 const REDIRECTS = readFileSync('public/_redirects', 'utf8');
+const HEADERS = readFileSync('public/_headers', 'utf8');
 const FASTLY_WORKER = readFileSync('compute-js/src/index.js', 'utf8');
 
 describe('embed route parity', () => {
@@ -31,28 +40,58 @@ describe('embed route parity', () => {
       (line) => /^\/embed\s/.test(line.trim()),
     );
     expect(rule, 'public/_redirects has no /embed rule').toBeDefined();
-    expect(rule).toContain('/embed.html');
+    expect(rule).toContain(EMBED_WIDGET_ASSET);
   });
 
   it('the Fastly worker rewrites /embed to the widget', () => {
     // Fastly serves production and never reads _redirects, so the rewrite has
-    // to exist here independently.
+    // to exist here independently. Nothing executes this worker before it is
+    // deployed, so wiring is all a test can check from here.
     expect(
       FASTLY_WORKER,
-      'compute-js must special-case the bare /embed path',
-    ).toMatch(/pathname === '\/embed'/);
-    expect(FASTLY_WORKER).toContain("new URL('/embed.html'");
+      'compute-js must route the bare /embed path through isEmbedWidgetPath',
+    ).toContain('isEmbedWidgetPath(url.pathname)');
+    expect(FASTLY_WORKER).toContain("from './embedWidget.js'");
+  });
+
+  it('the rewrite target actually ships', () => {
+    // Every assertion above checks that three files agree on a path. None of
+    // them notices if the file that path points at stops existing, which
+    // silently returns production to the SPA-shell-in-an-iframe bug.
+    const widget = readFileSync(`public${EMBED_WIDGET_ASSET}`, 'utf8');
+    expect(widget).toContain('<title>Divine Video Widget</title>');
+  });
+
+  it('the widget carries the marker the worker verifies it by', () => {
+    // The worker cannot distinguish the widget from the SPA fallback by status
+    // or content type — both are HTML at 200 — so it greps for this string. If
+    // the script is ever renamed, the worker starts rejecting the real widget.
+    expect(readFileSync(`public${EMBED_WIDGET_ASSET}`, 'utf8')).toContain(EMBED_WIDGET_MARKER);
   });
 
   it('keeps the widget framable from third-party origins on both targets', () => {
     // A widget browsers refuse to frame is as broken as a missing route.
-    expect(REDIRECTS.includes('/embed') && FASTLY_WORKER.includes('frame-ancestors *')).toBe(true);
-    expect(readFileSync('public/_headers', 'utf8')).toContain('frame-ancestors *');
+    expect(HEADERS).toContain('frame-ancestors *');
+    expect(applyEmbedWidgetHeaders(new Headers()).get('Content-Security-Policy'))
+      .toBe('frame-ancestors *');
+  });
+
+  it('caches the widget shell instead of inheriting no-store from app HTML', () => {
+    // The shell is static; the viewer script fetches live data over its own
+    // relay connections. public/_headers asks for the same 30 minutes.
+    const headers = applyEmbedWidgetHeaders(new Headers({ 'Cache-Control': 'no-store' }));
+    expect(headers.get('Cache-Control')).toBe('public, max-age=1800');
+    expect(headers.get('Surrogate-Control')).toBe('max-age=1800');
+    expect(HEADERS).toContain('max-age=1800');
   });
 
   it('does not collide with the /embed/:id video player', () => {
-    // The oEmbed player matches `startsWith('/embed/')`, which requires the
-    // trailing slash. If that ever loosens, the widget rewrite would swallow it.
-    expect(FASTLY_WORKER).toContain("startsWith('/embed/')");
+    // The oEmbed player owns every path below /embed/. The widget owns the bare
+    // path and nothing else.
+    expect(isEmbedWidgetPath('/embed')).toBe(true);
+    expect(isEmbedWidgetPath('/embed/')).toBe(true);
+    expect(isEmbedWidgetPath('/embed/abc123')).toBe(false);
+    expect(isEmbedWidgetPath('/embedded')).toBe(false);
+    expect(isEmbedWidgetPath('/')).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

Every embed anyone has pasted onto their site renders the Divine 404 page inside their sidebar. This makes `/embed` resolve to the existing widget on Fastly.

## What was actually wrong

Nothing was missing from the widget. `public/embed.html`, `public/embed-viewer.js` (17KB), `public/embed-styles.css`, the `frame-ancestors *` headers, and the `/embed -> /embed.html` rewrite **all already exist** and are all correct.

The rewrite lives in `public/_redirects` — a Cloudflare Pages / Netlify convention. Production `divine.video` is served by **Fastly**, whose worker never reads that file. So:

1. `/embed` reaches the worker, misses `embed.html` in the static handler, and falls through to the SPA shell
2. `embed` is a single path segment, so the client router matches `/:nip19` before the catch-all
3. `NIP19Page` can't decode `"embed"` as bech32 and renders the 404 — wrapped in the full app layout, hence a nav bar and bottom nav inside a 350px iframe

Reproducible against production right now:

```
/embed       -> <title>Divine Web - Short-form Looping Videos on Nostr</title>   # SPA shell
/embed.html  -> <title>Divine Video Widget</title>                               # the real widget
```

**Nothing failed loudly.** The SPA returns HTTP 200 for every path, and the rewrite *does* work on Cloudflare preview deploys — so this passed review and shipped. The preview panel on `/get-embed` was not buggy; it was faithfully showing what subscribers get.

## The fix

Rewrite the bare `/embed` path to `embed.html` in the worker, before the SPA fallback.

- **No collision** with the `/embed/:id` oEmbed video player above it — that matches `startsWith('/embed/')`, which requires the trailing slash.
- **Caching set explicitly** rather than inheriting the `no-store` that `applyStaticResponseHeaders` applies to app HTML. The shell is static and the viewer fetches live data over its own relay connections, so the `max-age=1800` that `public/_headers` already specifies is the right value.
- **CSP set here too**, since `public/_headers` only covers the Cloudflare deploy.

## Guardrail

`tests/embed-route-parity.test.ts` asserts the generator, the Cloudflare rewrite, and the Fastly rewrite all agree on one path, and that the widget stays framable on both targets. The absence of this check is precisely what let a fix for one deploy target ship without the other.

Verified it fails with the worker change reverted:

```
× the Fastly worker rewrites /embed to the widget
  → compute-js must special-case the bare /embed path
```

## Validation

`npm run test` (tsc, eslint, vitest, build) exits 0. Confirmed the live widget assets serve 200 and that `embed-viewer.js` is self-contained — it reads `npub`/`theme`/`count`/`autorefresh`, exactly the params the generator emits, and talks directly to Nostr relays with no API dependency.

**Needs a Fastly deploy to take effect** — `npm run fastly:deploy && npm run fastly:publish`, since this changes the edge worker.

## Note

I first fixed this by building a React `/embed` route, before discovering the widget already existed. That's reverted; this PR contains no duplicate implementation.