### PR TITLE
fix(lists): filter private people lists from public surfaces

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -68,13 +68,13 @@ people sets use separate owner-aware detail routes: `/list/:pubkey/:listId`
 for video lists and `/people-lists/:pubkey/:listId` for people lists. Keeping
 people lists outside `/list/*` preserves compatibility with installed mobile
 apps, which claim `/list/*` for video-list deep links. Kind `30000` is not
-uniformly a people set: Divine's legacy block list is a kind `30000` event
-with `d=block`, which
+uniformly a people set: Divine reserves some d-tags for private or moderation
+lists (`block`, `mute`, `hidden`, `denylist`, and `dm-contacts`), which
 [`parsePeopleListFromEvent`](./src/lib/parsePeopleListFromEvent.ts) rejects,
 so the route builders in
-[`src/lib/eventRouting.ts`](./src/lib/eventRouting.ts) leave that one d-tag on
-the generic event route rather than sending it to a detail page that cannot
-render it.
+[`src/lib/eventRouting.ts`](./src/lib/eventRouting.ts) leave those d-tags on
+the generic event route rather than sending them to a detail page that cannot
+render them.
 
 ## Styling
 

--- a/src/hooks/usePeopleLists.test.ts
+++ b/src/hooks/usePeopleLists.test.ts
@@ -47,7 +47,8 @@ describe('people list hooks', () => {
     mockNostrQuery.mockResolvedValue([
       peopleListEvent({ created_at: 10, tags: [['d', 'friends'], ['title', 'Old']] }),
       peopleListEvent({ created_at: 20, tags: [['d', 'friends'], ['title', 'New']] }),
-      peopleListEvent({ created_at: 30, tags: [['d', 'block'], ['p', MEMBER]] }),
+      peopleListEvent({ created_at: 30, tags: [['d', 'block'], ['title', 'Blocked'], ['p', MEMBER]] }),
+      peopleListEvent({ created_at: 40, tags: [['d', 'mute'], ['title', 'Muted'], ['p', MEMBER]] }),
     ]);
     const { usePeopleLists } = await import('./usePeopleLists');
 

--- a/src/lib/eventRouting.test.ts
+++ b/src/lib/eventRouting.test.ts
@@ -63,19 +63,22 @@ describe('eventRouting', () => {
     );
   });
 
-  it('keeps legacy block list events on the generic event route', () => {
-    const event = makeEvent({
-      id: 'b'.repeat(64),
-      kind: 30000,
-      pubkey: 'a'.repeat(64),
-      tags: [['d', 'block']],
-    });
+  it.each(['block', 'mute', 'hidden', 'denylist', 'dm-contacts'])(
+    'keeps reserved people list d tag %s on the generic event route',
+    (dTag) => {
+      const event = makeEvent({
+        id: 'b'.repeat(64),
+        kind: 30000,
+        pubkey: 'a'.repeat(64),
+        tags: [['d', dTag]],
+      });
 
-    expect(buildAddressableRoute(30000, event.pubkey, 'block')).toBe(
-      buildAddressableEventPath(30000, event.pubkey, 'block'),
-    );
-    expect(buildResolvedEventRoute(event)).toBe(buildEventPath(event.id));
-  });
+      expect(buildAddressableRoute(30000, event.pubkey, dTag)).toBe(
+        buildAddressableEventPath(30000, event.pubkey, dTag),
+      );
+      expect(buildResolvedEventRoute(event)).toBe(buildEventPath(event.id));
+    },
+  );
 
   it('keeps people and video list paths distinct under one d tag', () => {
     const pubkey = 'a'.repeat(64);

--- a/src/lib/eventRouting.ts
+++ b/src/lib/eventRouting.ts
@@ -1,6 +1,6 @@
 import type { NostrEvent } from '@nostrify/nostrify';
 import { VIDEO_KINDS } from '@/types/video';
-import { BLOCK_LIST_D_TAG } from '@/lib/blocklistFilter';
+import { isReservedPeopleListDTag } from '@/lib/peopleListConstants';
 import { buildProfileLinkPath } from '@/lib/profileLinks';
 
 const LIST_EVENT_KINDS = new Set([
@@ -69,7 +69,7 @@ export function buildAddressableRoute(kind: number, pubkey: string, identifier: 
     return buildListPath(pubkey, identifier);
   }
 
-  if (kind === PEOPLE_LIST_EVENT_KIND && identifier !== BLOCK_LIST_D_TAG) {
+  if (kind === PEOPLE_LIST_EVENT_KIND && !isReservedPeopleListDTag(identifier)) {
     return buildPeopleListPath(pubkey, identifier);
   }
 
@@ -86,7 +86,7 @@ export function buildResolvedEventRoute(event: Pick<NostrEvent, 'id' | 'kind' | 
     return buildListPath(event.pubkey, dTag);
   }
 
-  if (dTag && event.kind === PEOPLE_LIST_EVENT_KIND && dTag !== BLOCK_LIST_D_TAG) {
+  if (dTag && event.kind === PEOPLE_LIST_EVENT_KIND && !isReservedPeopleListDTag(dTag)) {
     return buildPeopleListPath(event.pubkey, dTag);
   }
 

--- a/src/lib/parsePeopleListFromEvent.test.ts
+++ b/src/lib/parsePeopleListFromEvent.test.ts
@@ -51,11 +51,33 @@ describe('parsePeopleListFromEvent', () => {
     expect(parsePeopleListFromEvent(event)?.name).toBe('makers');
   });
 
+  it('accepts empty lists', () => {
+    expect(parsePeopleListFromEvent(peopleListEvent({ tags: [
+      ['d', 'makers'],
+      ['title', 'Makers'],
+    ] }))?.memberPubkeys).toEqual([]);
+  });
+
   it('rejects missing d tags, the reserved block list, and other event kinds', () => {
     expect(parsePeopleListFromEvent(peopleListEvent({ tags: [] }))).toBeNull();
-    expect(parsePeopleListFromEvent(peopleListEvent({ tags: [['d', 'block']] }))).toBeNull();
+    expect(parsePeopleListFromEvent(peopleListEvent({ tags: [
+      ['d', 'block'],
+      ['title', 'Blocked'],
+      ['p', ALICE],
+    ] }))).toBeNull();
     expect(parsePeopleListFromEvent(peopleListEvent({ kind: 30005 }))).toBeNull();
   });
+
+  it.each(['block', 'mute', 'hidden', 'denylist', 'dm-contacts'])(
+    'rejects reserved public-list d tag %s',
+    (id) => {
+      expect(parsePeopleListFromEvent(peopleListEvent({ tags: [
+        ['d', id],
+        ['title', 'Reserved'],
+        ['p', ALICE],
+      ] }))).toBeNull();
+    },
+  );
 
   it('uses the complete addressable coordinate as its key', () => {
     const list = parsePeopleListFromEvent(peopleListEvent());
@@ -73,5 +95,20 @@ describe('deduplicatePeopleLists', () => {
       'New',
       'makers',
     ]);
+  });
+
+  it('uses the lowest event id as the tie-breaker for equal timestamps', () => {
+    const higherId = peopleListEvent({
+      id: 'f'.repeat(64),
+      created_at: 20,
+      tags: [['d', 'friends'], ['title', 'Higher']],
+    });
+    const lowerId = peopleListEvent({
+      id: '0'.repeat(64),
+      created_at: 20,
+      tags: [['d', 'friends'], ['title', 'Lower']],
+    });
+
+    expect(deduplicatePeopleLists([higherId, lowerId])[0]?.name).toBe('Lower');
   });
 });

--- a/src/lib/parsePeopleListFromEvent.ts
+++ b/src/lib/parsePeopleListFromEvent.ts
@@ -1,7 +1,8 @@
 // ABOUTME: Parses public NIP-51 kind 30000 follow sets into discoverable people lists
 
 import type { NostrEvent } from '@nostrify/nostrify';
-import { BLOCK_LIST_D_TAG } from '@/lib/blocklistFilter';
+
+import { isReservedPeopleListDTag } from '@/lib/peopleListConstants';
 
 export interface PeopleList {
   id: string;
@@ -21,7 +22,7 @@ export function parsePeopleListFromEvent(event: NostrEvent): PeopleList | null {
   if (event.kind !== 30000) return null;
 
   const id = event.tags.find((tag) => tag[0] === 'd')?.[1];
-  if (!id || id === BLOCK_LIST_D_TAG) return null;
+  if (!id || isReservedPeopleListDTag(id)) return null;
 
   const memberPubkeys = Array.from(new Set(
     event.tags
@@ -43,10 +44,10 @@ export function parsePeopleListFromEvent(event: NostrEvent): PeopleList | null {
 export function deduplicatePeopleLists(events: NostrEvent[]): PeopleList[] {
   const newestByAddress = new Map<string, PeopleList>();
 
-  events
+  [...events]
+    .sort((a, b) => b.created_at - a.created_at || a.id.localeCompare(b.id))
     .map(parsePeopleListFromEvent)
     .filter((list): list is PeopleList => list !== null)
-    .sort((a, b) => b.createdAt - a.createdAt)
     .forEach((list) => {
       const address = peopleListAddress(list);
       if (!newestByAddress.has(address)) {

--- a/src/lib/peopleListConstants.ts
+++ b/src/lib/peopleListConstants.ts
@@ -1,0 +1,13 @@
+import { BLOCK_LIST_D_TAG } from '@/lib/blocklistFilter';
+
+export const RESERVED_PEOPLE_LIST_D_TAGS = [
+  BLOCK_LIST_D_TAG,
+  'denylist',
+  'dm-contacts',
+  'hidden',
+  'mute',
+] as const;
+
+export function isReservedPeopleListDTag(dTag: string): boolean {
+  return RESERVED_PEOPLE_LIST_D_TAGS.includes(dTag as typeof RESERVED_PEOPLE_LIST_D_TAGS[number]);
+}


### PR DESCRIPTION
## Summary

- Filter reserved kind 30000 people-list d-tags from public people-list surfaces: block, mute, hidden, denylist, and dm-contacts.
- Share the reserved d-tag predicate between the parser and event router so reserved lists fall back to generic event routes.
- Keep untitled and empty public people lists valid, including the existing d-tag title fallback and empty-list UI state.
- Add parser, routing, and hook coverage, including the NIP-01 lowest-event-id tie-break for equal timestamps.

> Avoid naming corporate partners, customers, or other sensitive external brands in this PR title or body. Use generic descriptors unless a maintainer explicitly approves the public reference.

## Motivation

- Prevent reserved or private people-list events from being rendered on public list surfaces while the larger list integration work remains blocked.

## Related Issue

- Refs #505

## Testing

- [x] npm run test
- [ ] Manual verification completed

## Visuals

- [ ] UI change with screenshots/video attached
- [x] No visual change
- [x] Visuals and text avoid sensitive external brand or partner names unless explicitly approved
