### PR TITLE
feat(lists): complete people list detail surfaces

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -63,10 +63,12 @@ catch-all fallback.
 The retired `/discovery/new` chronological feed redirects to
 `/discovery/hot`; Discovery does not expose or mount an all-new-video feed.
 Public profiles expose a compact mixed NIP-51 list shelf and a filterable
-`/profile/:npub/lists` gallery. Kind `30005` video sets retain their
-owner-aware `/list/:pubkey/:listId` route; kind `30000` people sets use
-`/people-lists/:pubkey/:listId`, where member context appears above a primary
-video grid assembled from the listed pubkeys.
+`/profile/:npub/lists` gallery. Kind `30005` video sets and kind `30000`
+people sets share the owner-aware `/list/:pubkey/:listId` route, which
+dispatches to the matching detail surface after resolving the list event. If
+both kinds use the same owner and `d` tag, the route preserves existing behavior
+by rendering the video-list surface. The retired `/people-lists/:pubkey/:listId`
+shape redirects to the shared route.
 
 ## Styling
 

--- a/src/AppRouter.tsx
+++ b/src/AppRouter.tsx
@@ -27,9 +27,8 @@ import VideoPage from "./pages/VideoPage";
 import { LegacyVineVideoPage } from "./pages/LegacyVineVideoPage";
 import { TagPage } from "./pages/TagPage";
 import ListsPage from "./pages/ListsPage";
-import ListDetailPage from "./pages/ListDetailPage";
+import ListRoutePage, { LegacyPeopleListRedirect } from "./pages/ListRoutePage";
 import ProfileListsPage from "./pages/ProfileListsPage";
-import PeopleListDetailPage from "./pages/PeopleListDetailPage";
 import ModerationSettingsPage from "./pages/ModerationSettingsPage";
 import LinkedAccountsSettingsPage from "./pages/LinkedAccountsSettingsPage";
 import RelaysSettingsPage from "./pages/RelaysSettingsPage";
@@ -117,8 +116,8 @@ export function AppRouter() {
       <Route path="/merch" element={<MerchPage />} />
       <Route path="/services" element={<ServicesPage />} />
       <Route path="/u/:userId" element={<UniversalUserPage />} />
-      <Route path="/list/:pubkey/:listId" element={<ListDetailPage />} />
-      <Route path="/people-lists/:pubkey/:listId" element={<PeopleListDetailPage />} />
+      <Route path="/list/:pubkey/:listId" element={<ListRoutePage />} />
+      <Route path="/people-lists/:pubkey/:listId" element={<LegacyPeopleListRedirect />} />
       <Route path="/event/:eventId" element={<EventPage />} />
       <Route path="/event/a/:kind/:pubkey/:identifier" element={<EventPage />} />
       <Route path="/:nip19" element={<NIP19Page />} />

--- a/src/components/CreatePeopleListDialog.test.tsx
+++ b/src/components/CreatePeopleListDialog.test.tsx
@@ -1,0 +1,107 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { MemoryRouter } from 'react-router-dom';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { CreatePeopleListDialog } from './CreatePeopleListDialog';
+
+const mockCreatePeopleList = vi.fn();
+const mockToast = vi.fn();
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => {
+      const translations: Record<string, string> = {
+        'createPeopleListDialog.title': 'Create People List',
+        'createPeopleListDialog.description': 'Group people together.',
+        'createPeopleListDialog.nameLabel': 'List Name *',
+        'createPeopleListDialog.namePlaceholder': 'Favorite Creators',
+        'createPeopleListDialog.descriptionLabel': 'Description',
+        'createPeopleListDialog.descriptionPlaceholder': 'People whose loops you never miss...',
+        'createPeopleListDialog.imageLabel': 'Cover Image URL',
+        'createPeopleListDialog.imagePlaceholder': 'https://example.com/image.jpg',
+        'createPeopleListDialog.nameRequired': 'Name it first.',
+        'createPeopleListDialog.reservedName': 'That name is reserved for a system list.',
+        'createPeopleListDialog.imageInvalid': 'Use a full image URL.',
+        'createPeopleListDialog.cancelButton': 'Cancel',
+        'createPeopleListDialog.createButton': 'Create List',
+        'createPeopleListDialog.creatingButton': 'Creating...',
+        'createPeopleListDialog.createdTitle': 'People list created.',
+        'createPeopleListDialog.createdDescription': 'Ready.',
+        'createPeopleListDialog.failedTitle': "Didn't make it.",
+        'createPeopleListDialog.failedDescription': 'Try again?',
+      };
+      return translations[key] ?? key;
+    },
+  }),
+}));
+
+vi.mock('@/components/ui/dialog', () => ({
+  Dialog: ({ open, children }: { open: boolean; children: ReactNode }) => open ? <div>{children}</div> : null,
+  DialogContent: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  DialogDescription: ({ children }: { children: ReactNode }) => <p>{children}</p>,
+  DialogHeader: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  DialogTitle: ({ children }: { children: ReactNode }) => <h2>{children}</h2>,
+}));
+
+vi.mock('@/hooks/usePeopleListMutations', () => ({
+  useCreatePeopleList: () => ({
+    mutateAsync: mockCreatePeopleList,
+    isPending: false,
+  }),
+}));
+
+vi.mock('@/hooks/useToast', () => ({
+  useToast: () => ({
+    toast: mockToast,
+  }),
+}));
+
+function renderDialog() {
+  return render(
+    <MemoryRouter>
+      <CreatePeopleListDialog open onOpenChange={vi.fn()} prefilledMembers={['b'.repeat(64)]} />
+    </MemoryRouter>,
+  );
+}
+
+describe('CreatePeopleListDialog', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockCreatePeopleList.mockResolvedValue({
+      id: 'favorite-creators',
+      name: 'Favorite Creators',
+      pubkey: 'a'.repeat(64),
+    });
+  });
+
+  it('blocks reserved system list names before publishing', () => {
+    renderDialog();
+
+    fireEvent.change(screen.getByLabelText('List Name *'), {
+      target: { value: 'block' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Create List' }));
+
+    expect(screen.getByRole('alert')).toHaveTextContent('That name is reserved for a system list.');
+    expect(mockCreatePeopleList).not.toHaveBeenCalled();
+  });
+
+  it('creates a people list with prefilled members', async () => {
+    renderDialog();
+
+    fireEvent.change(screen.getByLabelText('List Name *'), {
+      target: { value: 'Favorite Creators' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Create List' }));
+
+    await waitFor(() => {
+      expect(mockCreatePeopleList).toHaveBeenCalledWith({
+        name: 'Favorite Creators',
+        description: undefined,
+        image: undefined,
+        memberPubkeys: ['b'.repeat(64)],
+      });
+    });
+  });
+});

--- a/src/components/CreatePeopleListDialog.tsx
+++ b/src/components/CreatePeopleListDialog.tsx
@@ -1,0 +1,213 @@
+import { useEffect, useState } from 'react';
+import type { FormEvent } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useNavigate } from 'react-router-dom';
+import { CircleNotch, UsersThree } from '@phosphor-icons/react';
+
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Textarea } from '@/components/ui/textarea';
+import { useCreatePeopleList } from '@/hooks/usePeopleListMutations';
+import { useToast } from '@/hooks/useToast';
+import { buildListPath } from '@/lib/eventRouting';
+import { isReservedPeopleListDTag, slugifyPeopleListName } from '@/lib/peopleListConstants';
+
+interface CreatePeopleListDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  prefilledMembers?: string[];
+}
+
+function isValidOptionalUrl(url: string): boolean {
+  if (!url) return true;
+
+  try {
+    new URL(url);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function CreatePeopleListDialog({
+  open,
+  onOpenChange,
+  prefilledMembers = [],
+}: CreatePeopleListDialogProps) {
+  const { t } = useTranslation();
+  const navigate = useNavigate();
+  const { toast } = useToast();
+  const createPeopleList = useCreatePeopleList();
+
+  const [name, setName] = useState('');
+  const [description, setDescription] = useState('');
+  const [image, setImage] = useState('');
+  const [nameError, setNameError] = useState('');
+  const [imageError, setImageError] = useState('');
+
+  useEffect(() => {
+    if (!open) {
+      setName('');
+      setDescription('');
+      setImage('');
+      setNameError('');
+      setImageError('');
+    }
+  }, [open]);
+
+  const handleSubmit = async (event: FormEvent) => {
+    event.preventDefault();
+    setNameError('');
+    setImageError('');
+
+    const trimmedName = name.trim();
+    const listId = slugifyPeopleListName(trimmedName);
+
+    if (!trimmedName || !listId) {
+      setNameError(t('createPeopleListDialog.nameRequired'));
+      return;
+    }
+
+    if (isReservedPeopleListDTag(listId)) {
+      setNameError(t('createPeopleListDialog.reservedName'));
+      return;
+    }
+
+    if (!isValidOptionalUrl(image)) {
+      setImageError(t('createPeopleListDialog.imageInvalid'));
+      return;
+    }
+
+    try {
+      const list = await createPeopleList.mutateAsync({
+        name: trimmedName,
+        description: description.trim() || undefined,
+        image: image.trim() || undefined,
+        memberPubkeys: prefilledMembers,
+      });
+
+      toast({
+        title: t('createPeopleListDialog.createdTitle'),
+        description: t('createPeopleListDialog.createdDescription', { name: list.name }),
+      });
+      onOpenChange(false);
+      navigate(buildListPath(list.pubkey, list.id));
+    } catch (error) {
+      toast({
+        title: t('createPeopleListDialog.failedTitle'),
+        description: error instanceof Error ? error.message : t('createPeopleListDialog.failedDescription'),
+        variant: 'destructive',
+      });
+    }
+  };
+
+  const isCreating = createPeopleList.isPending;
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(nextOpen) => {
+        if (!isCreating) {
+          onOpenChange(nextOpen);
+        }
+      }}
+    >
+      <DialogContent className="max-h-[90vh] max-w-md overflow-y-auto">
+        <DialogHeader>
+          <DialogTitle>{t('createPeopleListDialog.title')}</DialogTitle>
+          <DialogDescription>
+            {t('createPeopleListDialog.description')}
+          </DialogDescription>
+        </DialogHeader>
+
+        <form onSubmit={handleSubmit} className="space-y-4 pr-2">
+          <div className="space-y-2">
+            <Label htmlFor="create-people-list-name">{t('createPeopleListDialog.nameLabel')}</Label>
+            <Input
+              id="create-people-list-name"
+              placeholder={t('createPeopleListDialog.namePlaceholder')}
+              value={name}
+              onChange={(event) => {
+                setName(event.target.value);
+                if (nameError) setNameError('');
+              }}
+              disabled={isCreating}
+              aria-describedby={nameError ? 'create-people-list-name-error' : undefined}
+            />
+            {nameError && (
+              <p id="create-people-list-name-error" className="text-sm text-destructive" role="alert">
+                {nameError}
+              </p>
+            )}
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="create-people-list-description">{t('createPeopleListDialog.descriptionLabel')}</Label>
+            <Textarea
+              id="create-people-list-description"
+              placeholder={t('createPeopleListDialog.descriptionPlaceholder')}
+              value={description}
+              onChange={(event) => setDescription(event.target.value)}
+              rows={3}
+              disabled={isCreating}
+            />
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="create-people-list-image">{t('createPeopleListDialog.imageLabel')}</Label>
+            <Input
+              id="create-people-list-image"
+              type="url"
+              placeholder={t('createPeopleListDialog.imagePlaceholder')}
+              value={image}
+              onChange={(event) => {
+                setImage(event.target.value);
+                if (imageError) setImageError('');
+              }}
+              disabled={isCreating}
+              aria-describedby={imageError ? 'create-people-list-image-error' : undefined}
+            />
+            {imageError && (
+              <p id="create-people-list-image-error" className="text-sm text-destructive" role="alert">
+                {imageError}
+              </p>
+            )}
+          </div>
+
+          <div className="flex gap-2 pt-4">
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => onOpenChange(false)}
+              disabled={isCreating}
+              className="flex-1"
+            >
+              {t('createPeopleListDialog.cancelButton')}
+            </Button>
+            <Button type="submit" variant="sticker" disabled={isCreating} className="flex-1">
+              {isCreating ? (
+                <>
+                  <CircleNotch className="mr-2 h-4 w-4 animate-spin" />
+                  {t('createPeopleListDialog.creatingButton')}
+                </>
+              ) : (
+                <>
+                  <UsersThree className="mr-2 h-4 w-4" />
+                  {t('createPeopleListDialog.createButton')}
+                </>
+              )}
+            </Button>
+          </div>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/DeleteListDialog.tsx
+++ b/src/components/DeleteListDialog.tsx
@@ -11,6 +11,9 @@ import {
 } from '@/components/ui/dialog';
 import { Button } from '@/components/ui/button';
 import { WarningCircle as AlertCircle, CircleNotch as Loader2 } from '@phosphor-icons/react';
+import { useTranslation } from 'react-i18next';
+
+type DeleteListKind = 'video' | 'people';
 
 interface DeleteListDialogProps {
   open: boolean;
@@ -18,6 +21,7 @@ interface DeleteListDialogProps {
   onConfirm: () => void;
   listName: string;
   isDeleting: boolean;
+  listKind?: DeleteListKind;
 }
 
 export function DeleteListDialog({
@@ -26,12 +30,16 @@ export function DeleteListDialog({
   onConfirm,
   listName,
   isDeleting,
+  listKind = 'video',
 }: DeleteListDialogProps) {
+  const { t } = useTranslation();
   const handleClose = () => {
     if (!isDeleting) {
       onClose();
     }
   };
+
+  const itemKey = listKind === 'people' ? 'people' : 'videos';
 
   return (
     <Dialog open={open} onOpenChange={handleClose}>
@@ -39,17 +47,18 @@ export function DeleteListDialog({
         <DialogHeader>
           <DialogTitle className="flex items-center gap-2">
             <AlertCircle className="h-5 w-5 text-destructive" />
-            Delete List?
+            {t('deleteListDialog.title')}
           </DialogTitle>
           <DialogDescription>
-            This will permanently delete the list "{listName}". Videos in the list will not be affected.
+            {t(`deleteListDialog.${itemKey}Description`, { name: listName })}
           </DialogDescription>
         </DialogHeader>
 
         <div className="py-4">
           <div className="bg-brand-yellow-light border border-brand-yellow rounded-lg p-3 dark:bg-brand-yellow-dark">
             <p className="text-sm text-brand-yellow-dark dark:text-brand-yellow-light">
-              <strong>Note:</strong> This action sends a deletion request to relays. Most relays will honor this request, but deletion is not guaranteed on all relays.
+              <strong>{t('deleteListDialog.noteLabel')}</strong>{' '}
+              {t('deleteListDialog.relayNote')}
             </p>
           </div>
         </div>
@@ -60,7 +69,7 @@ export function DeleteListDialog({
             onClick={handleClose}
             disabled={isDeleting}
           >
-            Cancel
+            {t('deleteListDialog.cancelButton')}
           </Button>
           <Button
             variant="destructive"
@@ -70,10 +79,10 @@ export function DeleteListDialog({
             {isDeleting ? (
               <>
                 <Loader2 className="h-4 w-4 mr-2 animate-spin" />
-                Deleting...
+                {t('deleteListDialog.deletingButton')}
               </>
             ) : (
-              'Delete List'
+              t('deleteListDialog.deleteButton')
             )}
           </Button>
         </DialogFooter>

--- a/src/components/EditPeopleListDialog.test.tsx
+++ b/src/components/EditPeopleListDialog.test.tsx
@@ -1,0 +1,133 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { EditPeopleListDialog } from './EditPeopleListDialog';
+
+const mockUpdatePeopleList = vi.fn();
+const mockToast = vi.fn();
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => {
+      const translations: Record<string, string> = {
+        'editPeopleListDialog.title': 'Edit People List',
+        'editPeopleListDialog.description': 'Update this list.',
+        'editPeopleListDialog.nameLabel': 'List Name *',
+        'editPeopleListDialog.namePlaceholder': 'Favorite Creators',
+        'editPeopleListDialog.descriptionLabel': 'Description',
+        'editPeopleListDialog.descriptionPlaceholder': 'People whose loops you never miss...',
+        'editPeopleListDialog.imageLabel': 'Cover Image URL',
+        'editPeopleListDialog.imagePlaceholder': 'https://example.com/image.jpg',
+        'editPeopleListDialog.nameRequired': 'Name it first.',
+        'editPeopleListDialog.imageInvalid': 'Use a full image URL.',
+        'editPeopleListDialog.cancelButton': 'Cancel',
+        'editPeopleListDialog.saveButton': 'Save',
+        'editPeopleListDialog.savingButton': 'Saving...',
+        'editPeopleListDialog.savedTitle': 'Saved.',
+        'editPeopleListDialog.savedDescription': 'Updated.',
+        'editPeopleListDialog.failedTitle': "Didn't save.",
+        'editPeopleListDialog.failedDescription': 'Try again?',
+      };
+      return translations[key] ?? key;
+    },
+  }),
+}));
+
+vi.mock('@/components/ui/dialog', () => ({
+  Dialog: ({ open, children }: { open: boolean; children: ReactNode }) => open ? <div>{children}</div> : null,
+  DialogContent: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  DialogDescription: ({ children }: { children: ReactNode }) => <p>{children}</p>,
+  DialogHeader: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  DialogTitle: ({ children }: { children: ReactNode }) => <h2>{children}</h2>,
+}));
+
+vi.mock('@/hooks/usePeopleListMutations', () => ({
+  useUpdatePeopleList: () => ({
+    mutateAsync: mockUpdatePeopleList,
+    isPending: false,
+  }),
+}));
+
+vi.mock('@/hooks/useToast', () => ({
+  useToast: () => ({
+    toast: mockToast,
+  }),
+}));
+
+const OWNER = 'a'.repeat(64);
+
+describe('EditPeopleListDialog', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUpdatePeopleList.mockResolvedValue(undefined);
+  });
+
+  it('does not reset local edits when the same list refetches while open', () => {
+    const { rerender } = render(
+      <EditPeopleListDialog
+        open
+        onOpenChange={vi.fn()}
+        list={{
+          id: 'friends',
+          name: 'Friends',
+          description: 'Original',
+          pubkey: OWNER,
+          createdAt: 1,
+          memberPubkeys: [],
+        }}
+      />,
+    );
+
+    fireEvent.change(screen.getByLabelText('List Name *'), {
+      target: { value: 'Typed name' },
+    });
+
+    rerender(
+      <EditPeopleListDialog
+        open
+        onOpenChange={vi.fn()}
+        list={{
+          id: 'friends',
+          name: 'Refetched name',
+          description: 'Changed remotely',
+          pubkey: OWNER,
+          createdAt: 2,
+          memberPubkeys: [],
+        }}
+      />,
+    );
+
+    expect(screen.getByLabelText('List Name *')).toHaveValue('Typed name');
+  });
+
+  it('submits metadata updates with the owner pubkey and list id', async () => {
+    render(
+      <EditPeopleListDialog
+        open
+        onOpenChange={vi.fn()}
+        list={{
+          id: 'friends',
+          name: 'Friends',
+          description: 'Original',
+          pubkey: OWNER,
+          createdAt: 1,
+          memberPubkeys: [],
+        }}
+      />,
+    );
+
+    fireEvent.change(screen.getByLabelText('List Name *'), {
+      target: { value: 'Best People' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+    expect(mockUpdatePeopleList).toHaveBeenCalledWith({
+      ownerPubkey: OWNER,
+      listId: 'friends',
+      name: 'Best People',
+      description: 'Original',
+      image: undefined,
+    });
+  });
+});

--- a/src/components/EditPeopleListDialog.tsx
+++ b/src/components/EditPeopleListDialog.tsx
@@ -1,0 +1,213 @@
+import { useEffect, useState } from 'react';
+import type { FormEvent } from 'react';
+import { useTranslation } from 'react-i18next';
+import { CircleNotch, FloppyDisk } from '@phosphor-icons/react';
+
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Textarea } from '@/components/ui/textarea';
+import { useUpdatePeopleList } from '@/hooks/usePeopleListMutations';
+import { useToast } from '@/hooks/useToast';
+import type { PeopleList } from '@/lib/parsePeopleListFromEvent';
+
+interface EditPeopleListDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  list: PeopleList;
+}
+
+function isValidOptionalUrl(url: string): boolean {
+  if (!url) return true;
+
+  try {
+    new URL(url);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function EditPeopleListDialog({
+  open,
+  onOpenChange,
+  list,
+}: EditPeopleListDialogProps) {
+  const { t } = useTranslation();
+  const { toast } = useToast();
+  const updatePeopleList = useUpdatePeopleList();
+
+  const listKey = `${list.pubkey}:${list.id}`;
+  const [initializedListKey, setInitializedListKey] = useState<string | null>(null);
+  const [name, setName] = useState(list.name);
+  const [description, setDescription] = useState(list.description ?? '');
+  const [image, setImage] = useState(list.image ?? '');
+  const [nameError, setNameError] = useState('');
+  const [imageError, setImageError] = useState('');
+
+  useEffect(() => {
+    if (!open) {
+      setInitializedListKey(null);
+      return;
+    }
+
+    if (initializedListKey === listKey) {
+      return;
+    }
+
+    setName(list.name);
+    setDescription(list.description ?? '');
+    setImage(list.image ?? '');
+    setNameError('');
+    setImageError('');
+    setInitializedListKey(listKey);
+  }, [initializedListKey, list.description, list.image, list.name, listKey, open]);
+
+  const handleSubmit = async (event: FormEvent) => {
+    event.preventDefault();
+    setNameError('');
+    setImageError('');
+
+    const trimmedName = name.trim();
+    if (!trimmedName) {
+      setNameError(t('editPeopleListDialog.nameRequired'));
+      return;
+    }
+
+    if (!isValidOptionalUrl(image)) {
+      setImageError(t('editPeopleListDialog.imageInvalid'));
+      return;
+    }
+
+    try {
+      await updatePeopleList.mutateAsync({
+        ownerPubkey: list.pubkey,
+        listId: list.id,
+        name: trimmedName,
+        description: description.trim() || undefined,
+        image: image.trim() || undefined,
+      });
+
+      toast({
+        title: t('editPeopleListDialog.savedTitle'),
+        description: t('editPeopleListDialog.savedDescription', { name: trimmedName }),
+      });
+      onOpenChange(false);
+    } catch (error) {
+      toast({
+        title: t('editPeopleListDialog.failedTitle'),
+        description: error instanceof Error ? error.message : t('editPeopleListDialog.failedDescription'),
+        variant: 'destructive',
+      });
+    }
+  };
+
+  const isSaving = updatePeopleList.isPending;
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(nextOpen) => {
+        if (!isSaving) {
+          onOpenChange(nextOpen);
+        }
+      }}
+    >
+      <DialogContent className="max-h-[90vh] max-w-md overflow-y-auto">
+        <DialogHeader>
+          <DialogTitle>{t('editPeopleListDialog.title')}</DialogTitle>
+          <DialogDescription>
+            {t('editPeopleListDialog.description')}
+          </DialogDescription>
+        </DialogHeader>
+
+        <form onSubmit={handleSubmit} className="space-y-4 pr-2">
+          <div className="space-y-2">
+            <Label htmlFor="edit-people-list-name">{t('editPeopleListDialog.nameLabel')}</Label>
+            <Input
+              id="edit-people-list-name"
+              placeholder={t('editPeopleListDialog.namePlaceholder')}
+              value={name}
+              onChange={(event) => {
+                setName(event.target.value);
+                if (nameError) setNameError('');
+              }}
+              disabled={isSaving}
+              aria-describedby={nameError ? 'edit-people-list-name-error' : undefined}
+            />
+            {nameError && (
+              <p id="edit-people-list-name-error" className="text-sm text-destructive" role="alert">
+                {nameError}
+              </p>
+            )}
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="edit-people-list-description">{t('editPeopleListDialog.descriptionLabel')}</Label>
+            <Textarea
+              id="edit-people-list-description"
+              placeholder={t('editPeopleListDialog.descriptionPlaceholder')}
+              value={description}
+              onChange={(event) => setDescription(event.target.value)}
+              rows={3}
+              disabled={isSaving}
+            />
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="edit-people-list-image">{t('editPeopleListDialog.imageLabel')}</Label>
+            <Input
+              id="edit-people-list-image"
+              type="url"
+              placeholder={t('editPeopleListDialog.imagePlaceholder')}
+              value={image}
+              onChange={(event) => {
+                setImage(event.target.value);
+                if (imageError) setImageError('');
+              }}
+              disabled={isSaving}
+              aria-describedby={imageError ? 'edit-people-list-image-error' : undefined}
+            />
+            {imageError && (
+              <p id="edit-people-list-image-error" className="text-sm text-destructive" role="alert">
+                {imageError}
+              </p>
+            )}
+          </div>
+
+          <div className="flex gap-2 pt-4">
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => onOpenChange(false)}
+              disabled={isSaving}
+              className="flex-1"
+            >
+              {t('editPeopleListDialog.cancelButton')}
+            </Button>
+            <Button type="submit" variant="sticker" disabled={isSaving} className="flex-1">
+              {isSaving ? (
+                <>
+                  <CircleNotch className="mr-2 h-4 w-4 animate-spin" />
+                  {t('editPeopleListDialog.savingButton')}
+                </>
+              ) : (
+                <>
+                  <FloppyDisk className="mr-2 h-4 w-4" />
+                  {t('editPeopleListDialog.saveButton')}
+                </>
+              )}
+            </Button>
+          </div>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/ProfileListCard.test.tsx
+++ b/src/components/ProfileListCard.test.tsx
@@ -4,6 +4,7 @@ import { render, screen } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import { describe, expect, it } from 'vitest';
 import type { DiscoverableList } from '@/lib/profileLists';
+import { buildListPath } from '@/lib/eventRouting';
 import { ProfileListCard } from './ProfileListCard';
 
 const OWNER = 'a'.repeat(64);
@@ -18,9 +19,7 @@ function renderCard(type: DiscoverableList['type']) {
     ownerPubkey: OWNER,
     createdAt: 10,
     itemCount: type === 'people' ? 2 : 3,
-    href: type === 'people'
-      ? `/people-lists/${OWNER}/friends`
-      : `/list/${OWNER}/friends`,
+    href: buildListPath(OWNER, 'friends'),
   };
 
   render(<ProfileListCard list={list} />, { wrapper: MemoryRouter });
@@ -33,7 +32,7 @@ describe('ProfileListCard', () => {
     expect(screen.getByText('2 people')).toBeInTheDocument();
     expect(screen.getByRole('link', { name: /Friends/ })).toHaveAttribute(
       'href',
-      `/people-lists/${OWNER}/friends`,
+      buildListPath(OWNER, 'friends'),
     );
   });
 
@@ -43,7 +42,7 @@ describe('ProfileListCard', () => {
     expect(screen.getByText('3 videos')).toBeInTheDocument();
     expect(screen.getByRole('link', { name: /Favorites/ })).toHaveAttribute(
       'href',
-      `/list/${OWNER}/friends`,
+      buildListPath(OWNER, 'friends'),
     );
   });
 });

--- a/src/hooks/useListRouteKind.test.ts
+++ b/src/hooks/useListRouteKind.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest';
+
+import { resolveListRouteKind } from './useListRouteKind';
+
+describe('resolveListRouteKind', () => {
+  it('prefers video lists when both list kinds share a d tag', () => {
+    expect(resolveListRouteKind([{ kind: 30000 }, { kind: 30005 }])).toBe('videos');
+  });
+
+  it('routes people lists when no video list is present', () => {
+    expect(resolveListRouteKind([{ kind: 30000 }])).toBe('people');
+  });
+
+  it('returns missing when neither detail kind is present', () => {
+    expect(resolveListRouteKind([{ kind: 30001 }, { kind: 1 }])).toBe('missing');
+  });
+});

--- a/src/hooks/useListRouteKind.ts
+++ b/src/hooks/useListRouteKind.ts
@@ -1,0 +1,51 @@
+import type { NostrEvent } from '@nostrify/nostrify';
+import { useNostr } from '@nostrify/react';
+import { useQuery } from '@tanstack/react-query';
+
+import { getEventLookupRelayUrls } from '@/config/relays';
+import { useAppContext } from '@/hooks/useAppContext';
+import { PEOPLE_LIST_KIND } from '@/lib/peopleListConstants';
+
+export type ListRouteKind = 'videos' | 'people' | 'missing';
+
+const VIDEO_LIST_KIND = 30005;
+const LIST_ROUTE_KINDS = [VIDEO_LIST_KIND, PEOPLE_LIST_KIND];
+
+export function resolveListRouteKind(events: Array<Pick<NostrEvent, 'kind'>>): ListRouteKind {
+  if (events.some(event => event.kind === VIDEO_LIST_KIND)) {
+    return 'videos';
+  }
+
+  if (events.some(event => event.kind === PEOPLE_LIST_KIND)) {
+    return 'people';
+  }
+
+  return 'missing';
+}
+
+export function useListRouteKind(pubkey: string | undefined, listId: string | undefined) {
+  const { nostr } = useNostr();
+  const { config } = useAppContext();
+  const configuredRelayUrls = config.relayUrls || [config.relayUrl];
+  const relayKey = configuredRelayUrls.join(',');
+
+  return useQuery({
+    queryKey: ['list-route-kind', pubkey, listId, relayKey],
+    queryFn: async ({ signal }) => {
+      const events = await nostr.query([{
+        kinds: LIST_ROUTE_KINDS,
+        authors: [pubkey!],
+        '#d': [listId!],
+        limit: 10,
+      }], {
+        signal: AbortSignal.any([signal, AbortSignal.timeout(5000)]),
+        relays: getEventLookupRelayUrls({ configuredRelayUrls }),
+      });
+
+      return resolveListRouteKind(events);
+    },
+    enabled: Boolean(pubkey && listId),
+    staleTime: 60_000,
+    gcTime: 300_000,
+  });
+}

--- a/src/hooks/usePeopleListMutations.test.ts
+++ b/src/hooks/usePeopleListMutations.test.ts
@@ -1,0 +1,257 @@
+import type { NostrEvent } from '@nostrify/nostrify';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import React from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { PeopleList } from '@/lib/parsePeopleListFromEvent';
+
+const mocks = vi.hoisted(() => ({
+  nostrQuery: vi.fn(),
+  publishEvent: vi.fn(),
+  useCurrentUser: vi.fn(),
+}));
+
+vi.mock('@nostrify/react', () => ({
+  useNostr: () => ({
+    nostr: {
+      query: mocks.nostrQuery,
+    },
+  }),
+}));
+
+vi.mock('@/hooks/useNostrPublish', () => ({
+  useNostrPublish: () => ({
+    mutateAsync: mocks.publishEvent,
+  }),
+}));
+
+vi.mock('@/hooks/useCurrentUser', () => ({
+  useCurrentUser: () => mocks.useCurrentUser(),
+}));
+
+const OWNER = 'a'.repeat(64);
+const ALICE = 'b'.repeat(64);
+const BOB = 'c'.repeat(64);
+const PRIVATE_CONTENT = 'encrypted-private-members';
+
+function createWrapper(queryClient?: QueryClient) {
+  const client =
+    queryClient ??
+    new QueryClient({
+      defaultOptions: {
+        queries: { retry: false },
+        mutations: { retry: false },
+      },
+    });
+
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return React.createElement(QueryClientProvider, { client }, children);
+  };
+}
+
+function peopleListEvent(overrides: Partial<NostrEvent> = {}): NostrEvent {
+  return {
+    id: '1'.repeat(64),
+    pubkey: OWNER,
+    kind: 30000,
+    created_at: 2000,
+    tags: [
+      ['d', 'friends'],
+      ['title', 'Friends'],
+      ['description', 'Good people'],
+      ['p', ALICE],
+    ],
+    content: PRIVATE_CONTENT,
+    sig: 's'.repeat(128),
+    ...overrides,
+  };
+}
+
+function cachedList(overrides: Partial<PeopleList> = {}): PeopleList {
+  return {
+    id: 'friends',
+    name: 'Friends',
+    description: 'Good people',
+    pubkey: OWNER,
+    createdAt: 2000,
+    memberPubkeys: [ALICE],
+    ...overrides,
+  };
+}
+
+describe('usePeopleListMutations', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.useCurrentUser.mockReturnValue({ user: { pubkey: OWNER } });
+    mocks.nostrQuery.mockResolvedValue([peopleListEvent()]);
+    mocks.publishEvent.mockResolvedValue({
+      id: '2'.repeat(64),
+      pubkey: OWNER,
+      kind: 30000,
+      created_at: 3000,
+      tags: [],
+      content: '',
+      sig: 's'.repeat(128),
+    });
+  });
+
+  it('creates a kind 30000 people list with a slug d-tag and p tags', async () => {
+    const { useCreatePeopleList } = await import('./usePeopleListMutations');
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+    const { result } = renderHook(() => useCreatePeopleList(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await result.current.mutateAsync({
+      name: 'Cool People!',
+      description: 'Good loops',
+      memberPubkeys: [ALICE, ALICE, BOB],
+    });
+
+    expect(mocks.publishEvent).toHaveBeenCalledWith({
+      kind: 30000,
+      content: '',
+      tags: [
+        ['d', 'cool-people'],
+        ['title', 'Cool People!'],
+        ['description', 'Good loops'],
+        ['p', ALICE],
+        ['p', BOB],
+      ],
+    });
+    expect(queryClient.getQueryData<PeopleList[]>(['people-lists', OWNER])?.[0]).toMatchObject({
+      id: 'cool-people',
+      memberPubkeys: [ALICE, BOB],
+    });
+  });
+
+  it('preserves event content when updating people-list metadata', async () => {
+    const { useUpdatePeopleList } = await import('./usePeopleListMutations');
+    const { result } = renderHook(() => useUpdatePeopleList(), {
+      wrapper: createWrapper(),
+    });
+
+    await result.current.mutateAsync({
+      ownerPubkey: OWNER,
+      listId: 'friends',
+      name: 'Best people',
+      description: '',
+      image: 'https://cdn.example.com/list.jpg',
+    });
+
+    expect(mocks.publishEvent).toHaveBeenCalledWith({
+      kind: 30000,
+      content: PRIVATE_CONTENT,
+      tags: [
+        ['d', 'friends'],
+        ['title', 'Best people'],
+        ['image', 'https://cdn.example.com/list.jpg'],
+        ['p', ALICE],
+      ],
+    });
+  });
+
+  it('preserves event content when adding and removing people', async () => {
+    const { useAddPersonToPeopleList, useRemovePersonFromPeopleList } = await import('./usePeopleListMutations');
+    const { result: addResult } = renderHook(() => useAddPersonToPeopleList(), {
+      wrapper: createWrapper(),
+    });
+    await addResult.current.mutateAsync({
+      ownerPubkey: OWNER,
+      listId: 'friends',
+      memberPubkey: BOB,
+    });
+
+    expect(mocks.publishEvent).toHaveBeenLastCalledWith({
+      kind: 30000,
+      content: PRIVATE_CONTENT,
+      tags: [
+        ['d', 'friends'],
+        ['title', 'Friends'],
+        ['description', 'Good people'],
+        ['p', ALICE],
+        ['p', BOB],
+      ],
+    });
+
+    mocks.nostrQuery.mockResolvedValueOnce([
+      peopleListEvent({
+        tags: [
+          ['d', 'friends'],
+          ['title', 'Friends'],
+          ['p', ALICE],
+          ['p', BOB],
+        ],
+      }),
+    ]);
+    const { result: removeResult } = renderHook(() => useRemovePersonFromPeopleList(), {
+      wrapper: createWrapper(),
+    });
+    await removeResult.current.mutateAsync({
+      ownerPubkey: OWNER,
+      listId: 'friends',
+      memberPubkey: ALICE,
+    });
+
+    expect(mocks.publishEvent).toHaveBeenLastCalledWith({
+      kind: 30000,
+      content: PRIVATE_CONTENT,
+      tags: [
+        ['d', 'friends'],
+        ['title', 'Friends'],
+        ['p', BOB],
+      ],
+    });
+  });
+
+  it('rolls back optimistic people-list member updates when publish fails', async () => {
+    const { useAddPersonToPeopleList } = await import('./usePeopleListMutations');
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+    queryClient.setQueryData(['people-list', OWNER, 'friends'], cachedList());
+    queryClient.setQueryData(['people-lists', OWNER], [cachedList()]);
+    mocks.publishEvent.mockRejectedValueOnce(new Error('relay refused'));
+
+    const { result } = renderHook(() => useAddPersonToPeopleList(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await expect(result.current.mutateAsync({
+      ownerPubkey: OWNER,
+      listId: 'friends',
+      memberPubkey: BOB,
+    })).rejects.toThrow('relay refused');
+
+    await waitFor(() => {
+      expect(queryClient.getQueryData<PeopleList>(['people-list', OWNER, 'friends'])?.memberPubkeys).toEqual([ALICE]);
+      expect(queryClient.getQueryData<PeopleList[]>(['people-lists', OWNER])?.[0].memberPubkeys).toEqual([ALICE]);
+    });
+  });
+
+  it('publishes deletion events with address and kind tags and enforces owner', async () => {
+    const { useDeletePeopleList } = await import('./usePeopleListMutations');
+    const { result } = renderHook(() => useDeletePeopleList(), {
+      wrapper: createWrapper(),
+    });
+
+    await result.current.mutateAsync({ ownerPubkey: OWNER, listId: 'friends' });
+
+    expect(mocks.publishEvent).toHaveBeenCalledWith({
+      kind: 5,
+      content: 'People list deleted by owner',
+      tags: [
+        ['a', `30000:${OWNER}:friends`],
+        ['k', '30000'],
+      ],
+    });
+
+    await expect(result.current.mutateAsync({
+      ownerPubkey: BOB,
+      listId: 'friends',
+    })).rejects.toThrow('Only the list owner can update this people list');
+  });
+});

--- a/src/hooks/usePeopleListMutations.ts
+++ b/src/hooks/usePeopleListMutations.ts
@@ -1,0 +1,426 @@
+import type { NostrEvent } from '@nostrify/nostrify';
+import { useNostr } from '@nostrify/react';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { useCurrentUser } from '@/hooks/useCurrentUser';
+import { useNostrPublish } from '@/hooks/useNostrPublish';
+import { type PeopleList, parsePeopleListFromEvent } from '@/lib/parsePeopleListFromEvent';
+import {
+  isReservedPeopleListDTag,
+  PEOPLE_LIST_KIND,
+  slugifyPeopleListName,
+} from '@/lib/peopleListConstants';
+
+interface PeopleListMutationInput {
+  listId: string;
+  ownerPubkey: string;
+}
+
+interface PeopleListMemberMutationInput extends PeopleListMutationInput {
+  memberPubkey: string;
+}
+
+interface CreatePeopleListInput {
+  name: string;
+  description?: string;
+  image?: string;
+  memberPubkeys?: string[];
+}
+
+interface UpdatePeopleListInput extends PeopleListMutationInput {
+  name: string;
+  description?: string;
+  image?: string;
+}
+
+interface PeopleListMutationSnapshot {
+  list?: PeopleList | null;
+  lists?: PeopleList[];
+}
+
+type NostrQueryClient = {
+  query: (filters: unknown[], options: unknown) => Promise<NostrEvent[]>;
+};
+
+function assertOwner(userPubkey: string | undefined, ownerPubkey: string) {
+  if (!userPubkey) {
+    throw new Error('Must be logged in to update people lists');
+  }
+
+  if (userPubkey !== ownerPubkey) {
+    throw new Error('Only the list owner can update this people list');
+  }
+}
+
+function uniquePubkeys(pubkeys: string[]): string[] {
+  return Array.from(new Set(pubkeys.filter(Boolean)));
+}
+
+function peopleListsKey(ownerPubkey: string) {
+  return ['people-lists', ownerPubkey] as const;
+}
+
+function peopleListKey(ownerPubkey: string, listId: string) {
+  return ['people-list', ownerPubkey, listId] as const;
+}
+
+async function fetchCurrentPeopleListEvent(
+  nostr: NostrQueryClient,
+  ownerPubkey: string,
+  listId: string,
+): Promise<{ event: NostrEvent; list: PeopleList }> {
+  const events = await nostr.query(
+    [{
+      kinds: [PEOPLE_LIST_KIND],
+      authors: [ownerPubkey],
+      '#d': [listId],
+      limit: 10,
+    }],
+    { signal: AbortSignal.timeout(5000) },
+  );
+
+  const event = [...events].sort((a, b) => b.created_at - a.created_at)[0];
+  if (!event) {
+    throw new Error('People list not found');
+  }
+
+  const list = parsePeopleListFromEvent(event);
+  if (!list) {
+    throw new Error('People list is not editable');
+  }
+
+  return { event, list };
+}
+
+function buildPeopleListTags({
+  listId,
+  name,
+  description,
+  image,
+  memberPubkeys,
+}: {
+  listId: string;
+  name: string;
+  description?: string;
+  image?: string;
+  memberPubkeys: string[];
+}): string[][] {
+  const tags: string[][] = [
+    ['d', listId],
+    ['title', name],
+  ];
+
+  if (description) {
+    tags.push(['description', description]);
+  }
+
+  if (image) {
+    tags.push(['image', image]);
+  }
+
+  for (const pubkey of uniquePubkeys(memberPubkeys)) {
+    tags.push(['p', pubkey]);
+  }
+
+  return tags;
+}
+
+function replacePeopleListMetadataTags(
+  originalTags: string[][],
+  input: UpdatePeopleListInput,
+  currentList: PeopleList,
+): string[][] {
+  const preservedTags = originalTags.filter(([name]) => (
+    name !== 'd' && name !== 'title' && name !== 'description' && name !== 'image'
+  ));
+
+  return [
+    ...buildPeopleListTags({
+      listId: input.listId,
+      name: input.name,
+      description: input.description,
+      image: input.image,
+      memberPubkeys: currentList.memberPubkeys,
+    }).filter(([name]) => name !== 'p'),
+    ...preservedTags,
+  ];
+}
+
+function replacePeopleListMemberTags(originalTags: string[][], memberPubkeys: string[]): string[][] {
+  return [
+    ...originalTags.filter(([name]) => name !== 'p'),
+    ...uniquePubkeys(memberPubkeys).map((pubkey) => ['p', pubkey]),
+  ];
+}
+
+export function useCreatePeopleList() {
+  const { mutateAsync: publishEvent } = useNostrPublish();
+  const queryClient = useQueryClient();
+  const { user } = useCurrentUser();
+
+  return useMutation({
+    mutationFn: async ({
+      name,
+      description,
+      image,
+      memberPubkeys = [],
+    }: CreatePeopleListInput): Promise<PeopleList> => {
+      if (!user) {
+        throw new Error('Must be logged in to create people lists');
+      }
+
+      const listId = slugifyPeopleListName(name);
+      if (!listId) {
+        throw new Error('People list needs a name');
+      }
+
+      if (isReservedPeopleListDTag(listId)) {
+        throw new Error('That list name is reserved');
+      }
+
+      const members = uniquePubkeys(memberPubkeys);
+      const event = await publishEvent({
+        kind: PEOPLE_LIST_KIND,
+        content: '',
+        tags: buildPeopleListTags({
+          listId,
+          name,
+          description,
+          image,
+          memberPubkeys: members,
+        }),
+      });
+
+      return {
+        id: listId,
+        name,
+        description,
+        image,
+        pubkey: user.pubkey,
+        createdAt: event.created_at,
+        memberPubkeys: members,
+      };
+    },
+    onSuccess: (newList) => {
+      queryClient.setQueryData<PeopleList[]>(
+        peopleListsKey(newList.pubkey),
+        (oldLists) => [newList, ...(oldLists ?? []).filter((list) => list.id !== newList.id)],
+      );
+      queryClient.setQueryData(peopleListKey(newList.pubkey, newList.id), newList);
+      queryClient.invalidateQueries({ queryKey: ['people-lists', newList.pubkey] });
+    },
+  });
+}
+
+export function useUpdatePeopleList() {
+  const { nostr } = useNostr();
+  const { mutateAsync: publishEvent } = useNostrPublish();
+  const queryClient = useQueryClient();
+  const { user } = useCurrentUser();
+
+  return useMutation({
+    mutationFn: async (input: UpdatePeopleListInput) => {
+      assertOwner(user?.pubkey, input.ownerPubkey);
+      const { event, list } = await fetchCurrentPeopleListEvent(nostr, input.ownerPubkey, input.listId);
+
+      await publishEvent({
+        kind: PEOPLE_LIST_KIND,
+        content: event.content,
+        tags: replacePeopleListMetadataTags(event.tags, input, list),
+      });
+    },
+    onMutate: async (input): Promise<PeopleListMutationSnapshot> => {
+      await Promise.all([
+        queryClient.cancelQueries({ queryKey: peopleListKey(input.ownerPubkey, input.listId) }),
+        queryClient.cancelQueries({ queryKey: peopleListsKey(input.ownerPubkey) }),
+      ]);
+
+      const snapshot = {
+        list: queryClient.getQueryData<PeopleList | null>(peopleListKey(input.ownerPubkey, input.listId)),
+        lists: queryClient.getQueryData<PeopleList[]>(peopleListsKey(input.ownerPubkey)),
+      };
+
+      const updateList = (list: PeopleList): PeopleList => ({
+        ...list,
+        name: input.name,
+        description: input.description || undefined,
+        image: input.image || undefined,
+      });
+
+      queryClient.setQueryData<PeopleList | null>(
+        peopleListKey(input.ownerPubkey, input.listId),
+        (oldList) => oldList ? updateList(oldList) : oldList,
+      );
+      queryClient.setQueryData<PeopleList[]>(
+        peopleListsKey(input.ownerPubkey),
+        (oldLists) => oldLists?.map((list) => list.id === input.listId ? updateList(list) : list),
+      );
+
+      return snapshot;
+    },
+    onError: (_error, input, snapshot) => {
+      queryClient.setQueryData(peopleListKey(input.ownerPubkey, input.listId), snapshot?.list);
+      queryClient.setQueryData(peopleListsKey(input.ownerPubkey), snapshot?.lists);
+    },
+    onSettled: (_data, _error, input) => {
+      queryClient.invalidateQueries({ queryKey: peopleListKey(input.ownerPubkey, input.listId) });
+      queryClient.invalidateQueries({ queryKey: peopleListsKey(input.ownerPubkey) });
+    },
+  });
+}
+
+export function useAddPersonToPeopleList() {
+  const { nostr } = useNostr();
+  const { mutateAsync: publishEvent } = useNostrPublish();
+  const queryClient = useQueryClient();
+  const { user } = useCurrentUser();
+
+  return useMutation({
+    mutationFn: async (input: PeopleListMemberMutationInput) => {
+      assertOwner(user?.pubkey, input.ownerPubkey);
+      const { event, list } = await fetchCurrentPeopleListEvent(nostr, input.ownerPubkey, input.listId);
+      if (list.memberPubkeys.includes(input.memberPubkey)) {
+        return;
+      }
+
+      await publishEvent({
+        kind: PEOPLE_LIST_KIND,
+        content: event.content,
+        tags: replacePeopleListMemberTags(event.tags, [...list.memberPubkeys, input.memberPubkey]),
+      });
+    },
+    onMutate: async (input): Promise<PeopleListMutationSnapshot> => {
+      await Promise.all([
+        queryClient.cancelQueries({ queryKey: peopleListKey(input.ownerPubkey, input.listId) }),
+        queryClient.cancelQueries({ queryKey: peopleListsKey(input.ownerPubkey) }),
+      ]);
+
+      const snapshot = {
+        list: queryClient.getQueryData<PeopleList | null>(peopleListKey(input.ownerPubkey, input.listId)),
+        lists: queryClient.getQueryData<PeopleList[]>(peopleListsKey(input.ownerPubkey)),
+      };
+
+      const updateList = (list: PeopleList): PeopleList => (
+        list.memberPubkeys.includes(input.memberPubkey)
+          ? list
+          : { ...list, memberPubkeys: [...list.memberPubkeys, input.memberPubkey] }
+      );
+
+      queryClient.setQueryData<PeopleList | null>(
+        peopleListKey(input.ownerPubkey, input.listId),
+        (oldList) => oldList ? updateList(oldList) : oldList,
+      );
+      queryClient.setQueryData<PeopleList[]>(
+        peopleListsKey(input.ownerPubkey),
+        (oldLists) => oldLists?.map((list) => list.id === input.listId ? updateList(list) : list),
+      );
+
+      return snapshot;
+    },
+    onError: (_error, input, snapshot) => {
+      queryClient.setQueryData(peopleListKey(input.ownerPubkey, input.listId), snapshot?.list);
+      queryClient.setQueryData(peopleListsKey(input.ownerPubkey), snapshot?.lists);
+    },
+    onSettled: (_data, _error, input) => {
+      queryClient.invalidateQueries({ queryKey: peopleListKey(input.ownerPubkey, input.listId) });
+      queryClient.invalidateQueries({ queryKey: peopleListsKey(input.ownerPubkey) });
+    },
+  });
+}
+
+export function useRemovePersonFromPeopleList() {
+  const { nostr } = useNostr();
+  const { mutateAsync: publishEvent } = useNostrPublish();
+  const queryClient = useQueryClient();
+  const { user } = useCurrentUser();
+
+  return useMutation({
+    mutationFn: async (input: PeopleListMemberMutationInput) => {
+      assertOwner(user?.pubkey, input.ownerPubkey);
+      const { event, list } = await fetchCurrentPeopleListEvent(nostr, input.ownerPubkey, input.listId);
+      if (!list.memberPubkeys.includes(input.memberPubkey)) {
+        return;
+      }
+
+      await publishEvent({
+        kind: PEOPLE_LIST_KIND,
+        content: event.content,
+        tags: replacePeopleListMemberTags(
+          event.tags,
+          list.memberPubkeys.filter((pubkey) => pubkey !== input.memberPubkey),
+        ),
+      });
+    },
+    onMutate: async (input): Promise<PeopleListMutationSnapshot> => {
+      await Promise.all([
+        queryClient.cancelQueries({ queryKey: peopleListKey(input.ownerPubkey, input.listId) }),
+        queryClient.cancelQueries({ queryKey: peopleListsKey(input.ownerPubkey) }),
+      ]);
+
+      const snapshot = {
+        list: queryClient.getQueryData<PeopleList | null>(peopleListKey(input.ownerPubkey, input.listId)),
+        lists: queryClient.getQueryData<PeopleList[]>(peopleListsKey(input.ownerPubkey)),
+      };
+
+      const updateList = (list: PeopleList): PeopleList => ({
+        ...list,
+        memberPubkeys: list.memberPubkeys.filter((pubkey) => pubkey !== input.memberPubkey),
+      });
+
+      queryClient.setQueryData<PeopleList | null>(
+        peopleListKey(input.ownerPubkey, input.listId),
+        (oldList) => oldList ? updateList(oldList) : oldList,
+      );
+      queryClient.setQueryData<PeopleList[]>(
+        peopleListsKey(input.ownerPubkey),
+        (oldLists) => oldLists?.map((list) => list.id === input.listId ? updateList(list) : list),
+      );
+
+      return snapshot;
+    },
+    onError: (_error, input, snapshot) => {
+      queryClient.setQueryData(peopleListKey(input.ownerPubkey, input.listId), snapshot?.list);
+      queryClient.setQueryData(peopleListsKey(input.ownerPubkey), snapshot?.lists);
+    },
+    onSettled: (_data, _error, input) => {
+      queryClient.invalidateQueries({ queryKey: peopleListKey(input.ownerPubkey, input.listId) });
+      queryClient.invalidateQueries({ queryKey: peopleListsKey(input.ownerPubkey) });
+    },
+  });
+}
+
+export function useDeletePeopleList() {
+  const { mutateAsync: publishEvent } = useNostrPublish();
+  const queryClient = useQueryClient();
+  const { user } = useCurrentUser();
+
+  return useMutation({
+    mutationFn: async ({ listId, ownerPubkey }: PeopleListMutationInput) => {
+      assertOwner(user?.pubkey, ownerPubkey);
+
+      await publishEvent({
+        kind: 5,
+        content: 'People list deleted by owner',
+        tags: [
+          ['a', `${PEOPLE_LIST_KIND}:${ownerPubkey}:${listId}`],
+          ['k', String(PEOPLE_LIST_KIND)],
+        ],
+      });
+
+      return { listId, ownerPubkey };
+    },
+    onSuccess: ({ listId, ownerPubkey }) => {
+      queryClient.setQueryData<PeopleList[]>(
+        peopleListsKey(ownerPubkey),
+        (oldLists) => oldLists?.filter((list) => list.id !== listId) ?? [],
+      );
+      queryClient.setQueryData(peopleListKey(ownerPubkey, listId), null);
+      queryClient.invalidateQueries({ queryKey: ['people-lists'] });
+      queryClient.invalidateQueries({ queryKey: ['people-list', ownerPubkey, listId] });
+      queryClient.invalidateQueries({ queryKey: ['list-route-kind', ownerPubkey, listId] });
+    },
+  });
+}
+
+export const useAddToPeopleList = useAddPersonToPeopleList;
+export const useRemoveFromPeopleList = useRemovePersonFromPeopleList;

--- a/src/hooks/usePeopleListVideos.test.ts
+++ b/src/hooks/usePeopleListVideos.test.ts
@@ -107,9 +107,9 @@ describe('usePeopleListVideos', () => {
     await result.current.fetchNextPage();
     await waitFor(() => expect(mockNostrQuery).toHaveBeenCalledTimes(2));
 
-    // Cursor derives from the oldest raw event, not the deduped page size.
+    // Cursor derives from the oldest raw event, not the deduped page size, and stays inclusive.
     const secondFilters = mockNostrQuery.mock.calls[1][0];
-    expect(secondFilters[0].until).toBe(999);
+    expect(secondFilters[0].until).toBe(1000);
   });
 
   it('continues from the oldest retained video when raw results exceed the page cap', async () => {
@@ -129,7 +129,55 @@ describe('usePeopleListVideos', () => {
     await waitFor(() => expect(mockNostrQuery).toHaveBeenCalledTimes(2));
 
     const secondFilters = mockNostrQuery.mock.calls[1][0];
-    expect(secondFilters[0].until).toBe(940);
+    expect(secondFilters[0].until).toBe(941);
+  });
+
+  it('keeps same-timestamp boundary videos reachable across pages', async () => {
+    const firstPage = [
+      ...Array.from({ length: 59 }, (_, index) => (
+        videoEvent(ALICE, `first-${index}`, 1000 - index)
+      )),
+      videoEvent(ALICE, 'boundary-a', 941),
+    ];
+    const secondPage = [
+      videoEvent(ALICE, 'boundary-a', 941),
+      videoEvent(ALICE, 'boundary-b', 941),
+    ];
+    mockNostrQuery.mockResolvedValueOnce(firstPage).mockResolvedValueOnce(secondPage);
+    const { usePeopleListVideos } = await import('./usePeopleListVideos');
+
+    const { result } = renderHook(() => usePeopleListVideos([ALICE]), { wrapper: createWrapper() });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    await result.current.fetchNextPage();
+    await waitFor(() => expect(mockNostrQuery).toHaveBeenCalledTimes(2));
+
+    const secondFilters = mockNostrQuery.mock.calls[1][0];
+    expect(secondFilters[0].until).toBe(941);
+    const videos = result.current.data?.pages.flatMap((page) => page.videos) ?? [];
+    expect(videos.map((video) => video.vineId)).toContain('boundary-a');
+    expect(videos.map((video) => video.vineId)).toContain('boundary-b');
+  });
+
+  it('stops paginating when an inclusive boundary page adds no new videos', async () => {
+    const firstPage = Array.from({ length: 60 }, (_, index) => (
+      videoEvent(ALICE, `video-${index}`, 1000 - index)
+    ));
+    const duplicateBoundary = [videoEvent(ALICE, 'video-59', 941)];
+    mockNostrQuery.mockResolvedValueOnce(firstPage).mockResolvedValueOnce(duplicateBoundary);
+    const { usePeopleListVideos } = await import('./usePeopleListVideos');
+
+    const { result } = renderHook(() => usePeopleListVideos([ALICE]), { wrapper: createWrapper() });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.hasNextPage).toBe(true);
+
+    await result.current.fetchNextPage();
+    await waitFor(() => expect(mockNostrQuery).toHaveBeenCalledTimes(2));
+
+    expect(result.current.hasNextPage).toBe(false);
+    const videos = result.current.data?.pages.flatMap((page) => page.videos) ?? [];
+    expect(videos).toHaveLength(60);
   });
 
   it('stops paginating when the raw page comes back below the limit', async () => {

--- a/src/hooks/usePeopleListVideos.ts
+++ b/src/hooks/usePeopleListVideos.ts
@@ -3,11 +3,14 @@
 import { useMemo } from 'react';
 import { useNostr } from '@nostrify/react';
 import { useInfiniteQuery } from '@tanstack/react-query';
+import type { InfiniteData } from '@tanstack/react-query';
 import { parseVideoEvents } from '@/lib/videoParser';
 import {
   buildPeopleListVideoFilters,
   mergePeopleListVideoEvents,
+  peopleListVideoAddress,
   PEOPLE_LIST_VIDEO_PAGE_SIZE,
+  PEOPLE_LIST_VIDEO_RELAY_LIMIT,
 } from '@/lib/peopleListVideos';
 import { useFeedBlocklist } from '@/hooks/useFeedBlocklist';
 import { filterBlockedVideoPages } from '@/lib/blocklistFilter';
@@ -15,6 +18,7 @@ import type { ParsedVideoData } from '@/types/video';
 
 export interface PeopleListVideoPage {
   videos: ParsedVideoData[];
+  videoAddresses: string[];
   nextUntil?: number;
 }
 
@@ -24,14 +28,51 @@ interface UsePeopleListVideosOptions {
 
 function getNextUntil(events: { created_at: number }[], mergedEvents: { created_at: number }[]): number | undefined {
   if (mergedEvents.length >= PEOPLE_LIST_VIDEO_PAGE_SIZE) {
-    return mergedEvents[mergedEvents.length - 1].created_at - 1;
+    return mergedEvents[mergedEvents.length - 1].created_at;
   }
 
-  if (events.length >= PEOPLE_LIST_VIDEO_PAGE_SIZE && events.length > 0) {
-    return Math.min(...events.map((event) => event.created_at)) - 1;
+  if (events.length >= PEOPLE_LIST_VIDEO_RELAY_LIMIT && events.length > 0) {
+    return Math.min(...events.map((event) => event.created_at));
   }
 
   return undefined;
+}
+
+function videoDataAddress(video: ParsedVideoData): string | undefined {
+  if (!video.vineId) return undefined;
+  return `${video.pubkey}:${video.kind}:${video.vineId}`;
+}
+
+function pageAddsNewVideos(lastPage: PeopleListVideoPage, pages: PeopleListVideoPage[]): boolean {
+  const previousAddresses = new Set(
+    pages
+      .slice(0, -1)
+      .flatMap((page) => page.videoAddresses),
+  );
+
+  return lastPage.videoAddresses.some((address) => !previousAddresses.has(address));
+}
+
+function dedupeVideoPages(
+  data: InfiniteData<PeopleListVideoPage> | undefined,
+): InfiniteData<PeopleListVideoPage> | undefined {
+  if (!data) return data;
+
+  const seen = new Set<string>();
+
+  return {
+    ...data,
+    pages: data.pages.map((page) => ({
+      ...page,
+      videos: page.videos.filter((video) => {
+        const address = videoDataAddress(video);
+        if (!address) return true;
+        if (seen.has(address)) return false;
+        seen.add(address);
+        return true;
+      }),
+    })),
+  };
 }
 
 export function usePeopleListVideos(memberPubkeys: string[], options: UsePeopleListVideosOptions = {}) {
@@ -52,11 +93,18 @@ export function usePeopleListVideos(memberPubkeys: string[], options: UsePeopleL
 
       return {
         videos: parseVideoEvents(mergedEvents),
+        videoAddresses: mergedEvents
+          .map(peopleListVideoAddress)
+          .filter((address): address is string => Boolean(address)),
         nextUntil,
       };
     },
     initialPageParam: undefined as number | undefined,
-    getNextPageParam: (lastPage) => lastPage.nextUntil,
+    getNextPageParam: (lastPage, allPages) => {
+      if (!lastPage.nextUntil) return undefined;
+      if (!pageAddsNewVideos(lastPage, allPages)) return undefined;
+      return lastPage.nextUntil;
+    },
     enabled: enabled && stableMembers.length > 0,
     staleTime: 60_000,
     gcTime: 300_000,
@@ -67,7 +115,7 @@ export function usePeopleListVideos(memberPubkeys: string[], options: UsePeopleL
   // from query results, same as the other WebSocket feeds.
   const blockedPubkeys = useFeedBlocklist();
   const data = useMemo(
-    () => filterBlockedVideoPages(query.data, blockedPubkeys),
+    () => dedupeVideoPages(filterBlockedVideoPages(query.data, blockedPubkeys)),
     [query.data, blockedPubkeys],
   );
 

--- a/src/hooks/usePeopleLists.ts
+++ b/src/hooks/usePeopleLists.ts
@@ -3,8 +3,7 @@
 import { useNostr } from '@nostrify/react';
 import { useQuery } from '@tanstack/react-query';
 import { deduplicatePeopleLists } from '@/lib/parsePeopleListFromEvent';
-
-const PEOPLE_LIST_KIND = 30000;
+import { PEOPLE_LIST_KIND } from '@/lib/peopleListConstants';
 
 export function usePeopleLists(pubkey: string | undefined) {
   const { nostr } = useNostr();

--- a/src/lib/directSearch.test.ts
+++ b/src/lib/directSearch.test.ts
@@ -73,12 +73,17 @@ describe('directSearch', () => {
     });
   });
 
-  it('routes video lists and generic addressable events to useful paths', () => {
+  it('routes list naddrs and generic addressable events to useful paths', () => {
     const listId = 'spring-picks';
-    const listNaddr = nip19.naddrEncode({
+    const videoListNaddr = nip19.naddrEncode({
       identifier: listId,
       pubkey,
       kind: 30005,
+    });
+    const peopleListNaddr = nip19.naddrEncode({
+      identifier: 'friends',
+      pubkey,
+      kind: 30000,
     });
     const articleId = 'post-123';
     const article = nip19.naddrEncode({
@@ -88,8 +93,12 @@ describe('directSearch', () => {
       relays: ['wss://relay.example'],
     });
 
-    expect(getDirectSearchTarget(listNaddr)).toEqual({
+    expect(getDirectSearchTarget(videoListNaddr)).toEqual({
       path: buildListPath(pubkey, listId),
+      entity: 'event',
+    });
+    expect(getDirectSearchTarget(peopleListNaddr)).toEqual({
+      path: buildListPath(pubkey, 'friends'),
       entity: 'event',
     });
     expect(getDirectSearchTarget(article)).toEqual({

--- a/src/lib/eventRouting.test.ts
+++ b/src/lib/eventRouting.test.ts
@@ -2,10 +2,12 @@ import { describe, expect, it } from 'vitest';
 import type { NostrEvent } from '@nostrify/nostrify';
 import { SHORT_VIDEO_KIND } from '@/types/video';
 import {
+  buildAddressableRoute,
   buildAddressableEventPath,
   buildListPath,
   buildResolvedEventRoute,
   buildVideoPath,
+  isListDetailEventKind,
   isListEventKind,
   isNoteEventKind,
 } from './eventRouting';
@@ -43,6 +45,17 @@ describe('eventRouting', () => {
     expect(buildResolvedEventRoute(event)).toBe(buildListPath(event.pubkey, 'favorites'));
   });
 
+  it('routes people list events to the public list page', () => {
+    const event = makeEvent({
+      kind: 30000,
+      pubkey: 'a'.repeat(64),
+      tags: [['d', 'friends']],
+    });
+
+    expect(buildAddressableRoute(30000, event.pubkey, 'friends')).toBe(buildListPath(event.pubkey, 'friends'));
+    expect(buildResolvedEventRoute(event)).toBe(buildListPath(event.pubkey, 'friends'));
+  });
+
   it('keeps generic addressable events on the generic event route', () => {
     expect(buildAddressableEventPath(30023, 'b'.repeat(64), 'post-123')).toBe(
       '/event/a/30023/' + 'b'.repeat(64) + '/post-123'
@@ -52,6 +65,9 @@ describe('eventRouting', () => {
   it('classifies note and list kinds for rendering', () => {
     expect(isNoteEventKind(1)).toBe(true);
     expect(isNoteEventKind(1111)).toBe(true);
+    expect(isListDetailEventKind(30000)).toBe(true);
+    expect(isListDetailEventKind(30005)).toBe(true);
+    expect(isListDetailEventKind(30001)).toBe(false);
     expect(isListEventKind(30001)).toBe(true);
     expect(isListEventKind(22)).toBe(false);
   });

--- a/src/lib/eventRouting.ts
+++ b/src/lib/eventRouting.ts
@@ -16,6 +16,7 @@ const LIST_EVENT_KINDS = new Set([
 ]);
 
 const NOTE_EVENT_KINDS = new Set([1, 1111]);
+const LIST_DETAIL_EVENT_KINDS = new Set([30000, 30005]);
 
 export function buildVideoPath(identifier: string): string {
   return `/video/${encodeURIComponent(identifier)}`;
@@ -48,6 +49,10 @@ export function isNoteEventKind(kind: number): boolean {
   return NOTE_EVENT_KINDS.has(kind);
 }
 
+export function isListDetailEventKind(kind: number): boolean {
+  return LIST_DETAIL_EVENT_KINDS.has(kind);
+}
+
 export function getEventDTag(event: Pick<NostrEvent, 'tags'>): string | null {
   return event.tags.find(tag => tag[0] === 'd')?.[1] || null;
 }
@@ -57,7 +62,7 @@ export function buildAddressableRoute(kind: number, pubkey: string, identifier: 
     return buildVideoPath(identifier);
   }
 
-  if (kind === 30005) {
+  if (isListDetailEventKind(kind)) {
     return buildListPath(pubkey, identifier);
   }
 
@@ -70,7 +75,7 @@ export function buildResolvedEventRoute(event: Pick<NostrEvent, 'id' | 'kind' | 
   }
 
   const dTag = getEventDTag(event);
-  if (event.kind === 30005 && dTag) {
+  if (dTag && isListDetailEventKind(event.kind)) {
     return buildListPath(event.pubkey, dTag);
   }
 

--- a/src/lib/i18n/locales/ar/common.json
+++ b/src/lib/i18n/locales/ar/common.json
@@ -1515,5 +1515,69 @@
     "podcastEpisode": "حلقة بودكاست",
     "openInApplePodcasts": "فتح في Apple Podcasts",
     "playEpisode": "تشغيل الحلقة"
+  },
+  "createPeopleListDialog": {
+    "title": "Create People List",
+    "description": "Group people together and watch their latest loops in one place.",
+    "nameLabel": "List Name *",
+    "namePlaceholder": "Favorite Creators",
+    "descriptionLabel": "Description",
+    "descriptionPlaceholder": "People whose loops you never miss...",
+    "imageLabel": "Cover Image URL",
+    "imagePlaceholder": "https://example.com/image.jpg",
+    "nameRequired": "Name it first.",
+    "reservedName": "That name is reserved for a system list.",
+    "imageInvalid": "Use a full image URL.",
+    "cancelButton": "Cancel",
+    "creatingButton": "Creating...",
+    "createButton": "Create List",
+    "createdTitle": "People list created.",
+    "createdDescription": "\"{{name}}\" is ready.",
+    "failedTitle": "Didn't make it.",
+    "failedDescription": "People list creation hit a snag. Try again?"
+  },
+  "deleteListDialog": {
+    "title": "Delete List?",
+    "videosDescription": "This will permanently delete the list \"{{name}}\". Videos in the list will not be affected.",
+    "peopleDescription": "This will permanently delete the list \"{{name}}\". People in the list will not be affected.",
+    "noteLabel": "Note:",
+    "relayNote": "This action sends a deletion request to relays. Most relays will honor this request, but deletion is not guaranteed on all relays.",
+    "cancelButton": "Cancel",
+    "deletingButton": "Deleting...",
+    "deleteButton": "Delete List"
+  },
+  "editPeopleListDialog": {
+    "title": "Edit People List",
+    "description": "Update the name, description, or cover image for this list.",
+    "nameLabel": "List Name *",
+    "namePlaceholder": "Favorite Creators",
+    "descriptionLabel": "Description",
+    "descriptionPlaceholder": "People whose loops you never miss...",
+    "imageLabel": "Cover Image URL",
+    "imagePlaceholder": "https://example.com/image.jpg",
+    "nameRequired": "Name it first.",
+    "imageInvalid": "Use a full image URL.",
+    "cancelButton": "Cancel",
+    "savingButton": "Saving...",
+    "saveButton": "Save",
+    "savedTitle": "Saved.",
+    "savedDescription": "\"{{name}}\" is updated.",
+    "failedTitle": "Didn't save.",
+    "failedDescription": "People list updates hit a snag. Try again?"
+  },
+  "listsPage": {
+    "createList": "Create List",
+    "createFirstList": "Create Your First List",
+    "createVideoList": "Video list",
+    "createPeopleList": "People list"
+  },
+  "peopleListDetailPage": {
+    "editList": "Edit",
+    "delete": "Delete",
+    "share": "Share",
+    "deletedTitle": "People list deleted.",
+    "deletedDescription": "\"{{name}}\" has been removed.",
+    "deleteFailedTitle": "Delete failed.",
+    "deleteFailedDescription": "People list deletion hit a snag. Try again?"
   }
 }

--- a/src/lib/i18n/locales/de/common.json
+++ b/src/lib/i18n/locales/de/common.json
@@ -1431,5 +1431,69 @@
     "podcastEpisode": "Podcast-Episode",
     "openInApplePodcasts": "In Apple Podcasts öffnen",
     "playEpisode": "Episode abspielen"
+  },
+  "createPeopleListDialog": {
+    "title": "Create People List",
+    "description": "Group people together and watch their latest loops in one place.",
+    "nameLabel": "List Name *",
+    "namePlaceholder": "Favorite Creators",
+    "descriptionLabel": "Description",
+    "descriptionPlaceholder": "People whose loops you never miss...",
+    "imageLabel": "Cover Image URL",
+    "imagePlaceholder": "https://example.com/image.jpg",
+    "nameRequired": "Name it first.",
+    "reservedName": "That name is reserved for a system list.",
+    "imageInvalid": "Use a full image URL.",
+    "cancelButton": "Cancel",
+    "creatingButton": "Creating...",
+    "createButton": "Create List",
+    "createdTitle": "People list created.",
+    "createdDescription": "\"{{name}}\" is ready.",
+    "failedTitle": "Didn't make it.",
+    "failedDescription": "People list creation hit a snag. Try again?"
+  },
+  "deleteListDialog": {
+    "title": "Delete List?",
+    "videosDescription": "This will permanently delete the list \"{{name}}\". Videos in the list will not be affected.",
+    "peopleDescription": "This will permanently delete the list \"{{name}}\". People in the list will not be affected.",
+    "noteLabel": "Note:",
+    "relayNote": "This action sends a deletion request to relays. Most relays will honor this request, but deletion is not guaranteed on all relays.",
+    "cancelButton": "Cancel",
+    "deletingButton": "Deleting...",
+    "deleteButton": "Delete List"
+  },
+  "editPeopleListDialog": {
+    "title": "Edit People List",
+    "description": "Update the name, description, or cover image for this list.",
+    "nameLabel": "List Name *",
+    "namePlaceholder": "Favorite Creators",
+    "descriptionLabel": "Description",
+    "descriptionPlaceholder": "People whose loops you never miss...",
+    "imageLabel": "Cover Image URL",
+    "imagePlaceholder": "https://example.com/image.jpg",
+    "nameRequired": "Name it first.",
+    "imageInvalid": "Use a full image URL.",
+    "cancelButton": "Cancel",
+    "savingButton": "Saving...",
+    "saveButton": "Save",
+    "savedTitle": "Saved.",
+    "savedDescription": "\"{{name}}\" is updated.",
+    "failedTitle": "Didn't save.",
+    "failedDescription": "People list updates hit a snag. Try again?"
+  },
+  "listsPage": {
+    "createList": "Create List",
+    "createFirstList": "Create Your First List",
+    "createVideoList": "Video list",
+    "createPeopleList": "People list"
+  },
+  "peopleListDetailPage": {
+    "editList": "Edit",
+    "delete": "Delete",
+    "share": "Share",
+    "deletedTitle": "People list deleted.",
+    "deletedDescription": "\"{{name}}\" has been removed.",
+    "deleteFailedTitle": "Delete failed.",
+    "deleteFailedDescription": "People list deletion hit a snag. Try again?"
   }
 }

--- a/src/lib/i18n/locales/en/common.json
+++ b/src/lib/i18n/locales/en/common.json
@@ -1431,5 +1431,69 @@
     "podcastEpisode": "Podcast Episode",
     "openInApplePodcasts": "Open in Apple Podcasts",
     "playEpisode": "Play Episode"
+  },
+  "listsPage": {
+    "createList": "Create List",
+    "createFirstList": "Create Your First List",
+    "createVideoList": "Video list",
+    "createPeopleList": "People list"
+  },
+  "createPeopleListDialog": {
+    "title": "Create People List",
+    "description": "Group people together and watch their latest loops in one place.",
+    "nameLabel": "List Name *",
+    "namePlaceholder": "Favorite Creators",
+    "descriptionLabel": "Description",
+    "descriptionPlaceholder": "People whose loops you never miss...",
+    "imageLabel": "Cover Image URL",
+    "imagePlaceholder": "https://example.com/image.jpg",
+    "nameRequired": "Name it first.",
+    "reservedName": "That name is reserved for a system list.",
+    "imageInvalid": "Use a full image URL.",
+    "cancelButton": "Cancel",
+    "creatingButton": "Creating...",
+    "createButton": "Create List",
+    "createdTitle": "People list created.",
+    "createdDescription": "\"{{name}}\" is ready.",
+    "failedTitle": "Didn't make it.",
+    "failedDescription": "People list creation hit a snag. Try again?"
+  },
+  "editPeopleListDialog": {
+    "title": "Edit People List",
+    "description": "Update the name, description, or cover image for this list.",
+    "nameLabel": "List Name *",
+    "namePlaceholder": "Favorite Creators",
+    "descriptionLabel": "Description",
+    "descriptionPlaceholder": "People whose loops you never miss...",
+    "imageLabel": "Cover Image URL",
+    "imagePlaceholder": "https://example.com/image.jpg",
+    "nameRequired": "Name it first.",
+    "imageInvalid": "Use a full image URL.",
+    "cancelButton": "Cancel",
+    "savingButton": "Saving...",
+    "saveButton": "Save",
+    "savedTitle": "Saved.",
+    "savedDescription": "\"{{name}}\" is updated.",
+    "failedTitle": "Didn't save.",
+    "failedDescription": "People list updates hit a snag. Try again?"
+  },
+  "deleteListDialog": {
+    "title": "Delete List?",
+    "videosDescription": "This will permanently delete the list \"{{name}}\". Videos in the list will not be affected.",
+    "peopleDescription": "This will permanently delete the list \"{{name}}\". People in the list will not be affected.",
+    "noteLabel": "Note:",
+    "relayNote": "This action sends a deletion request to relays. Most relays will honor this request, but deletion is not guaranteed on all relays.",
+    "cancelButton": "Cancel",
+    "deletingButton": "Deleting...",
+    "deleteButton": "Delete List"
+  },
+  "peopleListDetailPage": {
+    "editList": "Edit",
+    "delete": "Delete",
+    "share": "Share",
+    "deletedTitle": "People list deleted.",
+    "deletedDescription": "\"{{name}}\" has been removed.",
+    "deleteFailedTitle": "Delete failed.",
+    "deleteFailedDescription": "People list deletion hit a snag. Try again?"
   }
 }

--- a/src/lib/i18n/locales/es/common.json
+++ b/src/lib/i18n/locales/es/common.json
@@ -1432,5 +1432,69 @@
     "podcastEpisode": "Episodio del podcast",
     "openInApplePodcasts": "Abrir en Apple Podcasts",
     "playEpisode": "Reproducir episodio"
+  },
+  "createPeopleListDialog": {
+    "title": "Create People List",
+    "description": "Group people together and watch their latest loops in one place.",
+    "nameLabel": "List Name *",
+    "namePlaceholder": "Favorite Creators",
+    "descriptionLabel": "Description",
+    "descriptionPlaceholder": "People whose loops you never miss...",
+    "imageLabel": "Cover Image URL",
+    "imagePlaceholder": "https://example.com/image.jpg",
+    "nameRequired": "Name it first.",
+    "reservedName": "That name is reserved for a system list.",
+    "imageInvalid": "Use a full image URL.",
+    "cancelButton": "Cancel",
+    "creatingButton": "Creating...",
+    "createButton": "Create List",
+    "createdTitle": "People list created.",
+    "createdDescription": "\"{{name}}\" is ready.",
+    "failedTitle": "Didn't make it.",
+    "failedDescription": "People list creation hit a snag. Try again?"
+  },
+  "deleteListDialog": {
+    "title": "Delete List?",
+    "videosDescription": "This will permanently delete the list \"{{name}}\". Videos in the list will not be affected.",
+    "peopleDescription": "This will permanently delete the list \"{{name}}\". People in the list will not be affected.",
+    "noteLabel": "Note:",
+    "relayNote": "This action sends a deletion request to relays. Most relays will honor this request, but deletion is not guaranteed on all relays.",
+    "cancelButton": "Cancel",
+    "deletingButton": "Deleting...",
+    "deleteButton": "Delete List"
+  },
+  "editPeopleListDialog": {
+    "title": "Edit People List",
+    "description": "Update the name, description, or cover image for this list.",
+    "nameLabel": "List Name *",
+    "namePlaceholder": "Favorite Creators",
+    "descriptionLabel": "Description",
+    "descriptionPlaceholder": "People whose loops you never miss...",
+    "imageLabel": "Cover Image URL",
+    "imagePlaceholder": "https://example.com/image.jpg",
+    "nameRequired": "Name it first.",
+    "imageInvalid": "Use a full image URL.",
+    "cancelButton": "Cancel",
+    "savingButton": "Saving...",
+    "saveButton": "Save",
+    "savedTitle": "Saved.",
+    "savedDescription": "\"{{name}}\" is updated.",
+    "failedTitle": "Didn't save.",
+    "failedDescription": "People list updates hit a snag. Try again?"
+  },
+  "listsPage": {
+    "createList": "Create List",
+    "createFirstList": "Create Your First List",
+    "createVideoList": "Video list",
+    "createPeopleList": "People list"
+  },
+  "peopleListDetailPage": {
+    "editList": "Edit",
+    "delete": "Delete",
+    "share": "Share",
+    "deletedTitle": "People list deleted.",
+    "deletedDescription": "\"{{name}}\" has been removed.",
+    "deleteFailedTitle": "Delete failed.",
+    "deleteFailedDescription": "People list deletion hit a snag. Try again?"
   }
 }

--- a/src/lib/i18n/locales/fil/common.json
+++ b/src/lib/i18n/locales/fil/common.json
@@ -1431,5 +1431,69 @@
     "podcastEpisode": "Podcast Episode",
     "openInApplePodcasts": "Buksan sa Apple Podcasts",
     "playEpisode": "I-play ang Episode"
+  },
+  "createPeopleListDialog": {
+    "title": "Create People List",
+    "description": "Group people together and watch their latest loops in one place.",
+    "nameLabel": "List Name *",
+    "namePlaceholder": "Favorite Creators",
+    "descriptionLabel": "Description",
+    "descriptionPlaceholder": "People whose loops you never miss...",
+    "imageLabel": "Cover Image URL",
+    "imagePlaceholder": "https://example.com/image.jpg",
+    "nameRequired": "Name it first.",
+    "reservedName": "That name is reserved for a system list.",
+    "imageInvalid": "Use a full image URL.",
+    "cancelButton": "Cancel",
+    "creatingButton": "Creating...",
+    "createButton": "Create List",
+    "createdTitle": "People list created.",
+    "createdDescription": "\"{{name}}\" is ready.",
+    "failedTitle": "Didn't make it.",
+    "failedDescription": "People list creation hit a snag. Try again?"
+  },
+  "deleteListDialog": {
+    "title": "Delete List?",
+    "videosDescription": "This will permanently delete the list \"{{name}}\". Videos in the list will not be affected.",
+    "peopleDescription": "This will permanently delete the list \"{{name}}\". People in the list will not be affected.",
+    "noteLabel": "Note:",
+    "relayNote": "This action sends a deletion request to relays. Most relays will honor this request, but deletion is not guaranteed on all relays.",
+    "cancelButton": "Cancel",
+    "deletingButton": "Deleting...",
+    "deleteButton": "Delete List"
+  },
+  "editPeopleListDialog": {
+    "title": "Edit People List",
+    "description": "Update the name, description, or cover image for this list.",
+    "nameLabel": "List Name *",
+    "namePlaceholder": "Favorite Creators",
+    "descriptionLabel": "Description",
+    "descriptionPlaceholder": "People whose loops you never miss...",
+    "imageLabel": "Cover Image URL",
+    "imagePlaceholder": "https://example.com/image.jpg",
+    "nameRequired": "Name it first.",
+    "imageInvalid": "Use a full image URL.",
+    "cancelButton": "Cancel",
+    "savingButton": "Saving...",
+    "saveButton": "Save",
+    "savedTitle": "Saved.",
+    "savedDescription": "\"{{name}}\" is updated.",
+    "failedTitle": "Didn't save.",
+    "failedDescription": "People list updates hit a snag. Try again?"
+  },
+  "listsPage": {
+    "createList": "Create List",
+    "createFirstList": "Create Your First List",
+    "createVideoList": "Video list",
+    "createPeopleList": "People list"
+  },
+  "peopleListDetailPage": {
+    "editList": "Edit",
+    "delete": "Delete",
+    "share": "Share",
+    "deletedTitle": "People list deleted.",
+    "deletedDescription": "\"{{name}}\" has been removed.",
+    "deleteFailedTitle": "Delete failed.",
+    "deleteFailedDescription": "People list deletion hit a snag. Try again?"
   }
 }

--- a/src/lib/i18n/locales/fr/common.json
+++ b/src/lib/i18n/locales/fr/common.json
@@ -1432,5 +1432,69 @@
     "podcastEpisode": "Épisode de podcast",
     "openInApplePodcasts": "Ouvrir dans Apple Podcasts",
     "playEpisode": "Lire l'épisode"
+  },
+  "createPeopleListDialog": {
+    "title": "Create People List",
+    "description": "Group people together and watch their latest loops in one place.",
+    "nameLabel": "List Name *",
+    "namePlaceholder": "Favorite Creators",
+    "descriptionLabel": "Description",
+    "descriptionPlaceholder": "People whose loops you never miss...",
+    "imageLabel": "Cover Image URL",
+    "imagePlaceholder": "https://example.com/image.jpg",
+    "nameRequired": "Name it first.",
+    "reservedName": "That name is reserved for a system list.",
+    "imageInvalid": "Use a full image URL.",
+    "cancelButton": "Cancel",
+    "creatingButton": "Creating...",
+    "createButton": "Create List",
+    "createdTitle": "People list created.",
+    "createdDescription": "\"{{name}}\" is ready.",
+    "failedTitle": "Didn't make it.",
+    "failedDescription": "People list creation hit a snag. Try again?"
+  },
+  "deleteListDialog": {
+    "title": "Delete List?",
+    "videosDescription": "This will permanently delete the list \"{{name}}\". Videos in the list will not be affected.",
+    "peopleDescription": "This will permanently delete the list \"{{name}}\". People in the list will not be affected.",
+    "noteLabel": "Note:",
+    "relayNote": "This action sends a deletion request to relays. Most relays will honor this request, but deletion is not guaranteed on all relays.",
+    "cancelButton": "Cancel",
+    "deletingButton": "Deleting...",
+    "deleteButton": "Delete List"
+  },
+  "editPeopleListDialog": {
+    "title": "Edit People List",
+    "description": "Update the name, description, or cover image for this list.",
+    "nameLabel": "List Name *",
+    "namePlaceholder": "Favorite Creators",
+    "descriptionLabel": "Description",
+    "descriptionPlaceholder": "People whose loops you never miss...",
+    "imageLabel": "Cover Image URL",
+    "imagePlaceholder": "https://example.com/image.jpg",
+    "nameRequired": "Name it first.",
+    "imageInvalid": "Use a full image URL.",
+    "cancelButton": "Cancel",
+    "savingButton": "Saving...",
+    "saveButton": "Save",
+    "savedTitle": "Saved.",
+    "savedDescription": "\"{{name}}\" is updated.",
+    "failedTitle": "Didn't save.",
+    "failedDescription": "People list updates hit a snag. Try again?"
+  },
+  "listsPage": {
+    "createList": "Create List",
+    "createFirstList": "Create Your First List",
+    "createVideoList": "Video list",
+    "createPeopleList": "People list"
+  },
+  "peopleListDetailPage": {
+    "editList": "Edit",
+    "delete": "Delete",
+    "share": "Share",
+    "deletedTitle": "People list deleted.",
+    "deletedDescription": "\"{{name}}\" has been removed.",
+    "deleteFailedTitle": "Delete failed.",
+    "deleteFailedDescription": "People list deletion hit a snag. Try again?"
   }
 }

--- a/src/lib/i18n/locales/id/common.json
+++ b/src/lib/i18n/locales/id/common.json
@@ -1431,5 +1431,69 @@
     "podcastEpisode": "Episode Podcast",
     "openInApplePodcasts": "Buka di Apple Podcasts",
     "playEpisode": "Putar Episode"
+  },
+  "createPeopleListDialog": {
+    "title": "Create People List",
+    "description": "Group people together and watch their latest loops in one place.",
+    "nameLabel": "List Name *",
+    "namePlaceholder": "Favorite Creators",
+    "descriptionLabel": "Description",
+    "descriptionPlaceholder": "People whose loops you never miss...",
+    "imageLabel": "Cover Image URL",
+    "imagePlaceholder": "https://example.com/image.jpg",
+    "nameRequired": "Name it first.",
+    "reservedName": "That name is reserved for a system list.",
+    "imageInvalid": "Use a full image URL.",
+    "cancelButton": "Cancel",
+    "creatingButton": "Creating...",
+    "createButton": "Create List",
+    "createdTitle": "People list created.",
+    "createdDescription": "\"{{name}}\" is ready.",
+    "failedTitle": "Didn't make it.",
+    "failedDescription": "People list creation hit a snag. Try again?"
+  },
+  "deleteListDialog": {
+    "title": "Delete List?",
+    "videosDescription": "This will permanently delete the list \"{{name}}\". Videos in the list will not be affected.",
+    "peopleDescription": "This will permanently delete the list \"{{name}}\". People in the list will not be affected.",
+    "noteLabel": "Note:",
+    "relayNote": "This action sends a deletion request to relays. Most relays will honor this request, but deletion is not guaranteed on all relays.",
+    "cancelButton": "Cancel",
+    "deletingButton": "Deleting...",
+    "deleteButton": "Delete List"
+  },
+  "editPeopleListDialog": {
+    "title": "Edit People List",
+    "description": "Update the name, description, or cover image for this list.",
+    "nameLabel": "List Name *",
+    "namePlaceholder": "Favorite Creators",
+    "descriptionLabel": "Description",
+    "descriptionPlaceholder": "People whose loops you never miss...",
+    "imageLabel": "Cover Image URL",
+    "imagePlaceholder": "https://example.com/image.jpg",
+    "nameRequired": "Name it first.",
+    "imageInvalid": "Use a full image URL.",
+    "cancelButton": "Cancel",
+    "savingButton": "Saving...",
+    "saveButton": "Save",
+    "savedTitle": "Saved.",
+    "savedDescription": "\"{{name}}\" is updated.",
+    "failedTitle": "Didn't save.",
+    "failedDescription": "People list updates hit a snag. Try again?"
+  },
+  "listsPage": {
+    "createList": "Create List",
+    "createFirstList": "Create Your First List",
+    "createVideoList": "Video list",
+    "createPeopleList": "People list"
+  },
+  "peopleListDetailPage": {
+    "editList": "Edit",
+    "delete": "Delete",
+    "share": "Share",
+    "deletedTitle": "People list deleted.",
+    "deletedDescription": "\"{{name}}\" has been removed.",
+    "deleteFailedTitle": "Delete failed.",
+    "deleteFailedDescription": "People list deletion hit a snag. Try again?"
   }
 }

--- a/src/lib/i18n/locales/it/common.json
+++ b/src/lib/i18n/locales/it/common.json
@@ -1432,5 +1432,69 @@
     "podcastEpisode": "Episodio podcast",
     "openInApplePodcasts": "Apri in Apple Podcasts",
     "playEpisode": "Riproduci episodio"
+  },
+  "createPeopleListDialog": {
+    "title": "Create People List",
+    "description": "Group people together and watch their latest loops in one place.",
+    "nameLabel": "List Name *",
+    "namePlaceholder": "Favorite Creators",
+    "descriptionLabel": "Description",
+    "descriptionPlaceholder": "People whose loops you never miss...",
+    "imageLabel": "Cover Image URL",
+    "imagePlaceholder": "https://example.com/image.jpg",
+    "nameRequired": "Name it first.",
+    "reservedName": "That name is reserved for a system list.",
+    "imageInvalid": "Use a full image URL.",
+    "cancelButton": "Cancel",
+    "creatingButton": "Creating...",
+    "createButton": "Create List",
+    "createdTitle": "People list created.",
+    "createdDescription": "\"{{name}}\" is ready.",
+    "failedTitle": "Didn't make it.",
+    "failedDescription": "People list creation hit a snag. Try again?"
+  },
+  "deleteListDialog": {
+    "title": "Delete List?",
+    "videosDescription": "This will permanently delete the list \"{{name}}\". Videos in the list will not be affected.",
+    "peopleDescription": "This will permanently delete the list \"{{name}}\". People in the list will not be affected.",
+    "noteLabel": "Note:",
+    "relayNote": "This action sends a deletion request to relays. Most relays will honor this request, but deletion is not guaranteed on all relays.",
+    "cancelButton": "Cancel",
+    "deletingButton": "Deleting...",
+    "deleteButton": "Delete List"
+  },
+  "editPeopleListDialog": {
+    "title": "Edit People List",
+    "description": "Update the name, description, or cover image for this list.",
+    "nameLabel": "List Name *",
+    "namePlaceholder": "Favorite Creators",
+    "descriptionLabel": "Description",
+    "descriptionPlaceholder": "People whose loops you never miss...",
+    "imageLabel": "Cover Image URL",
+    "imagePlaceholder": "https://example.com/image.jpg",
+    "nameRequired": "Name it first.",
+    "imageInvalid": "Use a full image URL.",
+    "cancelButton": "Cancel",
+    "savingButton": "Saving...",
+    "saveButton": "Save",
+    "savedTitle": "Saved.",
+    "savedDescription": "\"{{name}}\" is updated.",
+    "failedTitle": "Didn't save.",
+    "failedDescription": "People list updates hit a snag. Try again?"
+  },
+  "listsPage": {
+    "createList": "Create List",
+    "createFirstList": "Create Your First List",
+    "createVideoList": "Video list",
+    "createPeopleList": "People list"
+  },
+  "peopleListDetailPage": {
+    "editList": "Edit",
+    "delete": "Delete",
+    "share": "Share",
+    "deletedTitle": "People list deleted.",
+    "deletedDescription": "\"{{name}}\" has been removed.",
+    "deleteFailedTitle": "Delete failed.",
+    "deleteFailedDescription": "People list deletion hit a snag. Try again?"
   }
 }

--- a/src/lib/i18n/locales/ja/common.json
+++ b/src/lib/i18n/locales/ja/common.json
@@ -1431,5 +1431,69 @@
     "podcastEpisode": "ポッドキャストエピソード",
     "openInApplePodcasts": "Apple Podcastsで開く",
     "playEpisode": "エピソードを再生"
+  },
+  "createPeopleListDialog": {
+    "title": "Create People List",
+    "description": "Group people together and watch their latest loops in one place.",
+    "nameLabel": "List Name *",
+    "namePlaceholder": "Favorite Creators",
+    "descriptionLabel": "Description",
+    "descriptionPlaceholder": "People whose loops you never miss...",
+    "imageLabel": "Cover Image URL",
+    "imagePlaceholder": "https://example.com/image.jpg",
+    "nameRequired": "Name it first.",
+    "reservedName": "That name is reserved for a system list.",
+    "imageInvalid": "Use a full image URL.",
+    "cancelButton": "Cancel",
+    "creatingButton": "Creating...",
+    "createButton": "Create List",
+    "createdTitle": "People list created.",
+    "createdDescription": "\"{{name}}\" is ready.",
+    "failedTitle": "Didn't make it.",
+    "failedDescription": "People list creation hit a snag. Try again?"
+  },
+  "deleteListDialog": {
+    "title": "Delete List?",
+    "videosDescription": "This will permanently delete the list \"{{name}}\". Videos in the list will not be affected.",
+    "peopleDescription": "This will permanently delete the list \"{{name}}\". People in the list will not be affected.",
+    "noteLabel": "Note:",
+    "relayNote": "This action sends a deletion request to relays. Most relays will honor this request, but deletion is not guaranteed on all relays.",
+    "cancelButton": "Cancel",
+    "deletingButton": "Deleting...",
+    "deleteButton": "Delete List"
+  },
+  "editPeopleListDialog": {
+    "title": "Edit People List",
+    "description": "Update the name, description, or cover image for this list.",
+    "nameLabel": "List Name *",
+    "namePlaceholder": "Favorite Creators",
+    "descriptionLabel": "Description",
+    "descriptionPlaceholder": "People whose loops you never miss...",
+    "imageLabel": "Cover Image URL",
+    "imagePlaceholder": "https://example.com/image.jpg",
+    "nameRequired": "Name it first.",
+    "imageInvalid": "Use a full image URL.",
+    "cancelButton": "Cancel",
+    "savingButton": "Saving...",
+    "saveButton": "Save",
+    "savedTitle": "Saved.",
+    "savedDescription": "\"{{name}}\" is updated.",
+    "failedTitle": "Didn't save.",
+    "failedDescription": "People list updates hit a snag. Try again?"
+  },
+  "listsPage": {
+    "createList": "Create List",
+    "createFirstList": "Create Your First List",
+    "createVideoList": "Video list",
+    "createPeopleList": "People list"
+  },
+  "peopleListDetailPage": {
+    "editList": "Edit",
+    "delete": "Delete",
+    "share": "Share",
+    "deletedTitle": "People list deleted.",
+    "deletedDescription": "\"{{name}}\" has been removed.",
+    "deleteFailedTitle": "Delete failed.",
+    "deleteFailedDescription": "People list deletion hit a snag. Try again?"
   }
 }

--- a/src/lib/i18n/locales/ko/common.json
+++ b/src/lib/i18n/locales/ko/common.json
@@ -1431,5 +1431,69 @@
     "podcastEpisode": "팟캐스트 에피소드",
     "openInApplePodcasts": "Apple Podcasts에서 열기",
     "playEpisode": "에피소드 재생"
+  },
+  "createPeopleListDialog": {
+    "title": "Create People List",
+    "description": "Group people together and watch their latest loops in one place.",
+    "nameLabel": "List Name *",
+    "namePlaceholder": "Favorite Creators",
+    "descriptionLabel": "Description",
+    "descriptionPlaceholder": "People whose loops you never miss...",
+    "imageLabel": "Cover Image URL",
+    "imagePlaceholder": "https://example.com/image.jpg",
+    "nameRequired": "Name it first.",
+    "reservedName": "That name is reserved for a system list.",
+    "imageInvalid": "Use a full image URL.",
+    "cancelButton": "Cancel",
+    "creatingButton": "Creating...",
+    "createButton": "Create List",
+    "createdTitle": "People list created.",
+    "createdDescription": "\"{{name}}\" is ready.",
+    "failedTitle": "Didn't make it.",
+    "failedDescription": "People list creation hit a snag. Try again?"
+  },
+  "deleteListDialog": {
+    "title": "Delete List?",
+    "videosDescription": "This will permanently delete the list \"{{name}}\". Videos in the list will not be affected.",
+    "peopleDescription": "This will permanently delete the list \"{{name}}\". People in the list will not be affected.",
+    "noteLabel": "Note:",
+    "relayNote": "This action sends a deletion request to relays. Most relays will honor this request, but deletion is not guaranteed on all relays.",
+    "cancelButton": "Cancel",
+    "deletingButton": "Deleting...",
+    "deleteButton": "Delete List"
+  },
+  "editPeopleListDialog": {
+    "title": "Edit People List",
+    "description": "Update the name, description, or cover image for this list.",
+    "nameLabel": "List Name *",
+    "namePlaceholder": "Favorite Creators",
+    "descriptionLabel": "Description",
+    "descriptionPlaceholder": "People whose loops you never miss...",
+    "imageLabel": "Cover Image URL",
+    "imagePlaceholder": "https://example.com/image.jpg",
+    "nameRequired": "Name it first.",
+    "imageInvalid": "Use a full image URL.",
+    "cancelButton": "Cancel",
+    "savingButton": "Saving...",
+    "saveButton": "Save",
+    "savedTitle": "Saved.",
+    "savedDescription": "\"{{name}}\" is updated.",
+    "failedTitle": "Didn't save.",
+    "failedDescription": "People list updates hit a snag. Try again?"
+  },
+  "listsPage": {
+    "createList": "Create List",
+    "createFirstList": "Create Your First List",
+    "createVideoList": "Video list",
+    "createPeopleList": "People list"
+  },
+  "peopleListDetailPage": {
+    "editList": "Edit",
+    "delete": "Delete",
+    "share": "Share",
+    "deletedTitle": "People list deleted.",
+    "deletedDescription": "\"{{name}}\" has been removed.",
+    "deleteFailedTitle": "Delete failed.",
+    "deleteFailedDescription": "People list deletion hit a snag. Try again?"
   }
 }

--- a/src/lib/i18n/locales/ms/common.json
+++ b/src/lib/i18n/locales/ms/common.json
@@ -1431,5 +1431,69 @@
     "podcastEpisode": "Episod Podcast",
     "openInApplePodcasts": "Buka dalam Apple Podcasts",
     "playEpisode": "Mainkan Episod"
+  },
+  "createPeopleListDialog": {
+    "title": "Create People List",
+    "description": "Group people together and watch their latest loops in one place.",
+    "nameLabel": "List Name *",
+    "namePlaceholder": "Favorite Creators",
+    "descriptionLabel": "Description",
+    "descriptionPlaceholder": "People whose loops you never miss...",
+    "imageLabel": "Cover Image URL",
+    "imagePlaceholder": "https://example.com/image.jpg",
+    "nameRequired": "Name it first.",
+    "reservedName": "That name is reserved for a system list.",
+    "imageInvalid": "Use a full image URL.",
+    "cancelButton": "Cancel",
+    "creatingButton": "Creating...",
+    "createButton": "Create List",
+    "createdTitle": "People list created.",
+    "createdDescription": "\"{{name}}\" is ready.",
+    "failedTitle": "Didn't make it.",
+    "failedDescription": "People list creation hit a snag. Try again?"
+  },
+  "deleteListDialog": {
+    "title": "Delete List?",
+    "videosDescription": "This will permanently delete the list \"{{name}}\". Videos in the list will not be affected.",
+    "peopleDescription": "This will permanently delete the list \"{{name}}\". People in the list will not be affected.",
+    "noteLabel": "Note:",
+    "relayNote": "This action sends a deletion request to relays. Most relays will honor this request, but deletion is not guaranteed on all relays.",
+    "cancelButton": "Cancel",
+    "deletingButton": "Deleting...",
+    "deleteButton": "Delete List"
+  },
+  "editPeopleListDialog": {
+    "title": "Edit People List",
+    "description": "Update the name, description, or cover image for this list.",
+    "nameLabel": "List Name *",
+    "namePlaceholder": "Favorite Creators",
+    "descriptionLabel": "Description",
+    "descriptionPlaceholder": "People whose loops you never miss...",
+    "imageLabel": "Cover Image URL",
+    "imagePlaceholder": "https://example.com/image.jpg",
+    "nameRequired": "Name it first.",
+    "imageInvalid": "Use a full image URL.",
+    "cancelButton": "Cancel",
+    "savingButton": "Saving...",
+    "saveButton": "Save",
+    "savedTitle": "Saved.",
+    "savedDescription": "\"{{name}}\" is updated.",
+    "failedTitle": "Didn't save.",
+    "failedDescription": "People list updates hit a snag. Try again?"
+  },
+  "listsPage": {
+    "createList": "Create List",
+    "createFirstList": "Create Your First List",
+    "createVideoList": "Video list",
+    "createPeopleList": "People list"
+  },
+  "peopleListDetailPage": {
+    "editList": "Edit",
+    "delete": "Delete",
+    "share": "Share",
+    "deletedTitle": "People list deleted.",
+    "deletedDescription": "\"{{name}}\" has been removed.",
+    "deleteFailedTitle": "Delete failed.",
+    "deleteFailedDescription": "People list deletion hit a snag. Try again?"
   }
 }

--- a/src/lib/i18n/locales/nl/common.json
+++ b/src/lib/i18n/locales/nl/common.json
@@ -1431,5 +1431,69 @@
     "podcastEpisode": "Podcastaflevering",
     "openInApplePodcasts": "Openen in Apple Podcasts",
     "playEpisode": "Aflevering afspelen"
+  },
+  "createPeopleListDialog": {
+    "title": "Create People List",
+    "description": "Group people together and watch their latest loops in one place.",
+    "nameLabel": "List Name *",
+    "namePlaceholder": "Favorite Creators",
+    "descriptionLabel": "Description",
+    "descriptionPlaceholder": "People whose loops you never miss...",
+    "imageLabel": "Cover Image URL",
+    "imagePlaceholder": "https://example.com/image.jpg",
+    "nameRequired": "Name it first.",
+    "reservedName": "That name is reserved for a system list.",
+    "imageInvalid": "Use a full image URL.",
+    "cancelButton": "Cancel",
+    "creatingButton": "Creating...",
+    "createButton": "Create List",
+    "createdTitle": "People list created.",
+    "createdDescription": "\"{{name}}\" is ready.",
+    "failedTitle": "Didn't make it.",
+    "failedDescription": "People list creation hit a snag. Try again?"
+  },
+  "deleteListDialog": {
+    "title": "Delete List?",
+    "videosDescription": "This will permanently delete the list \"{{name}}\". Videos in the list will not be affected.",
+    "peopleDescription": "This will permanently delete the list \"{{name}}\". People in the list will not be affected.",
+    "noteLabel": "Note:",
+    "relayNote": "This action sends a deletion request to relays. Most relays will honor this request, but deletion is not guaranteed on all relays.",
+    "cancelButton": "Cancel",
+    "deletingButton": "Deleting...",
+    "deleteButton": "Delete List"
+  },
+  "editPeopleListDialog": {
+    "title": "Edit People List",
+    "description": "Update the name, description, or cover image for this list.",
+    "nameLabel": "List Name *",
+    "namePlaceholder": "Favorite Creators",
+    "descriptionLabel": "Description",
+    "descriptionPlaceholder": "People whose loops you never miss...",
+    "imageLabel": "Cover Image URL",
+    "imagePlaceholder": "https://example.com/image.jpg",
+    "nameRequired": "Name it first.",
+    "imageInvalid": "Use a full image URL.",
+    "cancelButton": "Cancel",
+    "savingButton": "Saving...",
+    "saveButton": "Save",
+    "savedTitle": "Saved.",
+    "savedDescription": "\"{{name}}\" is updated.",
+    "failedTitle": "Didn't save.",
+    "failedDescription": "People list updates hit a snag. Try again?"
+  },
+  "listsPage": {
+    "createList": "Create List",
+    "createFirstList": "Create Your First List",
+    "createVideoList": "Video list",
+    "createPeopleList": "People list"
+  },
+  "peopleListDetailPage": {
+    "editList": "Edit",
+    "delete": "Delete",
+    "share": "Share",
+    "deletedTitle": "People list deleted.",
+    "deletedDescription": "\"{{name}}\" has been removed.",
+    "deleteFailedTitle": "Delete failed.",
+    "deleteFailedDescription": "People list deletion hit a snag. Try again?"
   }
 }

--- a/src/lib/i18n/locales/pl/common.json
+++ b/src/lib/i18n/locales/pl/common.json
@@ -1433,5 +1433,69 @@
     "podcastEpisode": "Odcinek podcastu",
     "openInApplePodcasts": "Otwórz w Apple Podcasts",
     "playEpisode": "Odtwórz odcinek"
+  },
+  "createPeopleListDialog": {
+    "title": "Create People List",
+    "description": "Group people together and watch their latest loops in one place.",
+    "nameLabel": "List Name *",
+    "namePlaceholder": "Favorite Creators",
+    "descriptionLabel": "Description",
+    "descriptionPlaceholder": "People whose loops you never miss...",
+    "imageLabel": "Cover Image URL",
+    "imagePlaceholder": "https://example.com/image.jpg",
+    "nameRequired": "Name it first.",
+    "reservedName": "That name is reserved for a system list.",
+    "imageInvalid": "Use a full image URL.",
+    "cancelButton": "Cancel",
+    "creatingButton": "Creating...",
+    "createButton": "Create List",
+    "createdTitle": "People list created.",
+    "createdDescription": "\"{{name}}\" is ready.",
+    "failedTitle": "Didn't make it.",
+    "failedDescription": "People list creation hit a snag. Try again?"
+  },
+  "deleteListDialog": {
+    "title": "Delete List?",
+    "videosDescription": "This will permanently delete the list \"{{name}}\". Videos in the list will not be affected.",
+    "peopleDescription": "This will permanently delete the list \"{{name}}\". People in the list will not be affected.",
+    "noteLabel": "Note:",
+    "relayNote": "This action sends a deletion request to relays. Most relays will honor this request, but deletion is not guaranteed on all relays.",
+    "cancelButton": "Cancel",
+    "deletingButton": "Deleting...",
+    "deleteButton": "Delete List"
+  },
+  "editPeopleListDialog": {
+    "title": "Edit People List",
+    "description": "Update the name, description, or cover image for this list.",
+    "nameLabel": "List Name *",
+    "namePlaceholder": "Favorite Creators",
+    "descriptionLabel": "Description",
+    "descriptionPlaceholder": "People whose loops you never miss...",
+    "imageLabel": "Cover Image URL",
+    "imagePlaceholder": "https://example.com/image.jpg",
+    "nameRequired": "Name it first.",
+    "imageInvalid": "Use a full image URL.",
+    "cancelButton": "Cancel",
+    "savingButton": "Saving...",
+    "saveButton": "Save",
+    "savedTitle": "Saved.",
+    "savedDescription": "\"{{name}}\" is updated.",
+    "failedTitle": "Didn't save.",
+    "failedDescription": "People list updates hit a snag. Try again?"
+  },
+  "listsPage": {
+    "createList": "Create List",
+    "createFirstList": "Create Your First List",
+    "createVideoList": "Video list",
+    "createPeopleList": "People list"
+  },
+  "peopleListDetailPage": {
+    "editList": "Edit",
+    "delete": "Delete",
+    "share": "Share",
+    "deletedTitle": "People list deleted.",
+    "deletedDescription": "\"{{name}}\" has been removed.",
+    "deleteFailedTitle": "Delete failed.",
+    "deleteFailedDescription": "People list deletion hit a snag. Try again?"
   }
 }

--- a/src/lib/i18n/locales/pt/common.json
+++ b/src/lib/i18n/locales/pt/common.json
@@ -1432,5 +1432,69 @@
     "podcastEpisode": "Episódio do podcast",
     "openInApplePodcasts": "Abrir no Apple Podcasts",
     "playEpisode": "Tocar episódio"
+  },
+  "createPeopleListDialog": {
+    "title": "Create People List",
+    "description": "Group people together and watch their latest loops in one place.",
+    "nameLabel": "List Name *",
+    "namePlaceholder": "Favorite Creators",
+    "descriptionLabel": "Description",
+    "descriptionPlaceholder": "People whose loops you never miss...",
+    "imageLabel": "Cover Image URL",
+    "imagePlaceholder": "https://example.com/image.jpg",
+    "nameRequired": "Name it first.",
+    "reservedName": "That name is reserved for a system list.",
+    "imageInvalid": "Use a full image URL.",
+    "cancelButton": "Cancel",
+    "creatingButton": "Creating...",
+    "createButton": "Create List",
+    "createdTitle": "People list created.",
+    "createdDescription": "\"{{name}}\" is ready.",
+    "failedTitle": "Didn't make it.",
+    "failedDescription": "People list creation hit a snag. Try again?"
+  },
+  "deleteListDialog": {
+    "title": "Delete List?",
+    "videosDescription": "This will permanently delete the list \"{{name}}\". Videos in the list will not be affected.",
+    "peopleDescription": "This will permanently delete the list \"{{name}}\". People in the list will not be affected.",
+    "noteLabel": "Note:",
+    "relayNote": "This action sends a deletion request to relays. Most relays will honor this request, but deletion is not guaranteed on all relays.",
+    "cancelButton": "Cancel",
+    "deletingButton": "Deleting...",
+    "deleteButton": "Delete List"
+  },
+  "editPeopleListDialog": {
+    "title": "Edit People List",
+    "description": "Update the name, description, or cover image for this list.",
+    "nameLabel": "List Name *",
+    "namePlaceholder": "Favorite Creators",
+    "descriptionLabel": "Description",
+    "descriptionPlaceholder": "People whose loops you never miss...",
+    "imageLabel": "Cover Image URL",
+    "imagePlaceholder": "https://example.com/image.jpg",
+    "nameRequired": "Name it first.",
+    "imageInvalid": "Use a full image URL.",
+    "cancelButton": "Cancel",
+    "savingButton": "Saving...",
+    "saveButton": "Save",
+    "savedTitle": "Saved.",
+    "savedDescription": "\"{{name}}\" is updated.",
+    "failedTitle": "Didn't save.",
+    "failedDescription": "People list updates hit a snag. Try again?"
+  },
+  "listsPage": {
+    "createList": "Create List",
+    "createFirstList": "Create Your First List",
+    "createVideoList": "Video list",
+    "createPeopleList": "People list"
+  },
+  "peopleListDetailPage": {
+    "editList": "Edit",
+    "delete": "Delete",
+    "share": "Share",
+    "deletedTitle": "People list deleted.",
+    "deletedDescription": "\"{{name}}\" has been removed.",
+    "deleteFailedTitle": "Delete failed.",
+    "deleteFailedDescription": "People list deletion hit a snag. Try again?"
   }
 }

--- a/src/lib/i18n/locales/ro/common.json
+++ b/src/lib/i18n/locales/ro/common.json
@@ -1432,5 +1432,69 @@
     "podcastEpisode": "Episod de podcast",
     "openInApplePodcasts": "Deschide în Apple Podcasts",
     "playEpisode": "Redă episodul"
+  },
+  "createPeopleListDialog": {
+    "title": "Create People List",
+    "description": "Group people together and watch their latest loops in one place.",
+    "nameLabel": "List Name *",
+    "namePlaceholder": "Favorite Creators",
+    "descriptionLabel": "Description",
+    "descriptionPlaceholder": "People whose loops you never miss...",
+    "imageLabel": "Cover Image URL",
+    "imagePlaceholder": "https://example.com/image.jpg",
+    "nameRequired": "Name it first.",
+    "reservedName": "That name is reserved for a system list.",
+    "imageInvalid": "Use a full image URL.",
+    "cancelButton": "Cancel",
+    "creatingButton": "Creating...",
+    "createButton": "Create List",
+    "createdTitle": "People list created.",
+    "createdDescription": "\"{{name}}\" is ready.",
+    "failedTitle": "Didn't make it.",
+    "failedDescription": "People list creation hit a snag. Try again?"
+  },
+  "deleteListDialog": {
+    "title": "Delete List?",
+    "videosDescription": "This will permanently delete the list \"{{name}}\". Videos in the list will not be affected.",
+    "peopleDescription": "This will permanently delete the list \"{{name}}\". People in the list will not be affected.",
+    "noteLabel": "Note:",
+    "relayNote": "This action sends a deletion request to relays. Most relays will honor this request, but deletion is not guaranteed on all relays.",
+    "cancelButton": "Cancel",
+    "deletingButton": "Deleting...",
+    "deleteButton": "Delete List"
+  },
+  "editPeopleListDialog": {
+    "title": "Edit People List",
+    "description": "Update the name, description, or cover image for this list.",
+    "nameLabel": "List Name *",
+    "namePlaceholder": "Favorite Creators",
+    "descriptionLabel": "Description",
+    "descriptionPlaceholder": "People whose loops you never miss...",
+    "imageLabel": "Cover Image URL",
+    "imagePlaceholder": "https://example.com/image.jpg",
+    "nameRequired": "Name it first.",
+    "imageInvalid": "Use a full image URL.",
+    "cancelButton": "Cancel",
+    "savingButton": "Saving...",
+    "saveButton": "Save",
+    "savedTitle": "Saved.",
+    "savedDescription": "\"{{name}}\" is updated.",
+    "failedTitle": "Didn't save.",
+    "failedDescription": "People list updates hit a snag. Try again?"
+  },
+  "listsPage": {
+    "createList": "Create List",
+    "createFirstList": "Create Your First List",
+    "createVideoList": "Video list",
+    "createPeopleList": "People list"
+  },
+  "peopleListDetailPage": {
+    "editList": "Edit",
+    "delete": "Delete",
+    "share": "Share",
+    "deletedTitle": "People list deleted.",
+    "deletedDescription": "\"{{name}}\" has been removed.",
+    "deleteFailedTitle": "Delete failed.",
+    "deleteFailedDescription": "People list deletion hit a snag. Try again?"
   }
 }

--- a/src/lib/i18n/locales/sv/common.json
+++ b/src/lib/i18n/locales/sv/common.json
@@ -1431,5 +1431,69 @@
     "podcastEpisode": "Podcast-avsnitt",
     "openInApplePodcasts": "Öppna i Apple Podcasts",
     "playEpisode": "Spela avsnitt"
+  },
+  "createPeopleListDialog": {
+    "title": "Create People List",
+    "description": "Group people together and watch their latest loops in one place.",
+    "nameLabel": "List Name *",
+    "namePlaceholder": "Favorite Creators",
+    "descriptionLabel": "Description",
+    "descriptionPlaceholder": "People whose loops you never miss...",
+    "imageLabel": "Cover Image URL",
+    "imagePlaceholder": "https://example.com/image.jpg",
+    "nameRequired": "Name it first.",
+    "reservedName": "That name is reserved for a system list.",
+    "imageInvalid": "Use a full image URL.",
+    "cancelButton": "Cancel",
+    "creatingButton": "Creating...",
+    "createButton": "Create List",
+    "createdTitle": "People list created.",
+    "createdDescription": "\"{{name}}\" is ready.",
+    "failedTitle": "Didn't make it.",
+    "failedDescription": "People list creation hit a snag. Try again?"
+  },
+  "deleteListDialog": {
+    "title": "Delete List?",
+    "videosDescription": "This will permanently delete the list \"{{name}}\". Videos in the list will not be affected.",
+    "peopleDescription": "This will permanently delete the list \"{{name}}\". People in the list will not be affected.",
+    "noteLabel": "Note:",
+    "relayNote": "This action sends a deletion request to relays. Most relays will honor this request, but deletion is not guaranteed on all relays.",
+    "cancelButton": "Cancel",
+    "deletingButton": "Deleting...",
+    "deleteButton": "Delete List"
+  },
+  "editPeopleListDialog": {
+    "title": "Edit People List",
+    "description": "Update the name, description, or cover image for this list.",
+    "nameLabel": "List Name *",
+    "namePlaceholder": "Favorite Creators",
+    "descriptionLabel": "Description",
+    "descriptionPlaceholder": "People whose loops you never miss...",
+    "imageLabel": "Cover Image URL",
+    "imagePlaceholder": "https://example.com/image.jpg",
+    "nameRequired": "Name it first.",
+    "imageInvalid": "Use a full image URL.",
+    "cancelButton": "Cancel",
+    "savingButton": "Saving...",
+    "saveButton": "Save",
+    "savedTitle": "Saved.",
+    "savedDescription": "\"{{name}}\" is updated.",
+    "failedTitle": "Didn't save.",
+    "failedDescription": "People list updates hit a snag. Try again?"
+  },
+  "listsPage": {
+    "createList": "Create List",
+    "createFirstList": "Create Your First List",
+    "createVideoList": "Video list",
+    "createPeopleList": "People list"
+  },
+  "peopleListDetailPage": {
+    "editList": "Edit",
+    "delete": "Delete",
+    "share": "Share",
+    "deletedTitle": "People list deleted.",
+    "deletedDescription": "\"{{name}}\" has been removed.",
+    "deleteFailedTitle": "Delete failed.",
+    "deleteFailedDescription": "People list deletion hit a snag. Try again?"
   }
 }

--- a/src/lib/i18n/locales/tr/common.json
+++ b/src/lib/i18n/locales/tr/common.json
@@ -1431,5 +1431,69 @@
     "podcastEpisode": "Podcast Bölümü",
     "openInApplePodcasts": "Apple Podcasts'te aç",
     "playEpisode": "Bölümü oynat"
+  },
+  "createPeopleListDialog": {
+    "title": "Create People List",
+    "description": "Group people together and watch their latest loops in one place.",
+    "nameLabel": "List Name *",
+    "namePlaceholder": "Favorite Creators",
+    "descriptionLabel": "Description",
+    "descriptionPlaceholder": "People whose loops you never miss...",
+    "imageLabel": "Cover Image URL",
+    "imagePlaceholder": "https://example.com/image.jpg",
+    "nameRequired": "Name it first.",
+    "reservedName": "That name is reserved for a system list.",
+    "imageInvalid": "Use a full image URL.",
+    "cancelButton": "Cancel",
+    "creatingButton": "Creating...",
+    "createButton": "Create List",
+    "createdTitle": "People list created.",
+    "createdDescription": "\"{{name}}\" is ready.",
+    "failedTitle": "Didn't make it.",
+    "failedDescription": "People list creation hit a snag. Try again?"
+  },
+  "deleteListDialog": {
+    "title": "Delete List?",
+    "videosDescription": "This will permanently delete the list \"{{name}}\". Videos in the list will not be affected.",
+    "peopleDescription": "This will permanently delete the list \"{{name}}\". People in the list will not be affected.",
+    "noteLabel": "Note:",
+    "relayNote": "This action sends a deletion request to relays. Most relays will honor this request, but deletion is not guaranteed on all relays.",
+    "cancelButton": "Cancel",
+    "deletingButton": "Deleting...",
+    "deleteButton": "Delete List"
+  },
+  "editPeopleListDialog": {
+    "title": "Edit People List",
+    "description": "Update the name, description, or cover image for this list.",
+    "nameLabel": "List Name *",
+    "namePlaceholder": "Favorite Creators",
+    "descriptionLabel": "Description",
+    "descriptionPlaceholder": "People whose loops you never miss...",
+    "imageLabel": "Cover Image URL",
+    "imagePlaceholder": "https://example.com/image.jpg",
+    "nameRequired": "Name it first.",
+    "imageInvalid": "Use a full image URL.",
+    "cancelButton": "Cancel",
+    "savingButton": "Saving...",
+    "saveButton": "Save",
+    "savedTitle": "Saved.",
+    "savedDescription": "\"{{name}}\" is updated.",
+    "failedTitle": "Didn't save.",
+    "failedDescription": "People list updates hit a snag. Try again?"
+  },
+  "listsPage": {
+    "createList": "Create List",
+    "createFirstList": "Create Your First List",
+    "createVideoList": "Video list",
+    "createPeopleList": "People list"
+  },
+  "peopleListDetailPage": {
+    "editList": "Edit",
+    "delete": "Delete",
+    "share": "Share",
+    "deletedTitle": "People list deleted.",
+    "deletedDescription": "\"{{name}}\" has been removed.",
+    "deleteFailedTitle": "Delete failed.",
+    "deleteFailedDescription": "People list deletion hit a snag. Try again?"
   }
 }

--- a/src/lib/i18n/locales/ur/common.json
+++ b/src/lib/i18n/locales/ur/common.json
@@ -1431,5 +1431,69 @@
     "podcastEpisode": "پوڈکاسٹ قسط",
     "openInApplePodcasts": "Apple Podcasts میں کھولیں",
     "playEpisode": "قسط چلائیں"
+  },
+  "createPeopleListDialog": {
+    "title": "Create People List",
+    "description": "Group people together and watch their latest loops in one place.",
+    "nameLabel": "List Name *",
+    "namePlaceholder": "Favorite Creators",
+    "descriptionLabel": "Description",
+    "descriptionPlaceholder": "People whose loops you never miss...",
+    "imageLabel": "Cover Image URL",
+    "imagePlaceholder": "https://example.com/image.jpg",
+    "nameRequired": "Name it first.",
+    "reservedName": "That name is reserved for a system list.",
+    "imageInvalid": "Use a full image URL.",
+    "cancelButton": "Cancel",
+    "creatingButton": "Creating...",
+    "createButton": "Create List",
+    "createdTitle": "People list created.",
+    "createdDescription": "\"{{name}}\" is ready.",
+    "failedTitle": "Didn't make it.",
+    "failedDescription": "People list creation hit a snag. Try again?"
+  },
+  "deleteListDialog": {
+    "title": "Delete List?",
+    "videosDescription": "This will permanently delete the list \"{{name}}\". Videos in the list will not be affected.",
+    "peopleDescription": "This will permanently delete the list \"{{name}}\". People in the list will not be affected.",
+    "noteLabel": "Note:",
+    "relayNote": "This action sends a deletion request to relays. Most relays will honor this request, but deletion is not guaranteed on all relays.",
+    "cancelButton": "Cancel",
+    "deletingButton": "Deleting...",
+    "deleteButton": "Delete List"
+  },
+  "editPeopleListDialog": {
+    "title": "Edit People List",
+    "description": "Update the name, description, or cover image for this list.",
+    "nameLabel": "List Name *",
+    "namePlaceholder": "Favorite Creators",
+    "descriptionLabel": "Description",
+    "descriptionPlaceholder": "People whose loops you never miss...",
+    "imageLabel": "Cover Image URL",
+    "imagePlaceholder": "https://example.com/image.jpg",
+    "nameRequired": "Name it first.",
+    "imageInvalid": "Use a full image URL.",
+    "cancelButton": "Cancel",
+    "savingButton": "Saving...",
+    "saveButton": "Save",
+    "savedTitle": "Saved.",
+    "savedDescription": "\"{{name}}\" is updated.",
+    "failedTitle": "Didn't save.",
+    "failedDescription": "People list updates hit a snag. Try again?"
+  },
+  "listsPage": {
+    "createList": "Create List",
+    "createFirstList": "Create Your First List",
+    "createVideoList": "Video list",
+    "createPeopleList": "People list"
+  },
+  "peopleListDetailPage": {
+    "editList": "Edit",
+    "delete": "Delete",
+    "share": "Share",
+    "deletedTitle": "People list deleted.",
+    "deletedDescription": "\"{{name}}\" has been removed.",
+    "deleteFailedTitle": "Delete failed.",
+    "deleteFailedDescription": "People list deletion hit a snag. Try again?"
   }
 }

--- a/src/lib/i18n/locales/vi/common.json
+++ b/src/lib/i18n/locales/vi/common.json
@@ -1431,5 +1431,69 @@
     "podcastEpisode": "Tập podcast",
     "openInApplePodcasts": "Mở trong Apple Podcasts",
     "playEpisode": "Phát tập"
+  },
+  "createPeopleListDialog": {
+    "title": "Create People List",
+    "description": "Group people together and watch their latest loops in one place.",
+    "nameLabel": "List Name *",
+    "namePlaceholder": "Favorite Creators",
+    "descriptionLabel": "Description",
+    "descriptionPlaceholder": "People whose loops you never miss...",
+    "imageLabel": "Cover Image URL",
+    "imagePlaceholder": "https://example.com/image.jpg",
+    "nameRequired": "Name it first.",
+    "reservedName": "That name is reserved for a system list.",
+    "imageInvalid": "Use a full image URL.",
+    "cancelButton": "Cancel",
+    "creatingButton": "Creating...",
+    "createButton": "Create List",
+    "createdTitle": "People list created.",
+    "createdDescription": "\"{{name}}\" is ready.",
+    "failedTitle": "Didn't make it.",
+    "failedDescription": "People list creation hit a snag. Try again?"
+  },
+  "deleteListDialog": {
+    "title": "Delete List?",
+    "videosDescription": "This will permanently delete the list \"{{name}}\". Videos in the list will not be affected.",
+    "peopleDescription": "This will permanently delete the list \"{{name}}\". People in the list will not be affected.",
+    "noteLabel": "Note:",
+    "relayNote": "This action sends a deletion request to relays. Most relays will honor this request, but deletion is not guaranteed on all relays.",
+    "cancelButton": "Cancel",
+    "deletingButton": "Deleting...",
+    "deleteButton": "Delete List"
+  },
+  "editPeopleListDialog": {
+    "title": "Edit People List",
+    "description": "Update the name, description, or cover image for this list.",
+    "nameLabel": "List Name *",
+    "namePlaceholder": "Favorite Creators",
+    "descriptionLabel": "Description",
+    "descriptionPlaceholder": "People whose loops you never miss...",
+    "imageLabel": "Cover Image URL",
+    "imagePlaceholder": "https://example.com/image.jpg",
+    "nameRequired": "Name it first.",
+    "imageInvalid": "Use a full image URL.",
+    "cancelButton": "Cancel",
+    "savingButton": "Saving...",
+    "saveButton": "Save",
+    "savedTitle": "Saved.",
+    "savedDescription": "\"{{name}}\" is updated.",
+    "failedTitle": "Didn't save.",
+    "failedDescription": "People list updates hit a snag. Try again?"
+  },
+  "listsPage": {
+    "createList": "Create List",
+    "createFirstList": "Create Your First List",
+    "createVideoList": "Video list",
+    "createPeopleList": "People list"
+  },
+  "peopleListDetailPage": {
+    "editList": "Edit",
+    "delete": "Delete",
+    "share": "Share",
+    "deletedTitle": "People list deleted.",
+    "deletedDescription": "\"{{name}}\" has been removed.",
+    "deleteFailedTitle": "Delete failed.",
+    "deleteFailedDescription": "People list deletion hit a snag. Try again?"
   }
 }

--- a/src/lib/i18n/locales/zh/common.json
+++ b/src/lib/i18n/locales/zh/common.json
@@ -1431,5 +1431,69 @@
     "podcastEpisode": "播客单集",
     "openInApplePodcasts": "在 Apple 播客中打开",
     "playEpisode": "播放单集"
+  },
+  "createPeopleListDialog": {
+    "title": "Create People List",
+    "description": "Group people together and watch their latest loops in one place.",
+    "nameLabel": "List Name *",
+    "namePlaceholder": "Favorite Creators",
+    "descriptionLabel": "Description",
+    "descriptionPlaceholder": "People whose loops you never miss...",
+    "imageLabel": "Cover Image URL",
+    "imagePlaceholder": "https://example.com/image.jpg",
+    "nameRequired": "Name it first.",
+    "reservedName": "That name is reserved for a system list.",
+    "imageInvalid": "Use a full image URL.",
+    "cancelButton": "Cancel",
+    "creatingButton": "Creating...",
+    "createButton": "Create List",
+    "createdTitle": "People list created.",
+    "createdDescription": "\"{{name}}\" is ready.",
+    "failedTitle": "Didn't make it.",
+    "failedDescription": "People list creation hit a snag. Try again?"
+  },
+  "deleteListDialog": {
+    "title": "Delete List?",
+    "videosDescription": "This will permanently delete the list \"{{name}}\". Videos in the list will not be affected.",
+    "peopleDescription": "This will permanently delete the list \"{{name}}\". People in the list will not be affected.",
+    "noteLabel": "Note:",
+    "relayNote": "This action sends a deletion request to relays. Most relays will honor this request, but deletion is not guaranteed on all relays.",
+    "cancelButton": "Cancel",
+    "deletingButton": "Deleting...",
+    "deleteButton": "Delete List"
+  },
+  "editPeopleListDialog": {
+    "title": "Edit People List",
+    "description": "Update the name, description, or cover image for this list.",
+    "nameLabel": "List Name *",
+    "namePlaceholder": "Favorite Creators",
+    "descriptionLabel": "Description",
+    "descriptionPlaceholder": "People whose loops you never miss...",
+    "imageLabel": "Cover Image URL",
+    "imagePlaceholder": "https://example.com/image.jpg",
+    "nameRequired": "Name it first.",
+    "imageInvalid": "Use a full image URL.",
+    "cancelButton": "Cancel",
+    "savingButton": "Saving...",
+    "saveButton": "Save",
+    "savedTitle": "Saved.",
+    "savedDescription": "\"{{name}}\" is updated.",
+    "failedTitle": "Didn't save.",
+    "failedDescription": "People list updates hit a snag. Try again?"
+  },
+  "listsPage": {
+    "createList": "Create List",
+    "createFirstList": "Create Your First List",
+    "createVideoList": "Video list",
+    "createPeopleList": "People list"
+  },
+  "peopleListDetailPage": {
+    "editList": "Edit",
+    "delete": "Delete",
+    "share": "Share",
+    "deletedTitle": "People list deleted.",
+    "deletedDescription": "\"{{name}}\" has been removed.",
+    "deleteFailedTitle": "Delete failed.",
+    "deleteFailedDescription": "People list deletion hit a snag. Try again?"
   }
 }

--- a/src/lib/parsePeopleListFromEvent.ts
+++ b/src/lib/parsePeopleListFromEvent.ts
@@ -1,6 +1,7 @@
 // ABOUTME: Parses public NIP-51 kind 30000 follow sets into discoverable people lists
 
 import type { NostrEvent } from '@nostrify/nostrify';
+import { isReservedPeopleListDTag, PEOPLE_LIST_KIND } from '@/lib/peopleListConstants';
 
 export interface PeopleList {
   id: string;
@@ -13,14 +14,14 @@ export interface PeopleList {
 }
 
 export function peopleListAddress(list: PeopleList): string {
-  return `${list.pubkey}:30000:${list.id}`;
+  return `${list.pubkey}:${PEOPLE_LIST_KIND}:${list.id}`;
 }
 
 export function parsePeopleListFromEvent(event: NostrEvent): PeopleList | null {
-  if (event.kind !== 30000) return null;
+  if (event.kind !== PEOPLE_LIST_KIND) return null;
 
   const id = event.tags.find((tag) => tag[0] === 'd')?.[1];
-  if (!id || id === 'block') return null;
+  if (!id || isReservedPeopleListDTag(id)) return null;
 
   const memberPubkeys = Array.from(new Set(
     event.tags

--- a/src/lib/peopleListConstants.ts
+++ b/src/lib/peopleListConstants.ts
@@ -1,0 +1,11 @@
+export const PEOPLE_LIST_KIND = 30000;
+
+export const RESERVED_PEOPLE_LIST_D_TAGS = ['block'] as const;
+
+export function isReservedPeopleListDTag(dTag: string): boolean {
+  return RESERVED_PEOPLE_LIST_D_TAGS.includes(dTag as typeof RESERVED_PEOPLE_LIST_D_TAGS[number]);
+}
+
+export function slugifyPeopleListName(name: string): string {
+  return name.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '');
+}

--- a/src/lib/peopleListVideos.ts
+++ b/src/lib/peopleListVideos.ts
@@ -4,7 +4,15 @@ import type { NostrEvent, NostrFilter } from '@nostrify/nostrify';
 import { VIDEO_KINDS } from '@/types/video';
 
 const AUTHORS_PER_FILTER = 100;
+export const PEOPLE_LIST_VIDEO_RELAY_LIMIT = 60;
 export const PEOPLE_LIST_VIDEO_PAGE_SIZE = 60;
+
+export function peopleListVideoAddress(event: NostrEvent): string | undefined {
+  const dTag = event.tags.find((tag) => tag[0] === 'd')?.[1];
+  if (!dTag) return undefined;
+
+  return `${event.pubkey}:${event.kind}:${dTag}`;
+}
 
 export function buildPeopleListVideoFilters(
   pubkeys: string[],
@@ -17,7 +25,7 @@ export function buildPeopleListVideoFilters(
     filters.push({
       kinds: VIDEO_KINDS,
       authors: uniquePubkeys.slice(index, index + AUTHORS_PER_FILTER),
-      limit: PEOPLE_LIST_VIDEO_PAGE_SIZE,
+      limit: PEOPLE_LIST_VIDEO_RELAY_LIMIT,
       ...(until !== undefined ? { until } : {}),
     });
   }
@@ -32,10 +40,8 @@ export function mergePeopleListVideoEvents(events: NostrEvent[]): NostrEvent[] {
     .filter((event) => VIDEO_KINDS.includes(event.kind))
     .sort((a, b) => b.created_at - a.created_at)
     .forEach((event) => {
-      const dTag = event.tags.find((tag) => tag[0] === 'd')?.[1];
-      if (!dTag) return;
-
-      const address = `${event.pubkey}:${event.kind}:${dTag}`;
+      const address = peopleListVideoAddress(event);
+      if (!address) return;
       if (!newestByAddress.has(address)) {
         newestByAddress.set(address, event);
       }

--- a/src/lib/profileLists.test.ts
+++ b/src/lib/profileLists.test.ts
@@ -8,6 +8,7 @@ import {
   toDiscoverablePeopleList,
   toDiscoverableVideoList,
 } from './profileLists';
+import { buildListPath } from './eventRouting';
 
 const OWNER = 'a'.repeat(64);
 
@@ -34,7 +35,7 @@ describe('profile list presentation', () => {
       key: `30000:${OWNER}:friends`,
       type: 'people',
       itemCount: 2,
-      href: `/people-lists/${OWNER}/friends`,
+      href: buildListPath(OWNER, 'friends'),
     });
   });
 
@@ -43,7 +44,7 @@ describe('profile list presentation', () => {
       key: `30005:${OWNER}:favorites`,
       type: 'videos',
       itemCount: 1,
-      href: `/list/${OWNER}/favorites`,
+      href: buildListPath(OWNER, 'favorites'),
     });
   });
 

--- a/src/lib/profileLists.ts
+++ b/src/lib/profileLists.ts
@@ -2,6 +2,7 @@
 
 import type { PeopleList } from '@/lib/parsePeopleListFromEvent';
 import type { VideoList } from '@/lib/parseVideoListFromEvent';
+import { buildListPath } from '@/lib/eventRouting';
 
 export interface DiscoverableList {
   key: string;
@@ -27,7 +28,7 @@ export function toDiscoverablePeopleList(list: PeopleList): DiscoverableList {
     ownerPubkey: list.pubkey,
     createdAt: list.createdAt,
     itemCount: list.memberPubkeys.length,
-    href: `/people-lists/${list.pubkey}/${encodeURIComponent(list.id)}`,
+    href: buildListPath(list.pubkey, list.id),
   };
 }
 
@@ -42,7 +43,7 @@ export function toDiscoverableVideoList(list: VideoList): DiscoverableList {
     ownerPubkey: list.pubkey,
     createdAt: list.createdAt,
     itemCount: list.videoCoordinates.length,
-    href: `/list/${list.pubkey}/${encodeURIComponent(list.id)}`,
+    href: buildListPath(list.pubkey, list.id),
   };
 }
 

--- a/src/lib/shareUtils.test.ts
+++ b/src/lib/shareUtils.test.ts
@@ -9,7 +9,14 @@ vi.mock('@/lib/subdomainLinks', () => ({
   getApexShareUrl: (path: string) => `https://divine.video${path}`,
 }));
 
-import { getVideoShareUrl, getVideoShareData, getListShareUrl, getListShareData } from './shareUtils';
+import {
+  getVideoShareUrl,
+  getVideoShareData,
+  getListShareUrl,
+  getListShareData,
+  getPeopleListShareUrl,
+  getPeopleListShareData,
+} from './shareUtils';
 
 function makeVideo(overrides: Partial<ParsedVideoData> = {}): ParsedVideoData {
   return {
@@ -69,6 +76,24 @@ describe('getListShareData', () => {
     const data = getListShareData('pubkey-abc', 'my-list');
     expect(data).toEqual({
       url: 'https://divine.video/list/pubkey-abc/my-list',
+    });
+    expect(data).not.toHaveProperty('title');
+    expect(data).not.toHaveProperty('text');
+  });
+});
+
+describe('getPeopleListShareUrl', () => {
+  it('builds the people-list URL with pubkey and encoded listId', () => {
+    const url = getPeopleListShareUrl('pubkey-abc', 'close friends');
+    expect(url).toBe('https://divine.video/people-lists/pubkey-abc/close%20friends');
+  });
+});
+
+describe('getPeopleListShareData', () => {
+  it('returns only URL (no title/text)', () => {
+    const data = getPeopleListShareData('pubkey-abc', 'my-list');
+    expect(data).toEqual({
+      url: 'https://divine.video/people-lists/pubkey-abc/my-list',
     });
     expect(data).not.toHaveProperty('title');
     expect(data).not.toHaveProperty('text');

--- a/src/lib/shareUtils.ts
+++ b/src/lib/shareUtils.ts
@@ -2,6 +2,7 @@
 // ABOUTME: Single source of truth for all share link construction across the app
 
 import { getApexShareUrl } from '@/lib/subdomainLinks';
+import { buildListPath } from '@/lib/eventRouting';
 import type { ParsedVideoData } from '@/types/video';
 
 /** Build a shareable video URL (always apex domain, stable d-tag ID). */
@@ -20,7 +21,12 @@ export function getVideoShareData(video: ParsedVideoData): { url: string } {
 
 /** Build a shareable list URL (always apex domain). */
 export function getListShareUrl(pubkey: string, listId: string): string {
-  return getApexShareUrl(`/list/${pubkey}/${listId}`);
+  return getApexShareUrl(buildListPath(pubkey, listId));
+}
+
+/** Build a shareable people-list URL (always apex domain). */
+export function getPeopleListShareUrl(pubkey: string, listId: string): string {
+  return getApexShareUrl(`/people-lists/${pubkey}/${encodeURIComponent(listId)}`);
 }
 
 /** Build shareable data for a list (URL only — matches video share behavior). */
@@ -30,5 +36,15 @@ export function getListShareData(
 ): { url: string } {
   return {
     url: getListShareUrl(pubkey, listId),
+  };
+}
+
+/** Build shareable data for a people list (URL only — matches video share behavior). */
+export function getPeopleListShareData(
+  pubkey: string,
+  listId: string,
+): { url: string } {
+  return {
+    url: getPeopleListShareUrl(pubkey, listId),
   };
 }

--- a/src/pages/EventPage.test.tsx
+++ b/src/pages/EventPage.test.tsx
@@ -171,6 +171,23 @@ describe('EventPage', () => {
     expect(await screen.findByTestId('list-page')).toBeInTheDocument();
   });
 
+  it('redirects people lists to the shared list page', async () => {
+    const pubkey = 'a'.repeat(64);
+    mockFetchEventById.mockResolvedValue({
+      id: 'c'.repeat(64),
+      pubkey,
+      created_at: 1_700_000_000,
+      kind: 30000,
+      tags: [['d', 'friends']],
+      content: '',
+      sig: '1'.repeat(128),
+    });
+
+    renderPage([`/event/${'c'.repeat(64)}`]);
+
+    expect(await screen.findByTestId('list-page')).toBeInTheDocument();
+  });
+
   it('shows generic list-style events with reference links and raw json', async () => {
     const authorPubkey = 'c'.repeat(64);
     const referencedPubkey = 'd'.repeat(64);

--- a/src/pages/ListDetailPage.test.tsx
+++ b/src/pages/ListDetailPage.test.tsx
@@ -1,0 +1,151 @@
+import { render, screen } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { NostrEvent } from '@nostrify/nostrify';
+
+import ListDetailPage from './ListDetailPage';
+
+const OWNER = 'a'.repeat(64);
+const COLLABORATOR = 'b'.repeat(64);
+const OUTSIDER = 'c'.repeat(64);
+const { mockCurrentUser, mockQuery } = vi.hoisted(() => ({
+  mockCurrentUser: vi.fn(),
+  mockQuery: vi.fn(),
+}));
+
+vi.mock('@nostrify/react', () => ({
+  useNostr: () => ({
+    nostr: {
+      query: mockQuery,
+    },
+  }),
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, params?: Record<string, unknown>) => {
+      if (key === 'listDetailPage.videoCount') return `${params?.count ?? 0} videos`;
+      return key;
+    },
+  }),
+}));
+
+vi.mock('@/hooks/useCurrentUser', () => ({
+  useCurrentUser: () => ({ user: mockCurrentUser() }),
+}));
+
+vi.mock('@/hooks/useAuthor', () => ({
+  useAuthor: () => ({
+    data: {
+      metadata: {
+        name: 'Owner',
+      },
+    },
+  }),
+}));
+
+vi.mock('@/hooks/useVideoLists', () => ({
+  useRemoveVideoFromList: () => ({ mutateAsync: vi.fn() }),
+  useDeleteVideoList: () => ({ mutateAsync: vi.fn() }),
+}));
+
+vi.mock('@/hooks/useAppContext', () => ({
+  useAppContext: () => ({
+    config: {
+      relayUrl: 'wss://relay.divine.video',
+      relayUrls: ['wss://relay.divine.video'],
+    },
+  }),
+}));
+
+vi.mock('@/hooks/useToast', () => ({
+  useToast: () => ({ toast: vi.fn() }),
+}));
+
+vi.mock('@/hooks/useShare', () => ({
+  useShare: () => ({ share: vi.fn() }),
+}));
+
+vi.mock('@/components/EditListDialog', () => ({
+  EditListDialog: () => <div />,
+}));
+
+vi.mock('@/components/DeleteListDialog', () => ({
+  DeleteListDialog: () => <div />,
+}));
+
+function makeListEvent(): NostrEvent {
+  return {
+    id: 'd'.repeat(64),
+    pubkey: OWNER,
+    created_at: 1_700_000_000,
+    kind: 30005,
+    tags: [
+      ['d', 'favorites'],
+      ['title', 'Favorites'],
+      ['collaborative', 'true'],
+      ['collaborator', COLLABORATOR],
+    ],
+    content: '',
+    sig: 'e'.repeat(128),
+  };
+}
+
+function renderPage(currentUserPubkey: string) {
+  mockCurrentUser.mockReturnValue({ pubkey: currentUserPubkey });
+  mockQuery.mockImplementation(async (filters: Array<{ kinds?: number[]; authors?: string[] }>) => {
+    if (filters[0]?.kinds?.includes(30005)) {
+      return [makeListEvent()];
+    }
+
+    return [];
+  });
+
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+    },
+  });
+
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter initialEntries={[`/list/${OWNER}/favorites`]}>
+        <Routes>
+          <Route path="/list/:pubkey/:listId" element={<ListDetailPage />} />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+describe('ListDetailPage permissions', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('lets the owner edit metadata, delete the list, and edit content', async () => {
+    renderPage(OWNER);
+
+    expect(await screen.findByRole('button', { name: /listDetailPage.editList/ })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /listDetailPage.delete/ })).toBeInTheDocument();
+    expect(await screen.findByText('listDetailPage.emptyListOwnerHint')).toBeInTheDocument();
+  });
+
+  it('lets collaborators edit content without editing metadata or deleting the list', async () => {
+    renderPage(COLLABORATOR);
+
+    expect(await screen.findByText('listDetailPage.emptyListOwnerHint')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /listDetailPage.editList/ })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /listDetailPage.delete/ })).not.toBeInTheDocument();
+  });
+
+  it('hides edit controls from non-collaborators', async () => {
+    renderPage(OUTSIDER);
+
+    expect(await screen.findByText('listDetailPage.emptyList')).toBeInTheDocument();
+    expect(screen.queryByText('listDetailPage.emptyListOwnerHint')).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /listDetailPage.editList/ })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /listDetailPage.delete/ })).not.toBeInTheDocument();
+  });
+});

--- a/src/pages/ListRoutePage.test.tsx
+++ b/src/pages/ListRoutePage.test.tsx
@@ -1,0 +1,78 @@
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { buildListPath } from '@/lib/eventRouting';
+import ListRoutePage, { LegacyPeopleListRedirect } from './ListRoutePage';
+
+const OWNER = 'a'.repeat(64);
+const { mockUseListRouteKind } = vi.hoisted(() => ({
+  mockUseListRouteKind: vi.fn(),
+}));
+
+vi.mock('@/hooks/useListRouteKind', () => ({
+  useListRouteKind: (...args: unknown[]) => mockUseListRouteKind(...args),
+}));
+
+vi.mock('@/pages/ListDetailPage', () => ({
+  default: () => <div data-testid="video-list-page">Video list</div>,
+}));
+
+vi.mock('@/pages/PeopleListDetailPage', () => ({
+  default: () => <div data-testid="people-list-page">People list</div>,
+}));
+
+function renderCanonicalRoute(routeKind: 'videos' | 'people' | 'missing') {
+  mockUseListRouteKind.mockReturnValue({
+    data: routeKind,
+    isLoading: false,
+  });
+
+  return render(
+    <MemoryRouter initialEntries={[buildListPath(OWNER, 'friends')]}>
+      <Routes>
+        <Route path="/list/:pubkey/:listId" element={<ListRoutePage />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+describe('ListRoutePage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders the people-list surface for kind 30000 lists', () => {
+    renderCanonicalRoute('people');
+
+    expect(screen.getByTestId('people-list-page')).toBeInTheDocument();
+    expect(screen.queryByTestId('video-list-page')).not.toBeInTheDocument();
+    expect(mockUseListRouteKind).toHaveBeenCalledWith(OWNER, 'friends');
+  });
+
+  it('renders the video-list surface for kind 30005 lists', () => {
+    renderCanonicalRoute('videos');
+
+    expect(screen.getByTestId('video-list-page')).toBeInTheDocument();
+    expect(screen.queryByTestId('people-list-page')).not.toBeInTheDocument();
+  });
+
+  it('falls back to the video-list not-found surface when no list resolves', () => {
+    renderCanonicalRoute('missing');
+
+    expect(screen.getByTestId('video-list-page')).toBeInTheDocument();
+  });
+
+  it('redirects legacy people-list paths to the canonical list route', async () => {
+    render(
+      <MemoryRouter initialEntries={[`/people-lists/${OWNER}/friends`]}>
+        <Routes>
+          <Route path="/people-lists/:pubkey/:listId" element={<LegacyPeopleListRedirect />} />
+          <Route path="/list/:pubkey/:listId" element={<div data-testid="canonical-route" />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByTestId('canonical-route')).toBeInTheDocument();
+  });
+});

--- a/src/pages/ListRoutePage.tsx
+++ b/src/pages/ListRoutePage.tsx
@@ -1,0 +1,42 @@
+import { Navigate, useParams } from 'react-router-dom';
+
+import { Skeleton } from '@/components/ui/skeleton';
+import { useListRouteKind } from '@/hooks/useListRouteKind';
+import { buildListPath } from '@/lib/eventRouting';
+import ListDetailPage from '@/pages/ListDetailPage';
+import PeopleListDetailPage from '@/pages/PeopleListDetailPage';
+
+function ListRouteLoadingState() {
+  return (
+    <div className="container mx-auto max-w-5xl space-y-6 px-4 py-8">
+      <Skeleton className="h-9 w-64" />
+      <Skeleton className="h-28 w-full rounded-2xl" />
+      <Skeleton className="h-96 w-full rounded-2xl" />
+    </div>
+  );
+}
+
+export function LegacyPeopleListRedirect() {
+  const { pubkey, listId } = useParams<{ pubkey: string; listId: string }>();
+
+  if (!pubkey || !listId) {
+    return <Navigate to="/lists" replace />;
+  }
+
+  return <Navigate to={buildListPath(pubkey, listId)} replace />;
+}
+
+export default function ListRoutePage() {
+  const { pubkey, listId } = useParams<{ pubkey: string; listId: string }>();
+  const routeKind = useListRouteKind(pubkey, listId);
+
+  if (routeKind.isLoading) {
+    return <ListRouteLoadingState />;
+  }
+
+  if (routeKind.data === 'people') {
+    return <PeopleListDetailPage />;
+  }
+
+  return <ListDetailPage />;
+}

--- a/src/pages/ListsPage.test.tsx
+++ b/src/pages/ListsPage.test.tsx
@@ -1,0 +1,120 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { MemoryRouter } from 'react-router-dom';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import ListsPage from './ListsPage';
+
+const mockUseCurrentUser = vi.fn();
+const mockUseVideoLists = vi.fn();
+const mockUseTrendingVideoLists = vi.fn();
+const mockUseFollowedUsersLists = vi.fn();
+const mockUseFollowList = vi.fn();
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => {
+      const translations: Record<string, string> = {
+        'listsPage.createList': 'Create List',
+        'listsPage.createFirstList': 'Create Your First List',
+        'listsPage.createVideoList': 'Video list',
+        'listsPage.createPeopleList': 'People list',
+      };
+      return translations[key] ?? key;
+    },
+  }),
+}));
+
+vi.mock('@/hooks/useCurrentUser', () => ({
+  useCurrentUser: () => mockUseCurrentUser(),
+}));
+
+vi.mock('@/hooks/useVideoLists', () => ({
+  useVideoLists: () => mockUseVideoLists(),
+  useTrendingVideoLists: () => mockUseTrendingVideoLists(),
+  useFollowedUsersLists: () => mockUseFollowedUsersLists(),
+}));
+
+vi.mock('@/hooks/useFollowList', () => ({
+  useFollowList: () => mockUseFollowList(),
+}));
+
+vi.mock('@/hooks/useAuthor', () => ({
+  useAuthor: () => ({
+    data: { metadata: { name: 'Liz' } },
+  }),
+}));
+
+vi.mock('@/components/ui/dropdown-menu', () => ({
+  DropdownMenu: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  DropdownMenuTrigger: ({ children }: { children: ReactNode }) => <>{children}</>,
+  DropdownMenuContent: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  DropdownMenuItem: ({
+    children,
+    onClick,
+  }: {
+    children: ReactNode;
+    onClick?: () => void;
+  }) => (
+    <button type="button" onClick={onClick}>
+      {children}
+    </button>
+  ),
+}));
+
+vi.mock('@/components/CreateListDialog', () => ({
+  CreateListDialog: ({ open }: { open: boolean }) => (
+    open ? <div role="dialog" aria-label="Create video list" /> : null
+  ),
+}));
+
+vi.mock('@/components/CreatePeopleListDialog', () => ({
+  CreatePeopleListDialog: ({ open }: { open: boolean }) => (
+    open ? <div role="dialog" aria-label="Create people list" /> : null
+  ),
+}));
+
+function renderPage() {
+  return render(
+    <MemoryRouter>
+      <ListsPage />
+    </MemoryRouter>,
+  );
+}
+
+describe('ListsPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseCurrentUser.mockReturnValue({ user: { pubkey: 'a'.repeat(64) } });
+    mockUseVideoLists.mockReturnValue({ data: [], isLoading: false });
+    mockUseTrendingVideoLists.mockReturnValue({ data: [], isLoading: false });
+    mockUseFollowedUsersLists.mockReturnValue({ data: [], isLoading: false });
+    mockUseFollowList.mockReturnValue({ data: [] });
+  });
+
+  it('keeps video-list creation reachable from the create chooser', () => {
+    renderPage();
+
+    fireEvent.click(screen.getAllByRole('button', { name: /Video list/ })[0]);
+
+    expect(screen.getByRole('dialog', { name: 'Create video list' })).toBeInTheDocument();
+    expect(screen.queryByRole('dialog', { name: 'Create people list' })).not.toBeInTheDocument();
+  });
+
+  it('offers people-list creation from the same create chooser', () => {
+    renderPage();
+
+    fireEvent.click(screen.getAllByRole('button', { name: /People list/ })[0]);
+
+    expect(screen.getByRole('dialog', { name: 'Create people list' })).toBeInTheDocument();
+  });
+
+  it('keeps the empty-state create chooser wired to video-list creation', () => {
+    renderPage();
+
+    expect(screen.getByRole('button', { name: /Create Your First List/ })).toBeInTheDocument();
+    fireEvent.click(screen.getAllByRole('button', { name: /Video list/ })[1]);
+
+    expect(screen.getByRole('dialog', { name: 'Create video list' })).toBeInTheDocument();
+  });
+});

--- a/src/pages/ListsPage.tsx
+++ b/src/pages/ListsPage.tsx
@@ -2,6 +2,7 @@
 // ABOUTME: Shows user's lists, trending lists, and allows list creation
 
 import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { useVideoLists, useTrendingVideoLists, useFollowedUsersLists } from '@/hooks/useVideoLists';
 import { useFollowList } from '@/hooks/useFollowList';
 import { useCurrentUser } from '@/hooks/useCurrentUser';
@@ -11,11 +12,13 @@ import { nip19 } from 'nostr-tools';
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from '@/components/ui/dropdown-menu';
 import { Skeleton } from '@/components/ui/skeleton';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import { List, TrendUp as TrendingUp, Plus, Users, VideoCamera as Video, Clock } from '@phosphor-icons/react';
 import { genUserName } from '@/lib/genUserName';
 import { CreateListDialog } from '@/components/CreateListDialog';
+import { CreatePeopleListDialog } from '@/components/CreatePeopleListDialog';
 import { formatDistanceToNow } from 'date-fns';
 import { getSafeProfileImage } from '@/lib/imageUtils';
 
@@ -100,11 +103,46 @@ function ListCard({ list }: { list: ListCardProps }) {
   );
 }
 
+function CreateListMenu({
+  label,
+  onCreateVideoList,
+  onCreatePeopleList,
+}: {
+  label: string;
+  onCreateVideoList: () => void;
+  onCreatePeopleList: () => void;
+}) {
+  const { t } = useTranslation();
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button>
+          <Plus className="h-4 w-4 mr-2" />
+          {label}
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end">
+        <DropdownMenuItem onClick={onCreateVideoList}>
+          <Video className="h-4 w-4 mr-2" />
+          {t('listsPage.createVideoList')}
+        </DropdownMenuItem>
+        <DropdownMenuItem onClick={onCreatePeopleList}>
+          <Users className="h-4 w-4 mr-2" />
+          {t('listsPage.createPeopleList')}
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}
+
 export default function ListsPage() {
+  const { t } = useTranslation();
   const { user } = useCurrentUser();
   const { data: userLists, isLoading: userListsLoading } = useVideoLists(user?.pubkey);
   const { data: trendingLists, isLoading: trendingLoading } = useTrendingVideoLists();
-  const [showCreateDialog, setShowCreateDialog] = useState(false);
+  const [showCreateVideoDialog, setShowCreateVideoDialog] = useState(false);
+  const [showCreatePeopleDialog, setShowCreatePeopleDialog] = useState(false);
   const { data: followedPubkeys } = useFollowList();
   const { data: followedUsersLists, isLoading: discoverLoading } = useFollowedUsersLists(followedPubkeys);
 
@@ -118,10 +156,11 @@ export default function ListsPage() {
             Video Lists
           </h1>
           {user && (
-            <Button onClick={() => setShowCreateDialog(true)}>
-              <Plus className="h-4 w-4 mr-2" />
-              Create List
-            </Button>
+            <CreateListMenu
+              label={t('listsPage.createList')}
+              onCreateVideoList={() => setShowCreateVideoDialog(true)}
+              onCreatePeopleList={() => setShowCreatePeopleDialog(true)}
+            />
           )}
         </div>
         <p className="text-muted-foreground">
@@ -178,10 +217,11 @@ export default function ListsPage() {
                   <p className="text-muted-foreground mb-4">
                     You haven't created any lists yet
                   </p>
-                  <Button onClick={() => setShowCreateDialog(true)}>
-                    <Plus className="h-4 w-4 mr-2" />
-                    Create Your First List
-                  </Button>
+                  <CreateListMenu
+                    label={t('listsPage.createFirstList')}
+                    onCreateVideoList={() => setShowCreateVideoDialog(true)}
+                    onCreatePeopleList={() => setShowCreatePeopleDialog(true)}
+                  />
                 </CardContent>
               </Card>
             )}
@@ -290,11 +330,17 @@ export default function ListsPage() {
         </TabsContent>
       </Tabs>
 
-      {/* Create List Dialog */}
-      {showCreateDialog && (
+      {showCreateVideoDialog && (
         <CreateListDialog
-          open={showCreateDialog}
-          onClose={() => setShowCreateDialog(false)}
+          open={showCreateVideoDialog}
+          onClose={() => setShowCreateVideoDialog(false)}
+        />
+      )}
+
+      {showCreatePeopleDialog && (
+        <CreatePeopleListDialog
+          open={showCreatePeopleDialog}
+          onOpenChange={setShowCreatePeopleDialog}
         />
       )}
     </div>

--- a/src/pages/PeopleListDetailPage.test.tsx
+++ b/src/pages/PeopleListDetailPage.test.tsx
@@ -1,6 +1,6 @@
 // ABOUTME: Tests public people-list detail with people context and a video-primary feed
 
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { nip19 } from 'nostr-tools';
@@ -11,12 +11,85 @@ const ALICE = 'b'.repeat(64);
 const BOB = 'c'.repeat(64);
 const mockUsePeopleList = vi.fn();
 const mockUsePeopleListVideos = vi.fn();
+const mockShare = vi.fn();
+const mockUseCurrentUser = vi.fn();
+const mockDeletePeopleList = vi.fn();
+const mockToast = vi.fn();
 
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, values?: Record<string, string>) => {
+      const translations: Record<string, string> = {
+        'peopleListDetailPage.editList': 'Edit',
+        'peopleListDetailPage.delete': 'Delete',
+        'peopleListDetailPage.share': 'Share',
+        'peopleListDetailPage.deletedTitle': 'People list deleted.',
+        'peopleListDetailPage.deletedDescription': `"${values?.name}" has been removed.`,
+        'peopleListDetailPage.deleteFailedTitle': 'Delete failed.',
+        'peopleListDetailPage.deleteFailedDescription': 'People list deletion hit a snag. Try again?',
+      };
+      return translations[key] ?? key;
+    },
+  }),
+}));
 vi.mock('@/hooks/usePeopleLists', () => ({
   usePeopleList: (...args: unknown[]) => mockUsePeopleList(...args),
 }));
 vi.mock('@/hooks/usePeopleListVideos', () => ({
   usePeopleListVideos: (...args: unknown[]) => mockUsePeopleListVideos(...args),
+}));
+vi.mock('@/hooks/useAuthor', () => ({
+  useAuthor: () => ({
+    data: {
+      metadata: {
+        name: 'Liz',
+        picture: 'https://cdn.example.com/liz.jpg',
+      },
+    },
+  }),
+}));
+vi.mock('@/hooks/useShare', () => ({
+  useShare: () => ({
+    share: mockShare,
+  }),
+}));
+vi.mock('@/hooks/useCurrentUser', () => ({
+  useCurrentUser: () => mockUseCurrentUser(),
+}));
+vi.mock('@/hooks/useToast', () => ({
+  useToast: () => ({
+    toast: mockToast,
+  }),
+}));
+vi.mock('@/hooks/usePeopleListMutations', () => ({
+  useDeletePeopleList: () => ({
+    mutateAsync: mockDeletePeopleList,
+    isPending: false,
+  }),
+}));
+vi.mock('@/components/EditPeopleListDialog', () => ({
+  EditPeopleListDialog: ({ list }: { list: { name: string } }) => (
+    <div role="dialog" aria-label="Edit people list">
+      Editing {list.name}
+    </div>
+  ),
+}));
+vi.mock('@/components/DeleteListDialog', () => ({
+  DeleteListDialog: ({
+    listName,
+    onConfirm,
+  }: {
+    listName: string;
+    onConfirm: () => void;
+  }) => (
+    <div role="dialog" aria-label="Delete people list">
+      Delete {listName}
+      <button type="button" onClick={onConfirm}>Confirm delete</button>
+    </div>
+  ),
+}));
+vi.mock('@/lib/subdomainLinks', () => ({
+  getApexShareUrl: (path: string) => `https://divine.video${path}`,
 }));
 vi.mock('@/hooks/useBatchedAuthors', () => ({
   useBatchedAuthors: () => ({
@@ -39,6 +112,7 @@ function renderPage() {
     <MemoryRouter initialEntries={[`/people-lists/${OWNER}/friends`]}>
       <Routes>
         <Route path="/people-lists/:pubkey/:listId" element={<PeopleListDetailPage />} />
+        <Route path="/profile/:npub/lists" element={<div>Profile lists</div>} />
       </Routes>
     </MemoryRouter>,
   );
@@ -47,6 +121,8 @@ function renderPage() {
 describe('PeopleListDetailPage', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockUseCurrentUser.mockReturnValue({ user: null });
+    mockDeletePeopleList.mockResolvedValue(undefined);
     mockUsePeopleList.mockReturnValue({
       data: {
         id: 'friends',
@@ -76,6 +152,12 @@ describe('PeopleListDetailPage', () => {
 
     expect(screen.getByRole('heading', { name: 'Friends' })).toBeInTheDocument();
     expect(screen.getByText('Good people making good loops.')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /Liz List creator/ })).toHaveAttribute(
+      'href',
+      `/profile/${nip19.npubEncode(OWNER)}`,
+    );
+    expect(screen.getAllByText('2 people')).toHaveLength(2);
+    expect(screen.getByText('1 loop loaded')).toBeInTheDocument();
     const peopleHeading = screen.getByRole('heading', { name: 'People' });
     const videosHeading = screen.getByRole('heading', { name: 'Videos' });
     expect(peopleHeading.compareDocumentPosition(videosHeading) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
@@ -94,6 +176,47 @@ describe('PeopleListDetailPage', () => {
     );
     expect(screen.queryByRole('button', { name: /subscribe/i })).not.toBeInTheDocument();
   }, 10_000);
+
+  it('shares the people-list route', () => {
+    renderPage();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Share' }));
+
+    expect(mockShare).toHaveBeenCalledWith({
+      url: 'https://divine.video/people-lists/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/friends',
+    });
+  });
+
+  it('shows owner controls only for the list owner', () => {
+    mockUseCurrentUser.mockReturnValue({ user: { pubkey: OWNER } });
+    renderPage();
+
+    expect(screen.getByRole('button', { name: 'Edit' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Delete' })).toBeInTheDocument();
+  });
+
+  it('hides owner controls for non-owners', () => {
+    mockUseCurrentUser.mockReturnValue({ user: { pubkey: BOB } });
+    renderPage();
+
+    expect(screen.queryByRole('button', { name: 'Edit' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Delete' })).not.toBeInTheDocument();
+  });
+
+  it('deletes the people list through the owner control', async () => {
+    mockUseCurrentUser.mockReturnValue({ user: { pubkey: OWNER } });
+    renderPage();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Delete' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Confirm delete' }));
+
+    await waitFor(() => {
+      expect(mockDeletePeopleList).toHaveBeenCalledWith({
+        ownerPubkey: OWNER,
+        listId: 'friends',
+      });
+    });
+  });
 
   it('shows a not-found state when the exact list is absent', () => {
     mockUsePeopleList.mockReturnValue({

--- a/src/pages/PeopleListDetailPage.tsx
+++ b/src/pages/PeopleListDetailPage.tsx
@@ -1,21 +1,97 @@
 // ABOUTME: Public detail page for a NIP-51 people list with member videos as primary content
 
-import { ArrowLeft, UsersThree } from '@phosphor-icons/react';
+import { ArrowLeft, Clock, PencilSimple, ShareNetwork, Trash, UsersThree, VideoCamera } from '@phosphor-icons/react';
+import { formatDistanceToNow } from 'date-fns';
 import { nip19 } from 'nostr-tools';
-import { Link, useParams } from 'react-router-dom';
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Link, useNavigate, useParams } from 'react-router-dom';
+import { DeleteListDialog } from '@/components/DeleteListDialog';
+import { EditPeopleListDialog } from '@/components/EditPeopleListDialog';
 import { PeopleListMembers } from '@/components/PeopleListMembers';
 import { VideoGrid } from '@/components/VideoGrid';
 import { SectionHeader } from '@/components/brand/SectionHeader';
+import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import { Button } from '@/components/ui/button';
 import { Skeleton } from '@/components/ui/skeleton';
+import { useAuthor } from '@/hooks/useAuthor';
+import { useCurrentUser } from '@/hooks/useCurrentUser';
+import { useDeletePeopleList } from '@/hooks/usePeopleListMutations';
 import { usePeopleList } from '@/hooks/usePeopleLists';
 import { usePeopleListVideos } from '@/hooks/usePeopleListVideos';
+import { useShare } from '@/hooks/useShare';
+import { useToast } from '@/hooks/useToast';
+import { genUserName } from '@/lib/genUserName';
+import { getSafeProfileImage } from '@/lib/imageUtils';
+import { buildProfileLinkPath } from '@/lib/profileLinks';
+import { getPeopleListShareData } from '@/lib/shareUtils';
+
+function LoadMoreButton({
+  isFetching,
+  onClick,
+  className,
+}: {
+  isFetching: boolean;
+  onClick: () => void;
+  className?: string;
+}) {
+  return (
+    <Button
+      className={className}
+      variant="outline"
+      onClick={onClick}
+      disabled={isFetching}
+    >
+      {isFetching ? 'Loading...' : 'Load more'}
+    </Button>
+  );
+}
 
 function PeopleListContent({ pubkey, listId }: { pubkey: string; listId: string }) {
+  const { t } = useTranslation();
+  const navigate = useNavigate();
   const listQuery = usePeopleList(pubkey, listId);
+  const author = useAuthor(pubkey);
+  const { user } = useCurrentUser();
+  const { toast } = useToast();
+  const { share } = useShare();
+  const deletePeopleList = useDeletePeopleList();
+  const [showEditDialog, setShowEditDialog] = useState(false);
+  const [showDeleteDialog, setShowDeleteDialog] = useState(false);
   const memberPubkeys = listQuery.data?.memberPubkeys ?? [];
   const videosQuery = usePeopleListVideos(memberPubkeys);
   const videos = videosQuery.data?.pages.flatMap((page) => page.videos) ?? [];
+  const authorMetadata = author.data?.metadata;
+  const authorName = authorMetadata?.display_name || authorMetadata?.name || genUserName(pubkey);
+  const isOwner = user?.pubkey === pubkey;
+
+  const handleShare = () => {
+    share(getPeopleListShareData(pubkey, listId));
+  };
+
+  const handleDelete = async () => {
+    if (!listQuery.data) return;
+
+    try {
+      await deletePeopleList.mutateAsync({
+        ownerPubkey: pubkey,
+        listId,
+      });
+      toast({
+        title: t('peopleListDetailPage.deletedTitle'),
+        description: t('peopleListDetailPage.deletedDescription', { name: listQuery.data.name }),
+      });
+      navigate(`/profile/${nip19.npubEncode(pubkey)}/lists`);
+    } catch (error) {
+      toast({
+        title: t('peopleListDetailPage.deleteFailedTitle'),
+        description: error instanceof Error ? error.message : t('peopleListDetailPage.deleteFailedDescription'),
+        variant: 'destructive',
+      });
+    } finally {
+      setShowDeleteDialog(false);
+    }
+  };
 
   if (listQuery.isLoading) {
     return (
@@ -48,14 +124,71 @@ function PeopleListContent({ pubkey, listId }: { pubkey: string; listId: string 
         Back to lists
       </Link>
 
-      <header className="flex items-start gap-4">
-        <div className="flex h-14 w-14 shrink-0 items-center justify-center rounded-2xl bg-brand-light-green dark:bg-brand-dark-green">
-          <UsersThree className="h-7 w-7 text-brand-dark-green dark:text-brand-green" aria-hidden="true" />
+      <header className="space-y-5">
+        <div className="flex items-start justify-between gap-4">
+          <div className="flex min-w-0 items-start gap-4">
+            <div className="flex h-14 w-14 shrink-0 items-center justify-center rounded-2xl bg-brand-light-green dark:bg-brand-dark-green">
+              <UsersThree className="h-7 w-7 text-brand-dark-green dark:text-brand-green" aria-hidden="true" />
+            </div>
+            <div className="min-w-0">
+              <p className="text-sm font-semibold text-primary">People list</p>
+              <SectionHeader as="h2" className="text-3xl">{list.name}</SectionHeader>
+              {list.description && <p className="mt-2 text-muted-foreground">{list.description}</p>}
+            </div>
+          </div>
+          <div className="flex shrink-0 flex-wrap gap-2">
+            {isOwner && (
+              <>
+                <Button variant="outline" size="sm" onClick={() => setShowEditDialog(true)}>
+                  <PencilSimple className="mr-2 h-4 w-4" />
+                  {t('peopleListDetailPage.editList')}
+                </Button>
+                <Button variant="outline" size="sm" onClick={() => setShowDeleteDialog(true)}>
+                  <Trash className="mr-2 h-4 w-4" />
+                  {t('peopleListDetailPage.delete')}
+                </Button>
+              </>
+            )}
+            <Button variant="outline" size="sm" onClick={handleShare}>
+              <ShareNetwork className="mr-2 h-4 w-4" />
+              {t('peopleListDetailPage.share')}
+            </Button>
+          </div>
         </div>
-        <div className="min-w-0">
-          <p className="text-sm font-semibold text-primary">People list</p>
-          <SectionHeader as="h2" className="text-3xl">{list.name}</SectionHeader>
-          {list.description && <p className="mt-2 text-muted-foreground">{list.description}</p>}
+
+        <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+          <Link
+            to={buildProfileLinkPath({
+              pubkey,
+              nip05: authorMetadata?.nip05,
+              fallbackRoute: 'profile',
+            })}
+            className="flex items-center gap-2 rounded-xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          >
+            <Avatar size="sm">
+              <AvatarImage src={getSafeProfileImage(authorMetadata?.picture)} alt="" />
+              <AvatarFallback>{authorName[0]?.toUpperCase()}</AvatarFallback>
+            </Avatar>
+            <span>
+              <span className="block text-sm font-semibold">{authorName}</span>
+              <span className="block text-xs text-muted-foreground">List creator</span>
+            </span>
+          </Link>
+
+          <div className="flex flex-wrap items-center gap-4 text-sm text-muted-foreground">
+            <span className="inline-flex items-center gap-1">
+              <UsersThree className="h-4 w-4" />
+              {list.memberPubkeys.length} {list.memberPubkeys.length === 1 ? 'person' : 'people'}
+            </span>
+            <span className="inline-flex items-center gap-1">
+              <VideoCamera className="h-4 w-4" />
+              {videos.length} {videos.length === 1 ? 'loop' : 'loops'} loaded
+            </span>
+            <span className="inline-flex items-center gap-1">
+              <Clock className="h-4 w-4" />
+              {formatDistanceToNow(list.createdAt * 1000, { addSuffix: true })}
+            </span>
+          </div>
         </div>
       </header>
 
@@ -87,27 +220,21 @@ function PeopleListContent({ pubkey, listId }: { pubkey: string; listId: string 
             />
             {videosQuery.hasNextPage && (
               <div className="flex justify-center">
-                <Button
-                  variant="outline"
+                <LoadMoreButton
+                  isFetching={videosQuery.isFetchingNextPage}
                   onClick={() => videosQuery.fetchNextPage()}
-                  disabled={videosQuery.isFetchingNextPage}
-                >
-                  {videosQuery.isFetchingNextPage ? 'Loading…' : 'Load more'}
-                </Button>
+                />
               </div>
             )}
           </>
         ) : videosQuery.hasNextPage ? (
           <div className="rounded-2xl border border-dashed p-8 text-center text-muted-foreground">
             <p>More loops may be hiding on the next page.</p>
-            <Button
+            <LoadMoreButton
               className="mt-4"
-              variant="outline"
+              isFetching={videosQuery.isFetchingNextPage}
               onClick={() => videosQuery.fetchNextPage()}
-              disabled={videosQuery.isFetchingNextPage}
-            >
-              {videosQuery.isFetchingNextPage ? 'Loading...' : 'Load more'}
-            </Button>
+            />
           </div>
         ) : (
           <p className="rounded-2xl border border-dashed p-8 text-center text-muted-foreground">
@@ -115,6 +242,25 @@ function PeopleListContent({ pubkey, listId }: { pubkey: string; listId: string 
           </p>
         )}
       </section>
+
+      {showEditDialog && (
+        <EditPeopleListDialog
+          open={showEditDialog}
+          onOpenChange={setShowEditDialog}
+          list={list}
+        />
+      )}
+
+      {showDeleteDialog && (
+        <DeleteListDialog
+          open={showDeleteDialog}
+          onClose={() => setShowDeleteDialog(false)}
+          onConfirm={handleDelete}
+          listName={list.name}
+          isDeleting={deletePeopleList.isPending}
+          listKind="people"
+        />
+      )}
     </div>
   );
 }

--- a/src/pages/VideoPage.tsx
+++ b/src/pages/VideoPage.tsx
@@ -22,6 +22,7 @@ import { useQueryClient } from '@tanstack/react-query';
 import { useToast } from '@/hooks/useToast';
 import { genUserName } from '@/lib/genUserName';
 import { buildProfileLinkPath } from '@/lib/profileLinks';
+import { buildListPath } from '@/lib/eventRouting';
 import { debugLog } from '@/lib/debug';
 import { getVisiblePlaybackCount } from '@/lib/playbackCount';
 import { reportFunnelcakeFallback } from '@/lib/funnelcakeFallbackReporting';
@@ -290,7 +291,7 @@ export function VideoPage() {
       const target = params.toString() ? `/search?${params.toString()}` : '/search';
       navigate(target);
     } else if (context?.source === 'people-list' && context.pubkey && context.listId) {
-      navigate(`/people-lists/${context.pubkey}/${encodeURIComponent(context.listId)}`);
+      navigate(buildListPath(context.pubkey, context.listId));
     } else {
       navigate(-1); // Browser back
     }

--- a/tests/visual/a11y.spec.ts
+++ b/tests/visual/a11y.spec.ts
@@ -12,7 +12,7 @@ const ROUTES = [
   '/kids',
   `/profile/${PUBKEY}`,
   `/profile/${PUBKEY}/lists`,
-  `/people-lists/${PUBKEY}/friends`,
+  `/list/${PUBKEY}/friends`,
   '/__brand-preview',
 ];
 


### PR DESCRIPTION
## Summary

- Complete the people-list detail surface with owner attribution, stats, share, owner edit/delete affordances, and route-aware list handling.
- Add safe kind-30000 people-list mutation hooks that preserve existing event content on replacement publishes and publish correct deletion tags.
- Add create/edit people-list dialogs and a /lists create chooser that keeps video-list creation reachable.
- Fix people-list video pagination to use inclusive Nostr cursors, dedupe addressable videos across pages, and stop on duplicate-only boundary pages.
- Add route tests, share helpers, locale resource alignment, and focused regression coverage.

> Avoid naming corporate partners, customers, or other sensitive external brands in this PR title or body. Use generic descriptors unless a maintainer explicitly approves the public reference.

## Motivation

- #503 was mostly delivered by an earlier PR, but the detail page still had a real same-timestamp pagination loss bug and an incomplete header/share experience.
- #504 needs people-list create/edit/delete UI without regressing shipped video-list creation.
- The #501 write-hook foundation is required before CRUD dialogs can safely publish kind-30000 replacements.

## Related Issue

- Closes #503
- Closes #504
- Refs #501
- Refs #502

## Testing

- [x] `npm run test`
- [ ] Manual verification completed

## Visuals

- [ ] UI change with screenshots/video attached
- [ ] No visual change
- [x] Visuals and text avoid sensitive external brand or partner names unless explicitly approved