### PR TITLE
feat(discovery): add configurable featured tab

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -134,6 +134,8 @@ GET  /api/users/{pubkey}/following  - Following list
 POST /api/users/bulk                - Bulk user profiles
 GET  /api/search?q=                 - Full-text search
 GET  /api/hashtags/trending         - Trending hashtags
+GET  /api/featured-tabs             - Active featured Discovery tabs
+GET  /api/featured-tabs/{id}/videos - Curated videos for a featured tab
 ```
 
 ### Bulk Endpoint Pattern

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -62,6 +62,8 @@ subdomain and loading the corresponding Nostr profile. Static hosts use
 catch-all fallback.
 The retired `/discovery/new` chronological feed redirects to
 `/discovery/hot`; Discovery does not expose or mount an all-new-video feed.
+`/discovery/:tab` accepts the built-in Discovery tabs plus the currently
+eligible server-configured featured tab slug, when Funnelcake serves one.
 Public profiles expose a compact mixed NIP-51 list shelf and a filterable
 `/profile/:npub/lists` gallery. Kind `30005` video sets retain their
 owner-aware `/list/:pubkey/:listId` route; kind `30000` people sets use

--- a/src/components/VideoFeed.test.tsx
+++ b/src/components/VideoFeed.test.tsx
@@ -13,7 +13,9 @@ const {
   mockSetVideosForFullscreen,
   mockUpdateVideos,
   mockUseVideoPrefetch,
+  mockTrackEvent,
 } = vi.hoisted(() => ({
+  mockTrackEvent: vi.fn(),
   mockNavigate: vi.fn(),
   mockUseVideoProvider: vi.fn(),
   mockEnterFullscreen: vi.fn(),
@@ -24,6 +26,10 @@ const {
 
 vi.mock('@/hooks/useVideoProvider', () => ({
   useVideoProvider: mockUseVideoProvider,
+}));
+
+vi.mock('@/lib/analytics', () => ({
+  trackEvent: mockTrackEvent,
 }));
 
 vi.mock('@/hooks/useBatchedAuthors', () => ({
@@ -182,6 +188,55 @@ describe('VideoFeed', () => {
       [expect.objectContaining({ id: 'video-1' })],
       0,
     );
+  });
+
+  it('reports one featured impression per mount, not one per appended page', () => {
+    const makeVideos = (count: number) =>
+      Array.from({ length: count }, (_, index) => ({
+        id: `video-${index + 1}`,
+        pubkey: 'a'.repeat(64),
+        videoUrl: `https://example.com/video-${index + 1}.mp4`,
+      }));
+
+    mockUseVideoProvider.mockReturnValue({
+      data: { pages: [{ videos: makeVideos(1) }] },
+      fetchNextPage: vi.fn(),
+      hasNextPage: true,
+      isLoading: false,
+      error: null,
+      refetch: vi.fn(),
+      dataSource: 'funnelcake',
+    });
+
+    const { rerender } = render(
+      <MemoryRouter initialEntries={['/discovery/seasonal-theme']}>
+        <VideoFeed feedType="featured" featuredTabId="ft_1234abcd" />
+      </MemoryRouter>
+    );
+
+    expect(mockTrackEvent).toHaveBeenCalledExactlyOnceWith('featured_tab_video_impression', {
+      featured_tab_id: 'ft_1234abcd',
+      rendered_videos: 1,
+    });
+
+    // Second page arrives; the impression must not be counted again.
+    mockUseVideoProvider.mockReturnValue({
+      data: { pages: [{ videos: makeVideos(1) }, { videos: makeVideos(3).slice(1) }] },
+      fetchNextPage: vi.fn(),
+      hasNextPage: false,
+      isLoading: false,
+      error: null,
+      refetch: vi.fn(),
+      dataSource: 'funnelcake',
+    });
+
+    rerender(
+      <MemoryRouter initialEntries={['/discovery/seasonal-theme']}>
+        <VideoFeed feedType="featured" featuredTabId="ft_1234abcd" />
+      </MemoryRouter>
+    );
+
+    expect(mockTrackEvent).toHaveBeenCalledTimes(1);
   });
 
   it('does not prefetch full video files before first playback', () => {

--- a/src/components/VideoFeed.tsx
+++ b/src/components/VideoFeed.tsx
@@ -28,13 +28,15 @@ import { useVideoPrefetch } from '@/hooks/useVideoPrefetch';
 import { useCompilationFullscreen } from '@/hooks/useCompilationFullscreen';
 import { buildCompilationPlaybackUrl } from '@/lib/compilationPlayback';
 import type { PopularPeriod, PopularSource } from '@/hooks/useInfiniteVideosFunnelcake';
+import { trackEvent } from '@/lib/analytics';
 
 type ViewMode = 'feed' | 'grid';
 
 interface VideoFeedProps {
-  feedType?: 'discovery' | 'home' | 'trending' | 'hashtag' | 'profile' | 'recent' | 'classics' | 'foryou' | 'category' | 'popular';
+  feedType?: 'discovery' | 'home' | 'trending' | 'hashtag' | 'profile' | 'recent' | 'classics' | 'foryou' | 'category' | 'popular' | 'featured';
   hashtag?: string;
   category?: string;
+  featuredTabId?: string;
   pubkey?: string;
   limit?: number;
   sortMode?: SortMode; // NIP-50 sort mode (hot, top, rising, controversial)
@@ -59,6 +61,7 @@ export function VideoFeed({
   feedType = 'discovery',
   hashtag,
   category,
+  featuredTabId,
   pubkey,
   limit = 12, // Smaller first page improves initial paint on REST-backed feeds
   sortMode,
@@ -97,6 +100,7 @@ export function VideoFeed({
     feedType,
     hashtag,
     category,
+    featuredTabId,
     pubkey,
     pageSize: limit,
     sortMode,
@@ -168,8 +172,15 @@ export function VideoFeed({
         renderedVideos: filteredVideos.length,
         totalVideos: allVideos.length,
       });
+
+      if (feedType === 'featured' && featuredTabId) {
+        trackEvent('featured_tab_video_impression', {
+          featured_tab_id: featuredTabId,
+          rendered_videos: filteredVideos.length,
+        });
+      }
     }
-  }, [allVideos.length, filteredVideos.length, isLoading, trackInitialRender]);
+  }, [allVideos.length, featuredTabId, feedType, filteredVideos.length, isLoading, trackInitialRender]);
 
   // Track perceived first-render time for the Recent feed
   useEffect(() => {

--- a/src/components/VideoFeed.tsx
+++ b/src/components/VideoFeed.tsx
@@ -82,6 +82,9 @@ export function VideoFeed({
   const [showListDialog, setShowListDialog] = useState<{ videoId: string; videoPubkey: string } | null>(null);
   const [hasFirstPlayback, setHasFirstPlayback] = useState(false);
   const mountTimeRef = useRef<number | null>(null);
+  // The impression effect re-runs on every appended page; this keeps the
+  // featured-tab event to one per feed mount, like trackInitialRender.
+  const featuredImpressionSentRef = useRef<string | null>(null);
 
   const { checkContent } = useContentModeration();
   const navigate = useSubdomainNavigate();
@@ -173,7 +176,12 @@ export function VideoFeed({
         totalVideos: allVideos.length,
       });
 
-      if (feedType === 'featured' && featuredTabId) {
+      if (
+        feedType === 'featured' &&
+        featuredTabId &&
+        featuredImpressionSentRef.current !== featuredTabId
+      ) {
+        featuredImpressionSentRef.current = featuredTabId;
         trackEvent('featured_tab_video_impression', {
           featured_tab_id: featuredTabId,
           rendered_videos: filteredVideos.length,

--- a/src/hooks/useFeaturedTab.test.ts
+++ b/src/hooks/useFeaturedTab.test.ts
@@ -234,6 +234,32 @@ describe('useFeaturedTab', () => {
     expect(result.current.tab?.id).toBe('ft_1234abcd');
   });
 
+  it('stays unresolved when the request fails and no config was ever cached', async () => {
+    // "Request failed" is not "no such tab": callers redirect on isResolved, and
+    // treating an outage as an answer discards a valid shared featured link.
+    mockFetchFeaturedTabs.mockRejectedValueOnce(new Error('cold start outage'));
+
+    const { result } = renderHook(() => useFeaturedTab(), { wrapper: createWrapper() });
+
+    await flushQuery();
+
+    expect(result.current.tab).toBeNull();
+    expect(result.current.isResolved).toBe(false);
+  });
+
+  it('stays resolved through a failed refresh while a cached config is still fresh', async () => {
+    mockFetchFeaturedTabs.mockResolvedValueOnce(makeResponse());
+    const first = renderHook(() => useFeaturedTab(), { wrapper: createWrapper() });
+
+    await flushQuery();
+    first.unmount();
+
+    mockFetchFeaturedTabs.mockRejectedValueOnce(new Error('temporary outage'));
+    const second = renderHook(() => useFeaturedTab(), { wrapper: createWrapper() });
+
+    expect(second.result.current.isResolved).toBe(true);
+  });
+
   it('hides minor-restricted tabs when protected-minor status is unknown', async () => {
     minorState = 'unknown';
     mockFetchFeaturedTabs.mockResolvedValueOnce(makeResponse({ visible_to_minors: false }));

--- a/src/hooks/useFeaturedTab.test.ts
+++ b/src/hooks/useFeaturedTab.test.ts
@@ -8,9 +8,14 @@ import type { FeaturedTabsResponse } from '@/types/featuredTabs';
 const mockFetchFeaturedTabs = vi.fn();
 let minorState: 'protected' | 'not_protected' | 'unknown' = 'not_protected';
 let language = 'es-MX';
+let apiUrl = 'https://api.divine.video';
 
 vi.mock('@/lib/featuredTabsClient', () => ({
   fetchFeaturedTabs: mockFetchFeaturedTabs,
+}));
+
+vi.mock('@/config/api', () => ({
+  getFunnelcakeBaseUrl: () => apiUrl,
 }));
 
 vi.mock('@/hooks/useProtectedMinorStatus', () => ({
@@ -77,6 +82,7 @@ beforeEach(async () => {
   vi.clearAllMocks();
   minorState = 'not_protected';
   language = 'es-MX';
+  apiUrl = 'https://api.divine.video';
 
   const hook = await import('./useFeaturedTab');
   useFeaturedTab = hook.useFeaturedTab;
@@ -133,7 +139,7 @@ describe('useFeaturedTab', () => {
     expect(second.result.current?.id).toBe('ft_1234abcd');
   });
 
-  it('drops the last-good config after the 5 minute TTL', async () => {
+  it('keeps the last-good config across the poll boundary and drops it after the grace window', async () => {
     mockFetchFeaturedTabs.mockResolvedValueOnce(makeResponse());
     const first = renderHook(() => useFeaturedTab(), { wrapper: createWrapper() });
 
@@ -141,8 +147,32 @@ describe('useFeaturedTab', () => {
     expect(first.result.current?.id).toBe('ft_1234abcd');
     first.unmount();
 
+    // One poll interval (300s) has elapsed and the refresh is still in flight:
+    // dropping the tab here would bounce a reader off the tab they are on.
     vi.setSystemTime(new Date('2026-08-08T12:05:01Z'));
+    mockFetchFeaturedTabs.mockRejectedValueOnce(new Error('temporary outage'));
+    const second = renderHook(() => useFeaturedTab(), { wrapper: createWrapper() });
+    expect(second.result.current?.id).toBe('ft_1234abcd');
+    second.unmount();
+
+    // Two intervals with no successful refresh: the kill switch takes effect.
+    vi.setSystemTime(new Date('2026-08-08T12:10:01Z'));
     mockFetchFeaturedTabs.mockRejectedValueOnce(new Error('sustained outage'));
+    const third = renderHook(() => useFeaturedTab(), { wrapper: createWrapper() });
+
+    expect(third.result.current).toBeNull();
+  });
+
+  it('ignores a cached config that belongs to a different Funnelcake host', async () => {
+    mockFetchFeaturedTabs.mockResolvedValueOnce(makeResponse());
+    const first = renderHook(() => useFeaturedTab(), { wrapper: createWrapper() });
+
+    await flushQuery();
+    expect(first.result.current?.id).toBe('ft_1234abcd');
+    first.unmount();
+
+    apiUrl = 'https://relay.staging.dvines.org';
+    mockFetchFeaturedTabs.mockRejectedValueOnce(new Error('staging outage'));
     const second = renderHook(() => useFeaturedTab(), { wrapper: createWrapper() });
 
     expect(second.result.current).toBeNull();

--- a/src/hooks/useFeaturedTab.test.ts
+++ b/src/hooks/useFeaturedTab.test.ts
@@ -32,14 +32,17 @@ vi.mock('react-i18next', () => ({
   }),
 }));
 
-function createWrapper() {
-  const queryClient = new QueryClient({
+function createQueryClient() {
+  return new QueryClient({
     defaultOptions: {
       queries: {
         retry: false,
       },
     },
   });
+}
+
+function createWrapper(queryClient = createQueryClient()) {
 
   return function Wrapper({ children }: { children: React.ReactNode }) {
     return React.createElement(QueryClientProvider, { client: queryClient }, children);
@@ -74,20 +77,18 @@ async function flushQuery(): Promise<void> {
 }
 
 let useFeaturedTab: typeof import('./useFeaturedTab').useFeaturedTab;
-let clearFeaturedTabCacheForTests: typeof import('./useFeaturedTab').clearFeaturedTabCacheForTests;
 
 beforeEach(async () => {
   vi.useFakeTimers();
   vi.setSystemTime(new Date('2026-08-08T12:00:00Z'));
   vi.clearAllMocks();
+  mockFetchFeaturedTabs.mockReset();
   minorState = 'not_protected';
   language = 'es-MX';
   apiUrl = 'https://api.divine.video';
 
   const hook = await import('./useFeaturedTab');
   useFeaturedTab = hook.useFeaturedTab;
-  clearFeaturedTabCacheForTests = hook.clearFeaturedTabCacheForTests;
-  clearFeaturedTabCacheForTests();
 });
 
 afterEach(() => {
@@ -125,23 +126,25 @@ describe('useFeaturedTab', () => {
     });
   });
 
-  it('uses a fresh last-good config through one transient refresh failure', async () => {
+  it('uses a fresh cached config through one transient refresh failure', async () => {
+    const queryClient = createQueryClient();
     mockFetchFeaturedTabs.mockResolvedValueOnce(makeResponse());
-    const first = renderHook(() => useFeaturedTab(), { wrapper: createWrapper() });
+    const first = renderHook(() => useFeaturedTab(), { wrapper: createWrapper(queryClient) });
 
     await flushQuery();
     expect(first.result.current.tab?.id).toBe('ft_1234abcd');
     first.unmount();
 
     mockFetchFeaturedTabs.mockRejectedValueOnce(new Error('temporary outage'));
-    const second = renderHook(() => useFeaturedTab(), { wrapper: createWrapper() });
+    const second = renderHook(() => useFeaturedTab(), { wrapper: createWrapper(queryClient) });
 
     expect(second.result.current.tab?.id).toBe('ft_1234abcd');
   });
 
-  it('keeps the last-good config across the poll boundary and drops it after the grace window', async () => {
+  it('keeps the cached config across the poll boundary and drops it after the grace window', async () => {
+    const queryClient = createQueryClient();
     mockFetchFeaturedTabs.mockResolvedValueOnce(makeResponse());
-    const first = renderHook(() => useFeaturedTab(), { wrapper: createWrapper() });
+    const first = renderHook(() => useFeaturedTab(), { wrapper: createWrapper(queryClient) });
 
     await flushQuery();
     expect(first.result.current.tab?.id).toBe('ft_1234abcd');
@@ -151,21 +154,23 @@ describe('useFeaturedTab', () => {
     // dropping the tab here would bounce a reader off the tab they are on.
     vi.setSystemTime(new Date('2026-08-08T12:05:01Z'));
     mockFetchFeaturedTabs.mockRejectedValueOnce(new Error('temporary outage'));
-    const second = renderHook(() => useFeaturedTab(), { wrapper: createWrapper() });
+    const second = renderHook(() => useFeaturedTab(), { wrapper: createWrapper(queryClient) });
     expect(second.result.current.tab?.id).toBe('ft_1234abcd');
     second.unmount();
 
     // Past the poll interval plus its grace: the kill switch takes effect.
     vi.setSystemTime(new Date('2026-08-08T12:10:01Z'));
     mockFetchFeaturedTabs.mockRejectedValueOnce(new Error('sustained outage'));
-    const third = renderHook(() => useFeaturedTab(), { wrapper: createWrapper() });
+    const third = renderHook(() => useFeaturedTab(), { wrapper: createWrapper(queryClient) });
 
     expect(third.result.current.tab).toBeNull();
+    expect(third.result.current.isResolved).toBe(false);
   });
 
   it('ignores a cached config that belongs to a different Funnelcake host', async () => {
+    const queryClient = createQueryClient();
     mockFetchFeaturedTabs.mockResolvedValueOnce(makeResponse());
-    const first = renderHook(() => useFeaturedTab(), { wrapper: createWrapper() });
+    const first = renderHook(() => useFeaturedTab(), { wrapper: createWrapper(queryClient) });
 
     await flushQuery();
     expect(first.result.current.tab?.id).toBe('ft_1234abcd');
@@ -173,19 +178,20 @@ describe('useFeaturedTab', () => {
 
     apiUrl = 'https://relay.staging.dvines.org';
     mockFetchFeaturedTabs.mockRejectedValueOnce(new Error('staging outage'));
-    const second = renderHook(() => useFeaturedTab(), { wrapper: createWrapper() });
+    const second = renderHook(() => useFeaturedTab(), { wrapper: createWrapper(queryClient) });
 
     expect(second.result.current.tab).toBeNull();
   });
 
   it('clamps a hostile poll interval so it cannot extend the kill switch', async () => {
+    const queryClient = createQueryClient();
     // Without an upper clamp the grace window is a function of this number, so
     // a config endpoint could keep a killed tab on screen indefinitely.
     mockFetchFeaturedTabs.mockResolvedValueOnce({
       ...makeResponse(),
       poll_interval_seconds: 86400,
     });
-    const first = renderHook(() => useFeaturedTab(), { wrapper: createWrapper() });
+    const first = renderHook(() => useFeaturedTab(), { wrapper: createWrapper(queryClient) });
 
     await flushQuery();
     expect(first.result.current.tab?.id).toBe('ft_1234abcd');
@@ -194,9 +200,37 @@ describe('useFeaturedTab', () => {
     // 20 minutes: past the 15 minute clamp plus its grace, well inside 24 hours.
     vi.setSystemTime(new Date('2026-08-08T12:20:00Z'));
     mockFetchFeaturedTabs.mockRejectedValueOnce(new Error('sustained outage'));
-    const second = renderHook(() => useFeaturedTab(), { wrapper: createWrapper() });
+    const second = renderHook(() => useFeaturedTab(), { wrapper: createWrapper(queryClient) });
 
     expect(second.result.current.tab).toBeNull();
+  });
+
+  it('does not mark an expired cached config as resolved while the shared QueryClient refetches', async () => {
+    const queryClient = createQueryClient();
+    mockFetchFeaturedTabs.mockResolvedValueOnce(makeResponse());
+    const first = renderHook(() => useFeaturedTab(), { wrapper: createWrapper(queryClient) });
+
+    await flushQuery();
+    expect(first.result.current.tab?.slug).toBe('seasonal-theme');
+    first.unmount();
+
+    let release: (value: unknown) => void = () => {};
+    mockFetchFeaturedTabs.mockImplementationOnce(() => new Promise((resolve) => {
+      release = resolve;
+    }));
+    vi.setSystemTime(new Date('2026-08-08T12:10:00Z'));
+    const second = renderHook(() => useFeaturedTab(), { wrapper: createWrapper(queryClient) });
+
+    expect(second.result.current.tab).toBeNull();
+    expect(second.result.current.isResolved).toBe(false);
+
+    await act(async () => {
+      release(makeResponse());
+      await vi.advanceTimersByTimeAsync(0);
+    });
+
+    expect(second.result.current.tab?.slug).toBe('seasonal-theme');
+    expect(second.result.current.isResolved).toBe(true);
   });
 
   it('re-checks the editorial window against the clock, not the response identity', async () => {
@@ -248,14 +282,15 @@ describe('useFeaturedTab', () => {
   });
 
   it('stays resolved through a failed refresh while a cached config is still fresh', async () => {
+    const queryClient = createQueryClient();
     mockFetchFeaturedTabs.mockResolvedValueOnce(makeResponse());
-    const first = renderHook(() => useFeaturedTab(), { wrapper: createWrapper() });
+    const first = renderHook(() => useFeaturedTab(), { wrapper: createWrapper(queryClient) });
 
     await flushQuery();
     first.unmount();
 
     mockFetchFeaturedTabs.mockRejectedValueOnce(new Error('temporary outage'));
-    const second = renderHook(() => useFeaturedTab(), { wrapper: createWrapper() });
+    const second = renderHook(() => useFeaturedTab(), { wrapper: createWrapper(queryClient) });
 
     expect(second.result.current.isResolved).toBe(true);
   });

--- a/src/hooks/useFeaturedTab.test.ts
+++ b/src/hooks/useFeaturedTab.test.ts
@@ -106,7 +106,7 @@ describe('useFeaturedTab', () => {
     await flushQuery();
 
     expect(mockFetchFeaturedTabs).toHaveBeenCalled();
-    expect(result.current).toBeNull();
+    expect(result.current.tab).toBeNull();
   });
 
   it('resolves an eligible localized featured tab', async () => {
@@ -116,7 +116,7 @@ describe('useFeaturedTab', () => {
 
     await flushQuery();
 
-    expect(result.current).toEqual({
+    expect(result.current.tab).toEqual({
       id: 'ft_1234abcd',
       slug: 'seasonal-theme',
       label: 'Especial',
@@ -130,13 +130,13 @@ describe('useFeaturedTab', () => {
     const first = renderHook(() => useFeaturedTab(), { wrapper: createWrapper() });
 
     await flushQuery();
-    expect(first.result.current?.id).toBe('ft_1234abcd');
+    expect(first.result.current.tab?.id).toBe('ft_1234abcd');
     first.unmount();
 
     mockFetchFeaturedTabs.mockRejectedValueOnce(new Error('temporary outage'));
     const second = renderHook(() => useFeaturedTab(), { wrapper: createWrapper() });
 
-    expect(second.result.current?.id).toBe('ft_1234abcd');
+    expect(second.result.current.tab?.id).toBe('ft_1234abcd');
   });
 
   it('keeps the last-good config across the poll boundary and drops it after the grace window', async () => {
@@ -144,7 +144,7 @@ describe('useFeaturedTab', () => {
     const first = renderHook(() => useFeaturedTab(), { wrapper: createWrapper() });
 
     await flushQuery();
-    expect(first.result.current?.id).toBe('ft_1234abcd');
+    expect(first.result.current.tab?.id).toBe('ft_1234abcd');
     first.unmount();
 
     // One poll interval (300s) has elapsed and the refresh is still in flight:
@@ -152,15 +152,15 @@ describe('useFeaturedTab', () => {
     vi.setSystemTime(new Date('2026-08-08T12:05:01Z'));
     mockFetchFeaturedTabs.mockRejectedValueOnce(new Error('temporary outage'));
     const second = renderHook(() => useFeaturedTab(), { wrapper: createWrapper() });
-    expect(second.result.current?.id).toBe('ft_1234abcd');
+    expect(second.result.current.tab?.id).toBe('ft_1234abcd');
     second.unmount();
 
-    // Two intervals with no successful refresh: the kill switch takes effect.
+    // Past the poll interval plus its grace: the kill switch takes effect.
     vi.setSystemTime(new Date('2026-08-08T12:10:01Z'));
     mockFetchFeaturedTabs.mockRejectedValueOnce(new Error('sustained outage'));
     const third = renderHook(() => useFeaturedTab(), { wrapper: createWrapper() });
 
-    expect(third.result.current).toBeNull();
+    expect(third.result.current.tab).toBeNull();
   });
 
   it('ignores a cached config that belongs to a different Funnelcake host', async () => {
@@ -168,14 +168,70 @@ describe('useFeaturedTab', () => {
     const first = renderHook(() => useFeaturedTab(), { wrapper: createWrapper() });
 
     await flushQuery();
-    expect(first.result.current?.id).toBe('ft_1234abcd');
+    expect(first.result.current.tab?.id).toBe('ft_1234abcd');
     first.unmount();
 
     apiUrl = 'https://relay.staging.dvines.org';
     mockFetchFeaturedTabs.mockRejectedValueOnce(new Error('staging outage'));
     const second = renderHook(() => useFeaturedTab(), { wrapper: createWrapper() });
 
-    expect(second.result.current).toBeNull();
+    expect(second.result.current.tab).toBeNull();
+  });
+
+  it('clamps a hostile poll interval so it cannot extend the kill switch', async () => {
+    // Without an upper clamp the grace window is a function of this number, so
+    // a config endpoint could keep a killed tab on screen indefinitely.
+    mockFetchFeaturedTabs.mockResolvedValueOnce({
+      ...makeResponse(),
+      poll_interval_seconds: 86400,
+    });
+    const first = renderHook(() => useFeaturedTab(), { wrapper: createWrapper() });
+
+    await flushQuery();
+    expect(first.result.current.tab?.id).toBe('ft_1234abcd');
+    first.unmount();
+
+    // 20 minutes: past the 15 minute clamp plus its grace, well inside 24 hours.
+    vi.setSystemTime(new Date('2026-08-08T12:20:00Z'));
+    mockFetchFeaturedTabs.mockRejectedValueOnce(new Error('sustained outage'));
+    const second = renderHook(() => useFeaturedTab(), { wrapper: createWrapper() });
+
+    expect(second.result.current.tab).toBeNull();
+  });
+
+  it('re-checks the editorial window against the clock, not the response identity', async () => {
+    mockFetchFeaturedTabs.mockResolvedValueOnce(makeResponse({
+      ends_at: '2026-08-08T12:02:00Z',
+    }));
+    const { result, rerender } = renderHook(() => useFeaturedTab(), { wrapper: createWrapper() });
+
+    await flushQuery();
+    expect(result.current.tab?.id).toBe('ft_1234abcd');
+
+    // Same cached response object, later clock: ends_at has passed.
+    vi.setSystemTime(new Date('2026-08-08T12:03:00Z'));
+    rerender();
+
+    expect(result.current.tab).toBeNull();
+  });
+
+  it('reports the configuration as unresolved until the first request settles', async () => {
+    let release: (value: unknown) => void = () => {};
+    mockFetchFeaturedTabs.mockImplementationOnce(() => new Promise((resolve) => {
+      release = resolve;
+    }));
+
+    const { result } = renderHook(() => useFeaturedTab(), { wrapper: createWrapper() });
+
+    expect(result.current.isResolved).toBe(false);
+
+    await act(async () => {
+      release(makeResponse());
+      await vi.advanceTimersByTimeAsync(0);
+    });
+
+    expect(result.current.isResolved).toBe(true);
+    expect(result.current.tab?.id).toBe('ft_1234abcd');
   });
 
   it('hides minor-restricted tabs when protected-minor status is unknown', async () => {
@@ -187,6 +243,6 @@ describe('useFeaturedTab', () => {
     await flushQuery();
 
     expect(mockFetchFeaturedTabs).toHaveBeenCalled();
-    expect(result.current).toBeNull();
+    expect(result.current.tab).toBeNull();
   });
 });

--- a/src/hooks/useFeaturedTab.test.ts
+++ b/src/hooks/useFeaturedTab.test.ts
@@ -1,0 +1,162 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { FeaturedTabsResponse } from '@/types/featuredTabs';
+
+const mockFetchFeaturedTabs = vi.fn();
+let minorState: 'protected' | 'not_protected' | 'unknown' = 'not_protected';
+let language = 'es-MX';
+
+vi.mock('@/lib/featuredTabsClient', () => ({
+  fetchFeaturedTabs: mockFetchFeaturedTabs,
+}));
+
+vi.mock('@/hooks/useProtectedMinorStatus', () => ({
+  useProtectedMinorStatus: () => ({
+    state: minorState,
+    isKnown: minorState !== 'unknown',
+    verifiedMinorAt: null,
+  }),
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    i18n: { language },
+  }),
+}));
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+      },
+    },
+  });
+
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return React.createElement(QueryClientProvider, { client: queryClient }, children);
+  };
+}
+
+function makeResponse(overrides: Partial<FeaturedTabsResponse['featured_tabs'][number]> = {}): FeaturedTabsResponse {
+  return {
+    poll_interval_seconds: 300,
+    featured_tabs: [
+      {
+        id: 'ft_1234abcd',
+        slug: 'seasonal-theme',
+        label: { default: 'Seasonal', es: 'Especial' },
+        position: { web: { after: 'hot' } },
+        starts_at: '2026-08-01T00:00:00Z',
+        ends_at: '2026-09-01T00:00:00Z',
+        enabled: true,
+        visible_to_minors: true,
+        disclosure_label: null,
+        has_content: true,
+        ...overrides,
+      },
+    ],
+  };
+}
+
+async function flushQuery(): Promise<void> {
+  await act(async () => {
+    await vi.advanceTimersByTimeAsync(0);
+  });
+}
+
+let useFeaturedTab: typeof import('./useFeaturedTab').useFeaturedTab;
+let clearFeaturedTabCacheForTests: typeof import('./useFeaturedTab').clearFeaturedTabCacheForTests;
+
+beforeEach(async () => {
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date('2026-08-08T12:00:00Z'));
+  vi.clearAllMocks();
+  minorState = 'not_protected';
+  language = 'es-MX';
+
+  const hook = await import('./useFeaturedTab');
+  useFeaturedTab = hook.useFeaturedTab;
+  clearFeaturedTabCacheForTests = hook.clearFeaturedTabCacheForTests;
+  clearFeaturedTabCacheForTests();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('useFeaturedTab', () => {
+  it('returns null when Funnelcake serves no featured configuration', async () => {
+    mockFetchFeaturedTabs.mockResolvedValueOnce({
+      poll_interval_seconds: 300,
+      featured_tabs: [],
+    });
+
+    const { result } = renderHook(() => useFeaturedTab(), { wrapper: createWrapper() });
+
+    await flushQuery();
+
+    expect(mockFetchFeaturedTabs).toHaveBeenCalled();
+    expect(result.current).toBeNull();
+  });
+
+  it('resolves an eligible localized featured tab', async () => {
+    mockFetchFeaturedTabs.mockResolvedValueOnce(makeResponse());
+
+    const { result } = renderHook(() => useFeaturedTab(), { wrapper: createWrapper() });
+
+    await flushQuery();
+
+    expect(result.current).toEqual({
+      id: 'ft_1234abcd',
+      slug: 'seasonal-theme',
+      label: 'Especial',
+      position: { after: 'hot' },
+      disclosureLabel: null,
+    });
+  });
+
+  it('uses a fresh last-good config through one transient refresh failure', async () => {
+    mockFetchFeaturedTabs.mockResolvedValueOnce(makeResponse());
+    const first = renderHook(() => useFeaturedTab(), { wrapper: createWrapper() });
+
+    await flushQuery();
+    expect(first.result.current?.id).toBe('ft_1234abcd');
+    first.unmount();
+
+    mockFetchFeaturedTabs.mockRejectedValueOnce(new Error('temporary outage'));
+    const second = renderHook(() => useFeaturedTab(), { wrapper: createWrapper() });
+
+    expect(second.result.current?.id).toBe('ft_1234abcd');
+  });
+
+  it('drops the last-good config after the 5 minute TTL', async () => {
+    mockFetchFeaturedTabs.mockResolvedValueOnce(makeResponse());
+    const first = renderHook(() => useFeaturedTab(), { wrapper: createWrapper() });
+
+    await flushQuery();
+    expect(first.result.current?.id).toBe('ft_1234abcd');
+    first.unmount();
+
+    vi.setSystemTime(new Date('2026-08-08T12:05:01Z'));
+    mockFetchFeaturedTabs.mockRejectedValueOnce(new Error('sustained outage'));
+    const second = renderHook(() => useFeaturedTab(), { wrapper: createWrapper() });
+
+    expect(second.result.current).toBeNull();
+  });
+
+  it('hides minor-restricted tabs when protected-minor status is unknown', async () => {
+    minorState = 'unknown';
+    mockFetchFeaturedTabs.mockResolvedValueOnce(makeResponse({ visible_to_minors: false }));
+
+    const { result } = renderHook(() => useFeaturedTab(), { wrapper: createWrapper() });
+
+    await flushQuery();
+
+    expect(mockFetchFeaturedTabs).toHaveBeenCalled();
+    expect(result.current).toBeNull();
+  });
+});

--- a/src/hooks/useFeaturedTab.test.ts
+++ b/src/hooks/useFeaturedTab.test.ts
@@ -126,6 +126,23 @@ describe('useFeaturedTab', () => {
     });
   });
 
+  it('fetches configuration from the supplied Funnelcake host', async () => {
+    mockFetchFeaturedTabs.mockResolvedValueOnce(makeResponse());
+
+    const { result } = renderHook(
+      () => useFeaturedTab({ apiUrl: 'https://api.staging.divine.video' }),
+      { wrapper: createWrapper() }
+    );
+
+    await flushQuery();
+
+    expect(mockFetchFeaturedTabs).toHaveBeenCalledWith(
+      'https://api.staging.divine.video',
+      expect.any(AbortSignal)
+    );
+    expect(result.current.tab?.id).toBe('ft_1234abcd');
+  });
+
   it('uses a fresh cached config through one transient refresh failure', async () => {
     const queryClient = createQueryClient();
     mockFetchFeaturedTabs.mockResolvedValueOnce(makeResponse());

--- a/src/hooks/useFeaturedTab.ts
+++ b/src/hooks/useFeaturedTab.ts
@@ -84,7 +84,7 @@ export function useFeaturedTab(): FeaturedTabState {
   const minorStatus = useProtectedMinorStatus();
   const lastResolved = useRef<ResolvedFeaturedTab | null>(null);
 
-  const { isSuccess, isError } = useQuery({
+  const { isSuccess } = useQuery({
     queryKey: ['featured-tabs', apiUrl],
     queryFn: async ({ signal }) => {
       const response = await fetchFeaturedTabs(apiUrl, signal);
@@ -123,6 +123,10 @@ export function useFeaturedTab(): FeaturedTabState {
 
   return {
     tab: lastResolved.current,
-    isResolved: isSuccess || isError || response !== null,
+    // A failed request is not an answer. `isError` deliberately does not count:
+    // without a config in hand we do not know whether a given slug names a live
+    // featured tab, and a caller that redirected on it would throw away a valid
+    // shared link during a config outage. Unknown stays unknown.
+    isResolved: isSuccess || response !== null,
   };
 }

--- a/src/hooks/useFeaturedTab.ts
+++ b/src/hooks/useFeaturedTab.ts
@@ -1,0 +1,68 @@
+import { useMemo } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { useTranslation } from 'react-i18next';
+import { getFunnelcakeBaseUrl } from '@/config/api';
+import { useProtectedMinorStatus } from '@/hooks/useProtectedMinorStatus';
+import { fetchFeaturedTabs } from '@/lib/featuredTabsClient';
+import { selectFeaturedTab } from '@/lib/featuredTabEligibility';
+import type { FeaturedTabsResponse, ResolvedFeaturedTab } from '@/types/featuredTabs';
+
+const FEATURED_TAB_CACHE_TTL_MS = 5 * 60 * 1000;
+const MIN_REFETCH_INTERVAL_MS = 30 * 1000;
+const DEFAULT_REFETCH_INTERVAL_MS = 5 * 60 * 1000;
+
+let lastGoodConfig: { response: FeaturedTabsResponse; refreshedAt: number } | null = null;
+
+function getFreshCachedConfig(now: number): FeaturedTabsResponse | null {
+  if (!lastGoodConfig) return null;
+  return now - lastGoodConfig.refreshedAt <= FEATURED_TAB_CACHE_TTL_MS
+    ? lastGoodConfig.response
+    : null;
+}
+
+function getRefetchIntervalMs(response: FeaturedTabsResponse | undefined): number {
+  const seconds = response?.poll_interval_seconds;
+  if (!Number.isFinite(seconds) || !seconds || seconds <= 0) {
+    return DEFAULT_REFETCH_INTERVAL_MS;
+  }
+
+  return Math.max(MIN_REFETCH_INTERVAL_MS, seconds * 1000);
+}
+
+export function clearFeaturedTabCacheForTests(): void {
+  lastGoodConfig = null;
+}
+
+export function useFeaturedTab(): ResolvedFeaturedTab | null {
+  const apiUrl = getFunnelcakeBaseUrl();
+  const { i18n } = useTranslation();
+  const minorStatus = useProtectedMinorStatus();
+
+  const query = useQuery({
+    queryKey: ['featured-tabs', apiUrl],
+    queryFn: async ({ signal }) => {
+      const response = await fetchFeaturedTabs(apiUrl, signal);
+      lastGoodConfig = {
+        response,
+        refreshedAt: Date.now(),
+      };
+      return response;
+    },
+    staleTime: 60 * 1000,
+    gcTime: FEATURED_TAB_CACHE_TTL_MS,
+    refetchOnWindowFocus: true,
+    refetchInterval: (queryState) => getRefetchIntervalMs(queryState.state.data),
+  });
+
+  const response = getFreshCachedConfig(Date.now());
+
+  return useMemo(() => {
+    if (!response) return null;
+
+    return selectFeaturedTab(response.featured_tabs, {
+      now: new Date(),
+      minorState: minorStatus.state,
+      locale: i18n.language,
+    });
+  }, [i18n.language, minorStatus.state, response]);
+}

--- a/src/hooks/useFeaturedTab.ts
+++ b/src/hooks/useFeaturedTab.ts
@@ -7,18 +7,20 @@ import { fetchFeaturedTabs } from '@/lib/featuredTabsClient';
 import { selectFeaturedTab } from '@/lib/featuredTabEligibility';
 import type { FeaturedTabsResponse, ResolvedFeaturedTab } from '@/types/featuredTabs';
 
-const FEATURED_TAB_CACHE_TTL_MS = 5 * 60 * 1000;
 const MIN_REFETCH_INTERVAL_MS = 30 * 1000;
 const DEFAULT_REFETCH_INTERVAL_MS = 5 * 60 * 1000;
+// The last-good config is bounded so an editorial kill switch still takes
+// effect when the config endpoint is down. The bound has to leave room for the
+// poll itself: at exactly one interval a render can land before the in-flight
+// refresh resolves, drop the tab, and bounce a reader off the tab they are on.
+const STALE_CONFIG_GRACE_INTERVALS = 2;
+const GC_TIME_MS = 30 * 60 * 1000;
 
-let lastGoodConfig: { response: FeaturedTabsResponse; refreshedAt: number } | null = null;
-
-function getFreshCachedConfig(now: number): FeaturedTabsResponse | null {
-  if (!lastGoodConfig) return null;
-  return now - lastGoodConfig.refreshedAt <= FEATURED_TAB_CACHE_TTL_MS
-    ? lastGoodConfig.response
-    : null;
-}
+let lastGoodConfig: {
+  apiUrl: string;
+  response: FeaturedTabsResponse;
+  refreshedAt: number;
+} | null = null;
 
 function getRefetchIntervalMs(response: FeaturedTabsResponse | undefined): number {
   const seconds = response?.poll_interval_seconds;
@@ -27,6 +29,15 @@ function getRefetchIntervalMs(response: FeaturedTabsResponse | undefined): numbe
   }
 
   return Math.max(MIN_REFETCH_INTERVAL_MS, seconds * 1000);
+}
+
+function getFreshCachedConfig(apiUrl: string, now: number): FeaturedTabsResponse | null {
+  if (!lastGoodConfig || lastGoodConfig.apiUrl !== apiUrl) return null;
+
+  const maxAgeMs = getRefetchIntervalMs(lastGoodConfig.response) * STALE_CONFIG_GRACE_INTERVALS;
+  return now - lastGoodConfig.refreshedAt <= maxAgeMs
+    ? lastGoodConfig.response
+    : null;
 }
 
 export function clearFeaturedTabCacheForTests(): void {
@@ -43,18 +54,19 @@ export function useFeaturedTab(): ResolvedFeaturedTab | null {
     queryFn: async ({ signal }) => {
       const response = await fetchFeaturedTabs(apiUrl, signal);
       lastGoodConfig = {
+        apiUrl,
         response,
         refreshedAt: Date.now(),
       };
       return response;
     },
     staleTime: 60 * 1000,
-    gcTime: FEATURED_TAB_CACHE_TTL_MS,
+    gcTime: GC_TIME_MS,
     refetchOnWindowFocus: true,
     refetchInterval: (queryState) => getRefetchIntervalMs(queryState.state.data),
   });
 
-  const response = getFreshCachedConfig(Date.now());
+  const response = getFreshCachedConfig(apiUrl, Date.now());
 
   return useMemo(() => {
     if (!response) return null;

--- a/src/hooks/useFeaturedTab.ts
+++ b/src/hooks/useFeaturedTab.ts
@@ -38,7 +38,7 @@ export function useFeaturedTab(): ResolvedFeaturedTab | null {
   const { i18n } = useTranslation();
   const minorStatus = useProtectedMinorStatus();
 
-  const query = useQuery({
+  useQuery({
     queryKey: ['featured-tabs', apiUrl],
     queryFn: async ({ signal }) => {
       const response = await fetchFeaturedTabs(apiUrl, signal);

--- a/src/hooks/useFeaturedTab.ts
+++ b/src/hooks/useFeaturedTab.ts
@@ -1,4 +1,3 @@
-import { useRef } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { useTranslation } from 'react-i18next';
 import { getFunnelcakeBaseUrl } from '@/config/api';
@@ -32,12 +31,6 @@ export interface FeaturedTabState {
   isResolved: boolean;
 }
 
-let lastGoodConfig: {
-  apiUrl: string;
-  response: FeaturedTabsResponse;
-  refreshedAt: number;
-} | null = null;
-
 function getRefetchIntervalMs(response: FeaturedTabsResponse | undefined): number {
   const seconds = response?.poll_interval_seconds;
   if (!Number.isFinite(seconds) || !seconds || seconds <= 0) {
@@ -50,65 +43,40 @@ function getRefetchIntervalMs(response: FeaturedTabsResponse | undefined): numbe
   );
 }
 
-function getFreshCachedConfig(apiUrl: string, now: number): FeaturedTabsResponse | null {
-  if (!lastGoodConfig || lastGoodConfig.apiUrl !== apiUrl) return null;
+function getFreshCachedConfig(
+  response: FeaturedTabsResponse | undefined,
+  refreshedAt: number,
+  now: number
+): FeaturedTabsResponse | null {
+  if (!response || !refreshedAt) return null;
 
-  const maxAgeMs = getRefetchIntervalMs(lastGoodConfig.response) + STALE_CONFIG_GRACE_MS;
-  return now - lastGoodConfig.refreshedAt <= maxAgeMs
-    ? lastGoodConfig.response
+  const maxAgeMs = getRefetchIntervalMs(response) + STALE_CONFIG_GRACE_MS;
+  return now - refreshedAt <= maxAgeMs
+    ? response
     : null;
-}
-
-function isSameResolvedTab(
-  a: ResolvedFeaturedTab | null,
-  b: ResolvedFeaturedTab | null
-): boolean {
-  if (a === b) return true;
-  if (!a || !b) return false;
-
-  return a.id === b.id
-    && a.slug === b.slug
-    && a.label === b.label
-    && a.disclosureLabel === b.disclosureLabel
-    && a.position?.after === b.position?.after
-    && a.position?.before === b.position?.before;
-}
-
-export function clearFeaturedTabCacheForTests(): void {
-  lastGoodConfig = null;
 }
 
 export function useFeaturedTab(): FeaturedTabState {
   const apiUrl = getFunnelcakeBaseUrl();
   const { i18n } = useTranslation();
   const minorStatus = useProtectedMinorStatus();
-  const lastResolved = useRef<ResolvedFeaturedTab | null>(null);
 
-  const { isSuccess } = useQuery({
+  const { data, dataUpdatedAt } = useQuery({
     queryKey: ['featured-tabs', apiUrl],
-    queryFn: async ({ signal }) => {
-      const response = await fetchFeaturedTabs(apiUrl, signal);
-      lastGoodConfig = {
-        apiUrl,
-        response,
-        refreshedAt: Date.now(),
-      };
-      return response;
-    },
+    queryFn: ({ signal }) => fetchFeaturedTabs(apiUrl, signal),
     staleTime: 60 * 1000,
     gcTime: GC_TIME_MS,
     refetchOnWindowFocus: true,
     refetchInterval: (queryState) => getRefetchIntervalMs(queryState.state.data),
   });
 
-  const response = getFreshCachedConfig(apiUrl, Date.now());
+  const response = getFreshCachedConfig(data, dataUpdatedAt, Date.now());
 
   // Deliberately not memoized on the response identity: `starts_at` / `ends_at`
   // are evaluated against the current time, and a memo keyed on the response
   // would hold a decision taken before the editorial window opened or closed
   // until the next successful poll replaced the object. Selection is a scan of
-  // a short list, so it runs per render and the reference is stabilised below
-  // to keep consumers' effects and memos from churning.
+  // a short list, so it runs per render.
   const resolved = response
     ? selectFeaturedTab(response.featured_tabs, {
         now: new Date(),
@@ -117,16 +85,12 @@ export function useFeaturedTab(): FeaturedTabState {
       })
     : null;
 
-  if (!isSameResolvedTab(lastResolved.current, resolved)) {
-    lastResolved.current = resolved;
-  }
-
   return {
-    tab: lastResolved.current,
+    tab: resolved,
     // A failed request is not an answer. `isError` deliberately does not count:
     // without a config in hand we do not know whether a given slug names a live
     // featured tab, and a caller that redirected on it would throw away a valid
     // shared link during a config outage. Unknown stays unknown.
-    isResolved: isSuccess || response !== null,
+    isResolved: response !== null,
   };
 }

--- a/src/hooks/useFeaturedTab.ts
+++ b/src/hooks/useFeaturedTab.ts
@@ -56,8 +56,11 @@ function getFreshCachedConfig(
     : null;
 }
 
-export function useFeaturedTab(): FeaturedTabState {
-  const apiUrl = getFunnelcakeBaseUrl();
+export function useFeaturedTab({
+  apiUrl = getFunnelcakeBaseUrl(),
+}: {
+  apiUrl?: string;
+} = {}): FeaturedTabState {
   const { i18n } = useTranslation();
   const minorStatus = useProtectedMinorStatus();
 

--- a/src/hooks/useFeaturedTab.ts
+++ b/src/hooks/useFeaturedTab.ts
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { useRef } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { useTranslation } from 'react-i18next';
 import { getFunnelcakeBaseUrl } from '@/config/api';
@@ -9,12 +9,28 @@ import type { FeaturedTabsResponse, ResolvedFeaturedTab } from '@/types/featured
 
 const MIN_REFETCH_INTERVAL_MS = 30 * 1000;
 const DEFAULT_REFETCH_INTERVAL_MS = 5 * 60 * 1000;
-// The last-good config is bounded so an editorial kill switch still takes
-// effect when the config endpoint is down. The bound has to leave room for the
-// poll itself: at exactly one interval a render can land before the in-flight
-// refresh resolves, drop the tab, and bounce a reader off the tab they are on.
-const STALE_CONFIG_GRACE_INTERVALS = 2;
+// The poll cadence is server-supplied, so it is clamped at both ends. Without an
+// upper bound a misconfigured or hostile config response could set a very large
+// interval and, because the grace window below is derived from it, keep a killed
+// tab on screen for as long as it liked.
+const MAX_REFETCH_INTERVAL_MS = 15 * 60 * 1000;
+// Grace past one poll before the last-good config is dropped. At exactly one
+// interval a render can land before the in-flight refresh resolves, drop the
+// tab, and bounce a reader off the tab they are reading.
+const STALE_CONFIG_GRACE_MS = 60 * 1000;
 const GC_TIME_MS = 30 * 60 * 1000;
+
+export interface FeaturedTabState {
+  tab: ResolvedFeaturedTab | null;
+  /**
+   * Whether the featured configuration is known, either from a settled request
+   * or from a still-fresh last-good response. Callers that redirect on an
+   * unknown Discovery slug must wait for this: before it is true, `tab: null`
+   * only means "not loaded yet", and treating it as "no such tab" would break
+   * a deep link to a perfectly valid featured slug.
+   */
+  isResolved: boolean;
+}
 
 let lastGoodConfig: {
   apiUrl: string;
@@ -28,28 +44,47 @@ function getRefetchIntervalMs(response: FeaturedTabsResponse | undefined): numbe
     return DEFAULT_REFETCH_INTERVAL_MS;
   }
 
-  return Math.max(MIN_REFETCH_INTERVAL_MS, seconds * 1000);
+  return Math.min(
+    MAX_REFETCH_INTERVAL_MS,
+    Math.max(MIN_REFETCH_INTERVAL_MS, seconds * 1000)
+  );
 }
 
 function getFreshCachedConfig(apiUrl: string, now: number): FeaturedTabsResponse | null {
   if (!lastGoodConfig || lastGoodConfig.apiUrl !== apiUrl) return null;
 
-  const maxAgeMs = getRefetchIntervalMs(lastGoodConfig.response) * STALE_CONFIG_GRACE_INTERVALS;
+  const maxAgeMs = getRefetchIntervalMs(lastGoodConfig.response) + STALE_CONFIG_GRACE_MS;
   return now - lastGoodConfig.refreshedAt <= maxAgeMs
     ? lastGoodConfig.response
     : null;
+}
+
+function isSameResolvedTab(
+  a: ResolvedFeaturedTab | null,
+  b: ResolvedFeaturedTab | null
+): boolean {
+  if (a === b) return true;
+  if (!a || !b) return false;
+
+  return a.id === b.id
+    && a.slug === b.slug
+    && a.label === b.label
+    && a.disclosureLabel === b.disclosureLabel
+    && a.position?.after === b.position?.after
+    && a.position?.before === b.position?.before;
 }
 
 export function clearFeaturedTabCacheForTests(): void {
   lastGoodConfig = null;
 }
 
-export function useFeaturedTab(): ResolvedFeaturedTab | null {
+export function useFeaturedTab(): FeaturedTabState {
   const apiUrl = getFunnelcakeBaseUrl();
   const { i18n } = useTranslation();
   const minorStatus = useProtectedMinorStatus();
+  const lastResolved = useRef<ResolvedFeaturedTab | null>(null);
 
-  useQuery({
+  const { isSuccess, isError } = useQuery({
     queryKey: ['featured-tabs', apiUrl],
     queryFn: async ({ signal }) => {
       const response = await fetchFeaturedTabs(apiUrl, signal);
@@ -68,13 +103,26 @@ export function useFeaturedTab(): ResolvedFeaturedTab | null {
 
   const response = getFreshCachedConfig(apiUrl, Date.now());
 
-  return useMemo(() => {
-    if (!response) return null;
+  // Deliberately not memoized on the response identity: `starts_at` / `ends_at`
+  // are evaluated against the current time, and a memo keyed on the response
+  // would hold a decision taken before the editorial window opened or closed
+  // until the next successful poll replaced the object. Selection is a scan of
+  // a short list, so it runs per render and the reference is stabilised below
+  // to keep consumers' effects and memos from churning.
+  const resolved = response
+    ? selectFeaturedTab(response.featured_tabs, {
+        now: new Date(),
+        minorState: minorStatus.state,
+        locale: i18n.language,
+      })
+    : null;
 
-    return selectFeaturedTab(response.featured_tabs, {
-      now: new Date(),
-      minorState: minorStatus.state,
-      locale: i18n.language,
-    });
-  }, [i18n.language, minorStatus.state, response]);
+  if (!isSameResolvedTab(lastResolved.current, resolved)) {
+    lastResolved.current = resolved;
+  }
+
+  return {
+    tab: lastResolved.current,
+    isResolved: isSuccess || isError || response !== null,
+  };
 }

--- a/src/hooks/useFeaturedTabVideos.test.ts
+++ b/src/hooks/useFeaturedTabVideos.test.ts
@@ -1,0 +1,97 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockFetchFeaturedTabVideos = vi.fn();
+const mockTransformToVideoPage = vi.fn();
+
+vi.mock('@/lib/featuredTabsClient', () => ({
+  fetchFeaturedTabVideos: mockFetchFeaturedTabVideos,
+}));
+
+vi.mock('@/lib/funnelcakeTransform', () => ({
+  transformToVideoPage: mockTransformToVideoPage,
+}));
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+      },
+    },
+  });
+
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return React.createElement(QueryClientProvider, { client: queryClient }, children);
+  };
+}
+
+let useFeaturedTabVideos: typeof import('./useFeaturedTabVideos').useFeaturedTabVideos;
+
+beforeEach(async () => {
+  vi.clearAllMocks();
+  ({ useFeaturedTabVideos } = await import('./useFeaturedTabVideos'));
+});
+
+describe('useFeaturedTabVideos', () => {
+  it('does not request videos without an eligible config id', () => {
+    const { result } = renderHook(
+      () => useFeaturedTabVideos({ configId: undefined, enabled: true }),
+      { wrapper: createWrapper() }
+    );
+
+    expect(result.current.fetchStatus).toBe('idle');
+    expect(mockFetchFeaturedTabVideos).not.toHaveBeenCalled();
+  });
+
+  it('fetches the configured tab and paginates with the opaque cursor', async () => {
+    mockFetchFeaturedTabVideos
+      .mockResolvedValueOnce({ videos: [{}], has_more: true, next_cursor: 'cursor-2' })
+      .mockResolvedValueOnce({ videos: [{}], has_more: false, next_cursor: undefined });
+    mockTransformToVideoPage
+      .mockReturnValueOnce({
+        videos: [{ id: 'video-1', pubkey: 'pubkey-1', kind: 34236, createdAt: 1, vineId: 'one' }],
+        nextCursor: undefined,
+        rawCursor: 'cursor-2',
+        hasMore: true,
+      })
+      .mockReturnValueOnce({
+        videos: [{ id: 'video-2', pubkey: 'pubkey-2', kind: 34236, createdAt: 2, vineId: 'two' }],
+        nextCursor: undefined,
+        rawCursor: undefined,
+        hasMore: false,
+      });
+
+    const { result } = renderHook(
+      () => useFeaturedTabVideos({ configId: 'ft_1234abcd', pageSize: 12 }),
+      { wrapper: createWrapper() }
+    );
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    await act(async () => {
+      await result.current.fetchNextPage();
+    });
+
+    expect(mockFetchFeaturedTabVideos).toHaveBeenNthCalledWith(
+      1,
+      'https://api.divine.video',
+      'ft_1234abcd',
+      undefined,
+      12,
+      expect.any(AbortSignal)
+    );
+    expect(mockFetchFeaturedTabVideos).toHaveBeenNthCalledWith(
+      2,
+      'https://api.divine.video',
+      'ft_1234abcd',
+      'cursor-2',
+      12,
+      expect.any(AbortSignal)
+    );
+  });
+});

--- a/src/hooks/useFeaturedTabVideos.ts
+++ b/src/hooks/useFeaturedTabVideos.ts
@@ -1,0 +1,57 @@
+import { useInfiniteQuery } from '@tanstack/react-query';
+import { getFunnelcakeBaseUrl } from '@/config/api';
+import { fetchFeaturedTabVideos } from '@/lib/featuredTabsClient';
+import { transformToVideoPage } from '@/lib/funnelcakeTransform';
+import type { ParsedVideoData } from '@/types/video';
+
+export interface FeaturedTabVideoPage {
+  videos: ParsedVideoData[];
+  nextCursor: number | undefined;
+  rawCursor?: string;
+  hasMore: boolean;
+}
+
+export function useFeaturedTabVideos({
+  configId,
+  apiUrl = getFunnelcakeBaseUrl(),
+  pageSize = 12,
+  enabled = true,
+}: {
+  configId?: string;
+  apiUrl?: string;
+  pageSize?: number;
+  enabled?: boolean;
+}) {
+  return useInfiniteQuery<FeaturedTabVideoPage, Error>({
+    queryKey: ['featured-tab-videos', apiUrl, configId, pageSize],
+    queryFn: async ({ pageParam, signal }) => {
+      if (!configId) {
+        return {
+          videos: [],
+          nextCursor: undefined,
+          rawCursor: undefined,
+          hasMore: false,
+        };
+      }
+
+      const response = await fetchFeaturedTabVideos(
+        apiUrl,
+        configId,
+        typeof pageParam === 'string' ? pageParam : undefined,
+        pageSize,
+        signal
+      );
+
+      return transformToVideoPage(response, 'cursor');
+    },
+    getNextPageParam: (lastPage) => lastPage.rawCursor,
+    initialPageParam: undefined,
+    enabled: enabled && !!configId,
+    staleTime: 60 * 1000,
+    gcTime: 10 * 60 * 1000,
+    meta: {
+      source: 'funnelcake',
+      apiUrl,
+    },
+  });
+}

--- a/src/hooks/useFeaturedTabVideos.ts
+++ b/src/hooks/useFeaturedTabVideos.ts
@@ -25,18 +25,9 @@ export function useFeaturedTabVideos({
   return useInfiniteQuery<FeaturedTabVideoPage, Error>({
     queryKey: ['featured-tab-videos', apiUrl, configId, pageSize],
     queryFn: async ({ pageParam, signal }) => {
-      if (!configId) {
-        return {
-          videos: [],
-          nextCursor: undefined,
-          rawCursor: undefined,
-          hasMore: false,
-        };
-      }
-
       const response = await fetchFeaturedTabVideos(
         apiUrl,
-        configId,
+        configId!,
         typeof pageParam === 'string' ? pageParam : undefined,
         pageSize,
         signal

--- a/src/hooks/useFeaturedTabVideos.ts
+++ b/src/hooks/useFeaturedTabVideos.ts
@@ -25,9 +25,13 @@ export function useFeaturedTabVideos({
   return useInfiniteQuery<FeaturedTabVideoPage, Error>({
     queryKey: ['featured-tab-videos', apiUrl, configId, pageSize],
     queryFn: async ({ pageParam, signal }) => {
+      if (!configId) {
+        throw new Error('Featured tab config id is required');
+      }
+
       const response = await fetchFeaturedTabVideos(
         apiUrl,
-        configId!,
+        configId,
         typeof pageParam === 'string' ? pageParam : undefined,
         pageSize,
         signal

--- a/src/hooks/useVideoNavigation.ts
+++ b/src/hooks/useVideoNavigation.ts
@@ -12,7 +12,7 @@ import type { SortMode } from '@/types/nostr';
 type WebSocketFeedType = 'discovery' | 'home' | 'trending' | 'hashtag' | 'profile' | 'recent' | 'classics' | 'category';
 
 export interface VideoNavigationContext {
-  source: 'hashtag' | 'profile' | 'discovery' | 'home' | 'trending' | 'popular' | 'recent' | 'classics' | 'foryou' | 'category' | 'search' | 'people-list';
+  source: 'hashtag' | 'profile' | 'discovery' | 'home' | 'trending' | 'popular' | 'recent' | 'classics' | 'foryou' | 'category' | 'search' | 'people-list' | 'featured';
   hashtag?: string;
   pubkey?: string;
   listId?: string;
@@ -76,7 +76,7 @@ export function useVideoNavigation(videoId: string, options: UseVideoNavigationO
   const feedTypeForWebSocket: WebSocketFeedType | undefined = (() => {
     if (!context) return undefined;
     if (isPeopleListContext) return 'discovery';
-    if (context.source === 'foryou' || context.source === 'popular') return 'trending';
+    if (context.source === 'foryou' || context.source === 'popular' || context.source === 'featured') return 'trending';
     if (context.source === 'search') return 'discovery';
     if (
       context.source === 'hashtag' ||

--- a/src/hooks/useVideoProvider.blocklist.test.ts
+++ b/src/hooks/useVideoProvider.blocklist.test.ts
@@ -58,6 +58,17 @@ vi.mock('@/hooks/useInfiniteVideos', () => ({
   }),
 }));
 
+vi.mock('@/hooks/useFeaturedTabVideos', () => ({
+  useFeaturedTabVideos: () => ({
+    data: undefined,
+    fetchNextPage: vi.fn(),
+    hasNextPage: false,
+    isLoading: false,
+    error: null,
+    refetch: vi.fn(),
+  }),
+}));
+
 vi.mock('@/hooks/useAppContext', () => ({
   useAppContext: () => ({ config: { relayUrl: 'wss://relay.divine.video' } }),
 }));

--- a/src/hooks/useVideoProvider.test.ts
+++ b/src/hooks/useVideoProvider.test.ts
@@ -4,6 +4,7 @@ import type { RelayCapabilities } from '@/lib/relayCapabilities';
 
 const mockUseInfiniteVideos = vi.fn();
 const mockUseInfiniteVideosFunnelcake = vi.fn();
+const mockUseFeaturedTabVideos = vi.fn();
 const mockUseResolvedRelayCapabilities = vi.fn();
 
 let relayUrl = 'wss://relay.divine.video';
@@ -45,6 +46,10 @@ vi.mock('@/hooks/useInfiniteVideosFunnelcake', () => ({
   useInfiniteVideosFunnelcake: mockUseInfiniteVideosFunnelcake,
 }));
 
+vi.mock('@/hooks/useFeaturedTabVideos', () => ({
+  useFeaturedTabVideos: mockUseFeaturedTabVideos,
+}));
+
 vi.mock('@/hooks/useRelayCapabilities', () => ({
   useResolvedRelayCapabilities: mockUseResolvedRelayCapabilities,
 }));
@@ -76,6 +81,7 @@ beforeEach(async () => {
 
   mockUseInfiniteVideos.mockReturnValue(queryResult);
   mockUseInfiniteVideosFunnelcake.mockReturnValue(queryResult);
+  mockUseFeaturedTabVideos.mockReturnValue(queryResult);
   mockUseResolvedRelayCapabilities.mockReturnValue(makeCapabilities());
 
   const hook = await import('./useVideoProvider');
@@ -223,6 +229,48 @@ describe('useVideoProvider', () => {
       enabled: false,
     }));
     expect(result.current.dataSource).toBe('funnelcake');
+  });
+
+  it('routes featured feeds to the REST-only featured hook with no WebSocket fallback', () => {
+    const { result } = renderHook(() =>
+      useVideoProvider({
+        feedType: 'featured',
+        featuredTabId: 'ft_1234abcd',
+      })
+    );
+
+    expect(mockUseInfiniteVideosFunnelcake).toHaveBeenCalledWith(expect.objectContaining({
+      enabled: false,
+    }));
+    expect(mockUseFeaturedTabVideos).toHaveBeenCalledWith(expect.objectContaining({
+      configId: 'ft_1234abcd',
+      apiUrl: 'https://api.divine.video',
+      enabled: true,
+    }));
+    expect(mockUseInfiniteVideos).toHaveBeenCalledWith(expect.objectContaining({
+      enabled: false,
+    }));
+    expect(result.current.dataSource).toBe('funnelcake');
+  });
+
+  it('does not fall back to WebSocket when a featured REST query errors', () => {
+    mockUseFeaturedTabVideos.mockReturnValue({
+      ...queryResult,
+      error: new Error('No featured videos'),
+    });
+
+    const { result } = renderHook(() =>
+      useVideoProvider({
+        feedType: 'featured',
+        featuredTabId: 'ft_1234abcd',
+      })
+    );
+
+    expect(mockUseInfiniteVideos).toHaveBeenCalledWith(expect.objectContaining({
+      enabled: false,
+    }));
+    expect(result.current.dataSource).toBe('funnelcake');
+    expect(result.current.error?.message).toBe('No featured videos');
   });
 
   it('prefers Funnelcake for Divine hot feeds', () => {

--- a/src/hooks/useVideoProvider.ts
+++ b/src/hooks/useVideoProvider.ts
@@ -7,6 +7,7 @@ import { getFunnelcakeBaseUrl } from '@/config/api';
 import { useInfiniteVideos } from '@/hooks/useInfiniteVideos';
 import { useResolvedRelayCapabilities } from '@/hooks/useRelayCapabilities';
 import { useInfiniteVideosFunnelcake, type FunnelcakeFeedType, type FunnelcakeSortMode, type PopularPeriod, type PopularSource } from '@/hooks/useInfiniteVideosFunnelcake';
+import { useFeaturedTabVideos } from '@/hooks/useFeaturedTabVideos';
 import { useFeedBlocklist } from '@/hooks/useFeedBlocklist';
 import { filterBlockedVideoPages } from '@/lib/blocklistFilter';
 import { hasFunnelcake, getFunnelcakeUrl } from '@/config/relays';
@@ -15,7 +16,7 @@ import type { RelayCapabilities } from '@/lib/relayCapabilities';
 import type { SortMode } from '@/types/nostr';
 
 // Feed types that can be provided
-export type VideoFeedType = 'discovery' | 'home' | 'trending' | 'hashtag' | 'profile' | 'recent' | 'classics' | 'foryou' | 'category' | 'popular';
+export type VideoFeedType = 'discovery' | 'home' | 'trending' | 'hashtag' | 'profile' | 'recent' | 'classics' | 'foryou' | 'category' | 'popular' | 'featured';
 type WebsocketVideoFeedType = 'discovery' | 'home' | 'trending' | 'hashtag' | 'profile' | 'recent';
 const CLASSICS_RANDOMIZATION_WINDOW = 120;
 
@@ -26,6 +27,7 @@ interface UseVideoProviderOptions {
   popularPeriod?: PopularPeriod;
   hashtag?: string;
   category?: string;
+  featuredTabId?: string;
   pubkey?: string;
   pageSize?: number;
   enabled?: boolean;
@@ -62,6 +64,7 @@ function canServeFeedViaFunnelcake(feedType: VideoFeedType): boolean {
     case 'foryou':
     case 'category':
     case 'popular':
+    case 'featured':
       return true;
   }
 }
@@ -91,6 +94,8 @@ function mapToFunnelcakeFeedType(feedType: VideoFeedType): FunnelcakeFeedType {
       return 'category';
     case 'popular':
       return 'popular';
+    case 'featured':
+      return 'trending';
     default:
       return 'trending';
   }
@@ -142,6 +147,7 @@ export function canServeFeedViaWebsocket(
     case 'foryou':
     case 'category':
     case 'popular':
+    case 'featured':
       return false;
 
     case 'discovery':
@@ -221,6 +227,7 @@ export function useVideoProvider({
   popularPeriod,
   hashtag,
   category,
+  featuredTabId,
   pubkey,
   pageSize = 12,
   enabled = true,
@@ -237,6 +244,7 @@ export function useVideoProvider({
   });
 
   const shouldUseFunnelcake = decision.dataSource === 'funnelcake';
+  const isFeaturedFeed = feedType === 'featured';
 
   debugLog(`[useVideoProvider] Feed: ${feedType}, Relay: ${relayUrl}, Source: ${decision.dataSource}, Reason: ${decision.reason}`);
 
@@ -251,14 +259,22 @@ export function useVideoProvider({
     category,
     pubkey,
     pageSize,
-    enabled: enabled && shouldUseFunnelcake,
+    enabled: enabled && shouldUseFunnelcake && !isFeaturedFeed,
     // Keep Classics in a low, stable offset window.
     // Higher offsets on loops+classic queries are currently prone to backend timeouts.
     randomizeWithinTop: feedType === 'classics' ? CLASSICS_RANDOMIZATION_WINDOW : undefined,
   });
 
+  const featuredQuery = useFeaturedTabVideos({
+    configId: featuredTabId,
+    apiUrl: decision.apiUrl,
+    pageSize,
+    enabled: enabled && shouldUseFunnelcake && isFeaturedFeed && !!featuredTabId,
+  });
+
   const shouldEnableWebsocket =
     enabled &&
+    !isFeaturedFeed &&
     !!decision.websocketFeedType &&
     (!shouldUseFunnelcake || !!funnelcakeQuery.error);
 
@@ -271,10 +287,10 @@ export function useVideoProvider({
     enabled: shouldEnableWebsocket,
   });
 
-  const usingWebsocketFallback = shouldUseFunnelcake && !!funnelcakeQuery.error && !!decision.websocketFeedType;
+  const usingWebsocketFallback = shouldUseFunnelcake && !!funnelcakeQuery.error && !!decision.websocketFeedType && !isFeaturedFeed;
   const activeQuery = usingWebsocketFallback
     ? websocketQuery
-    : (shouldUseFunnelcake ? funnelcakeQuery : websocketQuery);
+    : (isFeaturedFeed ? featuredQuery : (shouldUseFunnelcake ? funnelcakeQuery : websocketQuery));
   const activeDataSource = usingWebsocketFallback
     ? 'websocket'
     : (shouldUseFunnelcake ? 'funnelcake' : 'websocket');

--- a/src/hooks/useVideoProvider.ts
+++ b/src/hooks/useVideoProvider.ts
@@ -94,8 +94,6 @@ function mapToFunnelcakeFeedType(feedType: VideoFeedType): FunnelcakeFeedType {
       return 'category';
     case 'popular':
       return 'popular';
-    case 'featured':
-      return 'trending';
     default:
       return 'trending';
   }

--- a/src/lib/featuredTabEligibility.test.ts
+++ b/src/lib/featuredTabEligibility.test.ts
@@ -29,6 +29,32 @@ describe('featured tab eligibility', () => {
     expect(isFeaturedTabEligible(makeConfig({ ends_at: '2026-08-07T00:00:00Z' }), now, 'not_protected')).toBe(false);
   });
 
+  it('fails closed when the gate flags arrive as non-boolean values', () => {
+    // The string "false" is truthy in JS, so a serializer or proxy that stringifies
+    // booleans must not be able to open the audience gate or defeat the kill switch.
+    expect(isFeaturedTabEligible(
+      makeConfig({ visible_to_minors: 'false' as never }), now, 'protected',
+    )).toBe(false);
+    expect(isFeaturedTabEligible(
+      makeConfig({ visible_to_minors: 'false' as never }), now, 'unknown',
+    )).toBe(false);
+    expect(isFeaturedTabEligible(makeConfig({ enabled: 'false' as never }), now, 'not_protected')).toBe(false);
+    expect(isFeaturedTabEligible(makeConfig({ has_content: 'false' as never }), now, 'not_protected')).toBe(false);
+    expect(isFeaturedTabEligible(makeConfig({ enabled: 1 as never }), now, 'not_protected')).toBe(false);
+  });
+
+  it('resolves to no featured tab when the payload is not a usable list', () => {
+    const options = { now, minorState: 'not_protected' as const, locale: 'en' };
+
+    // An HTTP 200 with a malformed envelope must degrade, not throw in render.
+    expect(selectFeaturedTab(undefined, options)).toBeNull();
+    expect(selectFeaturedTab(null, options)).toBeNull();
+    expect(selectFeaturedTab({ featured_tabs: [] }, options)).toBeNull();
+    expect(selectFeaturedTab([null, 'nope', 42], options)).toBeNull();
+    expect(selectFeaturedTab([makeConfig({ id: '' as never })], options)).toBeNull();
+    expect(selectFeaturedTab([makeConfig({ id: 42 as never })], options)).toBeNull();
+  });
+
   it('fails closed for known or unknown protected minor states', () => {
     const config = makeConfig({ visible_to_minors: false });
 

--- a/src/lib/featuredTabEligibility.test.ts
+++ b/src/lib/featuredTabEligibility.test.ts
@@ -59,4 +59,36 @@ describe('featured tab eligibility', () => {
       disclosureLabel: 'Featured',
     });
   });
+
+  it('skips configurations whose slug is not a usable discovery route', () => {
+    const options = { now, minorState: 'not_protected' as const, locale: 'en' };
+
+    // Discovery lowercases the route segment before matching, so a mixed-case
+    // slug renders a tab that a reload cannot resolve.
+    expect(selectFeaturedTab([makeConfig({ slug: 'Seasonal-Theme' })], options)).toBeNull();
+    expect(selectFeaturedTab([makeConfig({ slug: 'seasonal theme' })], options)).toBeNull();
+    expect(selectFeaturedTab([makeConfig({ slug: '../admin' })], options)).toBeNull();
+    // Reserved values would shadow a built-in tab and hide the featured panel.
+    expect(selectFeaturedTab([makeConfig({ slug: 'hot' })], options)).toBeNull();
+    expect(selectFeaturedTab([makeConfig({ slug: 'top' })], options)).toBeNull();
+  });
+
+  it('falls through to the next eligible configuration when a slug is unusable', () => {
+    const selected = selectFeaturedTab([
+      makeConfig({ id: 'ft_bad_slug', slug: 'hashtags' }),
+      makeConfig({ id: 'ft_eligible', label: { default: 'Default', es: 'Especial' }, disclosure_label: 'Featured' }),
+    ], {
+      now,
+      minorState: 'not_protected',
+      locale: 'es-MX',
+    });
+
+    expect(selected).toEqual({
+      id: 'ft_eligible',
+      slug: 'seasonal-theme',
+      label: 'Especial',
+      position: { after: 'hot' },
+      disclosureLabel: 'Featured',
+    });
+  });
 });

--- a/src/lib/featuredTabEligibility.test.ts
+++ b/src/lib/featuredTabEligibility.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest';
+
+import { isFeaturedTabEligible, selectFeaturedTab } from './featuredTabEligibility';
+import type { FeaturedTabConfigRaw } from '@/types/featuredTabs';
+
+function makeConfig(overrides: Partial<FeaturedTabConfigRaw> = {}): FeaturedTabConfigRaw {
+  return {
+    id: 'ft_1234abcd',
+    slug: 'seasonal-theme',
+    label: { default: 'Seasonal' },
+    position: { web: { after: 'hot' } },
+    starts_at: '2026-08-01T00:00:00Z',
+    ends_at: '2026-09-01T00:00:00Z',
+    enabled: true,
+    visible_to_minors: true,
+    disclosure_label: null,
+    has_content: true,
+    ...overrides,
+  };
+}
+
+describe('featured tab eligibility', () => {
+  const now = new Date('2026-08-08T12:00:00Z');
+
+  it('rejects disabled, out-of-window, and empty configurations', () => {
+    expect(isFeaturedTabEligible(makeConfig({ enabled: false }), now, 'not_protected')).toBe(false);
+    expect(isFeaturedTabEligible(makeConfig({ has_content: false }), now, 'not_protected')).toBe(false);
+    expect(isFeaturedTabEligible(makeConfig({ starts_at: '2026-08-09T00:00:00Z' }), now, 'not_protected')).toBe(false);
+    expect(isFeaturedTabEligible(makeConfig({ ends_at: '2026-08-07T00:00:00Z' }), now, 'not_protected')).toBe(false);
+  });
+
+  it('fails closed for known or unknown protected minor states', () => {
+    const config = makeConfig({ visible_to_minors: false });
+
+    expect(isFeaturedTabEligible(config, now, 'not_protected')).toBe(true);
+    expect(isFeaturedTabEligible(config, now, 'protected')).toBe(false);
+    expect(isFeaturedTabEligible(config, now, 'unknown')).toBe(false);
+  });
+
+  it('selects the first eligible tab and resolves display fields', () => {
+    const selected = selectFeaturedTab([
+      makeConfig({ id: 'ft_disabled', enabled: false }),
+      makeConfig({
+        id: 'ft_eligible',
+        label: { default: 'Default', es: 'Especial' },
+        disclosure_label: 'Featured',
+      }),
+    ], {
+      now,
+      minorState: 'not_protected',
+      locale: 'es-MX',
+    });
+
+    expect(selected).toEqual({
+      id: 'ft_eligible',
+      slug: 'seasonal-theme',
+      label: 'Especial',
+      position: { after: 'hot' },
+      disclosureLabel: 'Featured',
+    });
+  });
+});

--- a/src/lib/featuredTabEligibility.ts
+++ b/src/lib/featuredTabEligibility.ts
@@ -1,0 +1,54 @@
+import { parseFeaturedTabDisclosure, parseFeaturedTabPosition, pickFeaturedTabLabel } from '@/lib/featuredTabsTransform';
+import { isFeaturedTabMinorRestricted, type ProtectedMinorState } from '@/lib/protectedMinor';
+import type { FeaturedTabConfigRaw, ResolvedFeaturedTab } from '@/types/featuredTabs';
+
+function parseTimestamp(value: string): number | null {
+  const time = new Date(value).getTime();
+  return Number.isFinite(time) ? time : null;
+}
+
+export function isFeaturedTabEligible(
+  config: FeaturedTabConfigRaw,
+  now: Date,
+  minorState: ProtectedMinorState
+): boolean {
+  if (!config.enabled || !config.has_content) return false;
+  if (!config.visible_to_minors && isFeaturedTabMinorRestricted(minorState)) return false;
+
+  const startsAt = parseTimestamp(config.starts_at);
+  const endsAt = parseTimestamp(config.ends_at);
+  if (startsAt === null || endsAt === null) return false;
+
+  const currentTime = now.getTime();
+  return currentTime >= startsAt && currentTime <= endsAt;
+}
+
+export function selectFeaturedTab(
+  configs: FeaturedTabConfigRaw[],
+  {
+    now,
+    minorState,
+    locale,
+  }: {
+    now: Date;
+    minorState: ProtectedMinorState;
+    locale: string | null | undefined;
+  }
+): ResolvedFeaturedTab | null {
+  for (const config of configs) {
+    if (!isFeaturedTabEligible(config, now, minorState)) continue;
+
+    const label = pickFeaturedTabLabel(config.label, locale);
+    if (!label) continue;
+
+    return {
+      id: config.id,
+      slug: config.slug,
+      label,
+      position: parseFeaturedTabPosition(config.position),
+      disclosureLabel: parseFeaturedTabDisclosure(config.disclosure_label),
+    };
+  }
+
+  return null;
+}

--- a/src/lib/featuredTabEligibility.ts
+++ b/src/lib/featuredTabEligibility.ts
@@ -1,4 +1,9 @@
-import { parseFeaturedTabDisclosure, parseFeaturedTabPosition, pickFeaturedTabLabel } from '@/lib/featuredTabsTransform';
+import {
+  parseFeaturedTabDisclosure,
+  parseFeaturedTabPosition,
+  parseFeaturedTabSlug,
+  pickFeaturedTabLabel,
+} from '@/lib/featuredTabsTransform';
 import { isFeaturedTabMinorRestricted, type ProtectedMinorState } from '@/lib/protectedMinor';
 import type { FeaturedTabConfigRaw, ResolvedFeaturedTab } from '@/types/featuredTabs';
 
@@ -38,12 +43,15 @@ export function selectFeaturedTab(
   for (const config of configs) {
     if (!isFeaturedTabEligible(config, now, minorState)) continue;
 
+    const slug = parseFeaturedTabSlug(config.slug);
+    if (!slug) continue;
+
     const label = pickFeaturedTabLabel(config.label, locale);
     if (!label) continue;
 
     return {
       id: config.id,
-      slug: config.slug,
+      slug,
       label,
       position: parseFeaturedTabPosition(config.position),
       disclosureLabel: parseFeaturedTabDisclosure(config.disclosure_label),

--- a/src/lib/featuredTabEligibility.ts
+++ b/src/lib/featuredTabEligibility.ts
@@ -17,8 +17,11 @@ export function isFeaturedTabEligible(
   now: Date,
   minorState: ProtectedMinorState
 ): boolean {
-  if (!config.enabled || !config.has_content) return false;
-  if (!config.visible_to_minors && isFeaturedTabMinorRestricted(minorState)) return false;
+  // Fail closed on schema drift, matching protectedMinor.ts: these three flags
+  // are the kill switch and the audience gate, and a truthy non-boolean (the
+  // string "false" is truthy) must never be read as permission to render.
+  if (config.enabled !== true || config.has_content !== true) return false;
+  if (config.visible_to_minors !== true && isFeaturedTabMinorRestricted(minorState)) return false;
 
   const startsAt = parseTimestamp(config.starts_at);
   const endsAt = parseTimestamp(config.ends_at);
@@ -28,8 +31,24 @@ export function isFeaturedTabEligible(
   return currentTime >= startsAt && currentTime <= endsAt;
 }
 
+function isConfigObject(value: unknown): value is FeaturedTabConfigRaw {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+/**
+ * The config id is interpolated into the videos URL and reported as the
+ * analytics parameter, so an absent or non-string id makes the whole entry
+ * unusable rather than merely unlabelled.
+ */
+function parseConfigId(value: unknown): string | null {
+  return typeof value === 'string' && value.trim() ? value.trim() : null;
+}
+
 export function selectFeaturedTab(
-  configs: FeaturedTabConfigRaw[],
+  // `unknown` on purpose: this is the first code to touch the decoded response
+  // body, and an HTTP 200 carrying a missing or non-array `featured_tabs` must
+  // resolve to "no featured tab" rather than throw inside a render.
+  configs: unknown,
   {
     now,
     minorState,
@@ -40,8 +59,14 @@ export function selectFeaturedTab(
     locale: string | null | undefined;
   }
 ): ResolvedFeaturedTab | null {
+  if (!Array.isArray(configs)) return null;
+
   for (const config of configs) {
+    if (!isConfigObject(config)) continue;
     if (!isFeaturedTabEligible(config, now, minorState)) continue;
+
+    const id = parseConfigId(config.id);
+    if (!id) continue;
 
     const slug = parseFeaturedTabSlug(config.slug);
     if (!slug) continue;
@@ -50,7 +75,7 @@ export function selectFeaturedTab(
     if (!label) continue;
 
     return {
-      id: config.id,
+      id,
       slug,
       label,
       position: parseFeaturedTabPosition(config.position),

--- a/src/lib/featuredTabsClient.test.ts
+++ b/src/lib/featuredTabsClient.test.ts
@@ -1,0 +1,120 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { fetchFeaturedTabVideos, fetchFeaturedTabs } from './featuredTabsClient';
+import {
+  getFunnelcakeStatus,
+  isFunnelcakeAvailable,
+  recordFunnelcakeFailure,
+  resetFunnelcakeCircuit,
+} from './funnelcakeHealth';
+
+const API_URL = 'https://api.divine.video';
+
+function jsonResponse(body: unknown, init: { ok?: boolean; status?: number } = {}) {
+  const ok = init.ok ?? true;
+  return {
+    ok,
+    status: init.status ?? (ok ? 200 : 500),
+    statusText: ok ? 'OK' : 'Internal Server Error',
+    json: async () => body,
+  } as unknown as Response;
+}
+
+let fetchMock: ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  resetFunnelcakeCircuit(API_URL);
+  fetchMock = vi.fn();
+  vi.stubGlobal('fetch', fetchMock);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  resetFunnelcakeCircuit(API_URL);
+});
+
+describe('featuredTabsClient', () => {
+  it('requests the config endpoint and returns the decoded body', async () => {
+    const body = { poll_interval_seconds: 300, featured_tabs: [] };
+    fetchMock.mockResolvedValueOnce(jsonResponse(body));
+
+    await expect(fetchFeaturedTabs(API_URL)).resolves.toEqual(body);
+
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe('https://api.divine.video/api/featured-tabs');
+    expect((init as RequestInit).headers).toEqual({ Accept: 'application/json' });
+  });
+
+  it('encodes the config id into the videos path and passes cursor and limit', async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({
+      data: [],
+      pagination: { next_cursor: null, has_more: false },
+    }));
+
+    await fetchFeaturedTabVideos(API_URL, 'ft/1234 abcd', 'cursor-2', 12);
+
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      'https://api.divine.video/api/featured-tabs/ft%2F1234%20abcd/videos?cursor=cursor-2&limit=12'
+    );
+  });
+
+  it('omits an absent cursor rather than sending an empty one', async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({
+      data: [],
+      pagination: { next_cursor: null, has_more: false },
+    }));
+
+    await fetchFeaturedTabVideos(API_URL, 'ft_1234abcd', undefined, 12);
+
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      'https://api.divine.video/api/featured-tabs/ft_1234abcd/videos?limit=12'
+    );
+  });
+
+  it('throws on a non-ok response', async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({}, { ok: false, status: 503 }));
+
+    await expect(fetchFeaturedTabs(API_URL)).rejects.toThrow(/503/);
+  });
+
+  it('refuses to call the host while the shared circuit is open', async () => {
+    for (let i = 0; i < 3; i += 1) {
+      recordFunnelcakeFailure(API_URL, 'core feed outage');
+    }
+    expect(isFunnelcakeAvailable(API_URL)).toBe(false);
+
+    await expect(fetchFeaturedTabs(API_URL)).rejects.toThrow('Funnelcake circuit open');
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  // The core feeds (classics/hot/trending/hashtag/profile) share one breaker per
+  // API host. Featured is an optional surface with its own grace window, so its
+  // failures must not be able to push those feeds onto the relay.
+  it('does not record featured failures against the shared circuit breaker', async () => {
+    fetchMock.mockResolvedValue(jsonResponse({}, { ok: false, status: 500 }));
+
+    for (let i = 0; i < 5; i += 1) {
+      await expect(fetchFeaturedTabs(API_URL)).rejects.toThrow();
+    }
+
+    expect(getFunnelcakeStatus(API_URL).errorCount).toBe(0);
+    expect(isFunnelcakeAvailable(API_URL)).toBe(true);
+  });
+
+  it('does not record featured successes against the shared circuit breaker', async () => {
+    recordFunnelcakeFailure(API_URL, 'core feed outage');
+    fetchMock.mockResolvedValueOnce(jsonResponse({ poll_interval_seconds: 300, featured_tabs: [] }));
+
+    await fetchFeaturedTabs(API_URL);
+
+    expect(getFunnelcakeStatus(API_URL).errorCount).toBe(1);
+  });
+
+  it('propagates an abort from the caller signal', async () => {
+    const abortError = new DOMException('The operation was aborted.', 'AbortError');
+    fetchMock.mockRejectedValueOnce(abortError);
+
+    const controller = new AbortController();
+    await expect(fetchFeaturedTabs(API_URL, controller.signal)).rejects.toBe(abortError);
+  });
+});

--- a/src/lib/featuredTabsClient.ts
+++ b/src/lib/featuredTabsClient.ts
@@ -1,0 +1,89 @@
+import { API_CONFIG } from '@/config/api';
+import { isFunnelcakeAvailable, recordFunnelcakeFailure, recordFunnelcakeSuccess } from '@/lib/funnelcakeHealth';
+import { transformFeaturedTabVideosResponse } from '@/lib/featuredTabsTransform';
+import type { FunnelcakeResponse } from '@/types/funnelcake';
+import type { FeaturedTabsResponse, FeaturedTabVideosResponseRaw } from '@/types/featuredTabs';
+
+function buildUrl(baseUrl: string, endpoint: string, params: Record<string, string | number | undefined> = {}): string {
+  const url = new URL(endpoint, baseUrl);
+
+  for (const [key, value] of Object.entries(params)) {
+    if (value !== undefined && value !== '') {
+      url.searchParams.set(key, String(value));
+    }
+  }
+
+  return url.toString();
+}
+
+function isAbortRequestError(err: unknown): boolean {
+  return !!err && typeof err === 'object' && (err as { name?: unknown }).name === 'AbortError';
+}
+
+async function featuredTabsRequest<T>(
+  apiUrl: string,
+  endpoint: string,
+  params: Record<string, string | number | undefined>,
+  signal?: AbortSignal
+): Promise<T> {
+  if (!isFunnelcakeAvailable(apiUrl)) {
+    throw new Error('Funnelcake circuit open');
+  }
+
+  const timeoutSignal = AbortSignal.timeout(API_CONFIG.funnelcake.timeout);
+  const combinedSignal = signal
+    ? AbortSignal.any([signal, timeoutSignal])
+    : timeoutSignal;
+
+  try {
+    const response = await fetch(buildUrl(apiUrl, endpoint, params), {
+      signal: combinedSignal,
+      headers: {
+        Accept: 'application/json',
+      },
+    });
+
+    if (!response.ok) {
+      throw new Error(`Featured tabs request failed: ${response.status} ${response.statusText}`);
+    }
+
+    const data = await response.json();
+    recordFunnelcakeSuccess(apiUrl);
+    return data as T;
+  } catch (err) {
+    if (isAbortRequestError(err)) throw err;
+
+    const message = err instanceof Error ? err.message : 'Unknown featured tabs error';
+    recordFunnelcakeFailure(apiUrl, message);
+    throw err;
+  }
+}
+
+export function fetchFeaturedTabs(
+  apiUrl: string,
+  signal?: AbortSignal
+): Promise<FeaturedTabsResponse> {
+  return featuredTabsRequest<FeaturedTabsResponse>(
+    apiUrl,
+    '/api/featured-tabs',
+    {},
+    signal
+  );
+}
+
+export async function fetchFeaturedTabVideos(
+  apiUrl: string,
+  id: string,
+  cursor: string | undefined,
+  limit: number,
+  signal?: AbortSignal
+): Promise<FunnelcakeResponse> {
+  const response = await featuredTabsRequest<FeaturedTabVideosResponseRaw>(
+    apiUrl,
+    `/api/featured-tabs/${encodeURIComponent(id)}/videos`,
+    { cursor, limit },
+    signal
+  );
+
+  return transformFeaturedTabVideosResponse(response);
+}

--- a/src/lib/featuredTabsClient.ts
+++ b/src/lib/featuredTabsClient.ts
@@ -1,5 +1,5 @@
 import { API_CONFIG } from '@/config/api';
-import { isFunnelcakeAvailable, recordFunnelcakeFailure, recordFunnelcakeSuccess } from '@/lib/funnelcakeHealth';
+import { isFunnelcakeAvailable } from '@/lib/funnelcakeHealth';
 import { transformFeaturedTabVideosResponse } from '@/lib/featuredTabsTransform';
 import type { FunnelcakeResponse } from '@/types/funnelcake';
 import type { FeaturedTabsResponse, FeaturedTabVideosResponseRaw } from '@/types/featuredTabs';
@@ -16,10 +16,15 @@ function buildUrl(baseUrl: string, endpoint: string, params: Record<string, stri
   return url.toString();
 }
 
-function isAbortRequestError(err: unknown): boolean {
-  return !!err && typeof err === 'object' && (err as { name?: unknown }).name === 'AbortError';
-}
-
+/**
+ * Featured tabs read the shared Funnelcake circuit breaker but never write to
+ * it. The breaker is keyed by API host and is what the core feeds — classics,
+ * hot, trending, hashtag, profile — use to decide between REST and the relay.
+ * Featured is an optional editorial surface with its own last-good grace
+ * window, so letting its polls count toward the shared failure threshold would
+ * let one non-critical route push every core feed onto the relay. Reading the
+ * breaker still keeps featured off a host that is already known to be down.
+ */
 async function featuredTabsRequest<T>(
   apiUrl: string,
   endpoint: string,
@@ -35,28 +40,18 @@ async function featuredTabsRequest<T>(
     ? AbortSignal.any([signal, timeoutSignal])
     : timeoutSignal;
 
-  try {
-    const response = await fetch(buildUrl(apiUrl, endpoint, params), {
-      signal: combinedSignal,
-      headers: {
-        Accept: 'application/json',
-      },
-    });
+  const response = await fetch(buildUrl(apiUrl, endpoint, params), {
+    signal: combinedSignal,
+    headers: {
+      Accept: 'application/json',
+    },
+  });
 
-    if (!response.ok) {
-      throw new Error(`Featured tabs request failed: ${response.status} ${response.statusText}`);
-    }
-
-    const data = await response.json();
-    recordFunnelcakeSuccess(apiUrl);
-    return data as T;
-  } catch (err) {
-    if (isAbortRequestError(err)) throw err;
-
-    const message = err instanceof Error ? err.message : 'Unknown featured tabs error';
-    recordFunnelcakeFailure(apiUrl, message);
-    throw err;
+  if (!response.ok) {
+    throw new Error(`Featured tabs request failed: ${response.status} ${response.statusText}`);
   }
+
+  return await response.json() as T;
 }
 
 export function fetchFeaturedTabs(

--- a/src/lib/featuredTabsTransform.test.ts
+++ b/src/lib/featuredTabsTransform.test.ts
@@ -70,4 +70,14 @@ describe('featured tab transforms', () => {
     expect(response.next_cursor).toBe('cursor-2');
     expect(response.has_more).toBe(true);
   });
+
+  it('treats a malformed pagination envelope as the last page', () => {
+    expect(transformFeaturedTabVideosResponse({ data: [] } as never))
+      .toEqual({ videos: [], next_cursor: undefined, has_more: false });
+
+    expect(transformFeaturedTabVideosResponse({
+      data: [],
+      pagination: { has_more: true },
+    })).toEqual({ videos: [], next_cursor: undefined, has_more: false });
+  });
 });

--- a/src/lib/featuredTabsTransform.test.ts
+++ b/src/lib/featuredTabsTransform.test.ts
@@ -25,6 +25,13 @@ describe('featured tab transforms', () => {
     expect(parseFeaturedTabPosition({ web: { before: 'hashtags' } })).toEqual({ before: 'hashtags' });
   });
 
+  it('keeps a single anchor when the backend sends both after and before', () => {
+    expect(parseFeaturedTabPosition({ web: { after: 'hot', before: 'hashtags' } }))
+      .toEqual({ after: 'hot' });
+    expect(parseFeaturedTabPosition({ web: { after: 'rising', before: 'hashtags' } }))
+      .toEqual({ before: 'hashtags' });
+  });
+
   it('only accepts string disclosure labels', () => {
     expect(parseFeaturedTabDisclosure({ text: 'Ad' })).toBeNull();
     expect(parseFeaturedTabDisclosure(' Sponsored collection ')).toBe('Sponsored collec');

--- a/src/lib/featuredTabsTransform.test.ts
+++ b/src/lib/featuredTabsTransform.test.ts
@@ -32,9 +32,17 @@ describe('featured tab transforms', () => {
       .toEqual({ before: 'hashtags' });
   });
 
-  it('only accepts string disclosure labels', () => {
+  it('only accepts string disclosure labels and keeps the phrase readable', () => {
     expect(parseFeaturedTabDisclosure({ text: 'Ad' })).toBeNull();
-    expect(parseFeaturedTabDisclosure(' Sponsored collection ')).toBe('Sponsored collec');
+    expect(parseFeaturedTabDisclosure(' Sponsored collection ')).toBe('Sponsored collection');
+    expect(parseFeaturedTabDisclosure('Paid partnership')).toBe('Paid partnership');
+  });
+
+  it('strips invisible formatting from server-supplied strings', () => {
+    // A bidi override could otherwise reorder the tab bar around the label.
+    expect(pickFeaturedTabLabel({ default: 'Sea\u202esonal' }, 'en')).toBe('Seasonal');
+    expect(parseFeaturedTabDisclosure('Spon\u200bsored')).toBe('Sponsored');
+    expect(parseFeaturedTabDisclosure('\u200b\u202e')).toBeNull();
   });
 
   it('maps featured video envelopes without reordering server data', () => {

--- a/src/lib/featuredTabsTransform.test.ts
+++ b/src/lib/featuredTabsTransform.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest';
+
+import { parseFeaturedTabDisclosure, parseFeaturedTabPosition, pickFeaturedTabLabel, transformFeaturedTabVideosResponse } from './featuredTabsTransform';
+
+describe('featured tab transforms', () => {
+  it('picks a locale label and falls back to default with a length cap', () => {
+    expect(pickFeaturedTabLabel({
+      default: 'Seasonal Theme',
+      es: 'Tema',
+    }, 'es-MX')).toBe('Tema');
+
+    expect(pickFeaturedTabLabel({
+      default: 'This label is unexpectedly long and should be trimmed',
+    }, 'fr')).toBe('This label is unexpected');
+  });
+
+  it('rejects hostile position payloads and unknown tab names', () => {
+    expect(parseFeaturedTabPosition('after-hot')).toBeNull();
+    expect(parseFeaturedTabPosition({ web: { after: 'rising' } })).toBeNull();
+    expect(parseFeaturedTabPosition({ mobile: { after: 'popular' } })).toBeNull();
+  });
+
+  it('parses valid web position by tab name', () => {
+    expect(parseFeaturedTabPosition({ web: { after: 'hot' } })).toEqual({ after: 'hot' });
+    expect(parseFeaturedTabPosition({ web: { before: 'hashtags' } })).toEqual({ before: 'hashtags' });
+  });
+
+  it('only accepts string disclosure labels', () => {
+    expect(parseFeaturedTabDisclosure({ text: 'Ad' })).toBeNull();
+    expect(parseFeaturedTabDisclosure(' Sponsored collection ')).toBe('Sponsored collec');
+  });
+
+  it('maps featured video envelopes without reordering server data', () => {
+    const response = transformFeaturedTabVideosResponse({
+      data: [
+        {
+          id: 'video-2',
+          pubkey: 'pubkey-2',
+          created_at: '2026-08-08T00:00:00Z',
+          kind: 34236,
+          d_tag: 'two',
+          title: 'Two',
+          video_url: 'https://media.example/two.mp4',
+        },
+        {
+          id: 'video-1',
+          pubkey: 'pubkey-1',
+          created_at: '2026-08-07T00:00:00Z',
+          kind: 34236,
+          d_tag: 'one',
+          title: 'One',
+          video_url: 'https://media.example/one.mp4',
+        },
+      ],
+      pagination: {
+        next_cursor: 'cursor-2',
+        has_more: true,
+      },
+    });
+
+    expect(response.videos.map((video) => video.id)).toEqual(['video-2', 'video-1']);
+    expect(response.videos[0].created_at).toBe(1786147200);
+    expect(response.next_cursor).toBe('cursor-2');
+    expect(response.has_more).toBe(true);
+  });
+});

--- a/src/lib/featuredTabsTransform.ts
+++ b/src/lib/featuredTabsTransform.ts
@@ -129,7 +129,7 @@ export function transformFeaturedTabVideosResponse(
   response: FeaturedTabVideosResponseRaw
 ): FunnelcakeResponse {
   // `pagination` is guarded like `data`: a payload missing it would otherwise
-  // throw outside the client's try/catch, so the circuit breaker never sees it.
+  // throw a TypeError here, turning a merely malformed page into a broken feed.
   const pagination = response.pagination ?? {};
   const nextCursor = typeof pagination.next_cursor === 'string' && pagination.next_cursor
     ? pagination.next_cursor

--- a/src/lib/featuredTabsTransform.ts
+++ b/src/lib/featuredTabsTransform.ts
@@ -8,7 +8,10 @@ import type {
 } from '@/types/featuredTabs';
 
 const MAX_LABEL_LENGTH = 24;
-const MAX_DISCLOSURE_LENGTH = 16;
+// A disclosure is the one server-supplied string here whose meaning is legal
+// rather than decorative — "Sponsored", "Paid partnership". Room for the phrases
+// that matter, and the tab renders it in full rather than clipping it again.
+const MAX_DISCLOSURE_LENGTH = 24;
 const DISCOVERY_TAB_NAMES = new Set<DiscoveryTabName>(['foryou', 'classics', 'hot', 'hashtags']);
 // The slug is both the `/discovery/:tab` route segment and the Radix Tabs value.
 // The route comparison lowercases `params.tab`, so anything outside this shape
@@ -16,8 +19,17 @@ const DISCOVERY_TAB_NAMES = new Set<DiscoveryTabName>(['foryou', 'classics', 'ho
 const FEATURED_TAB_SLUG_PATTERN = /^[a-z0-9][a-z0-9-]{0,31}$/;
 const RESERVED_TAB_SLUGS = new Set<string>([...DISCOVERY_TAB_NAMES, 'top']);
 
+// Bidi overrides and other invisible formatting characters would let a
+// server-supplied string reorder or hide the text around it in the tab bar.
+// eslint-disable-next-line no-control-regex
+const INVISIBLE_FORMATTING = /[\u0000-\u001f\u007f\u200b-\u200f\u202a-\u202e\u2066-\u2069\ufeff]/g;
+
 function cleanShortString(value: string, maxLength: number): string {
-  return value.trim().replace(/\s+/g, ' ').slice(0, maxLength);
+  return value
+    .replace(INVISIBLE_FORMATTING, '')
+    .trim()
+    .replace(/\s+/g, ' ')
+    .slice(0, maxLength);
 }
 
 function parseDiscoveryTabName(value: unknown): DiscoveryTabName | null {

--- a/src/lib/featuredTabsTransform.ts
+++ b/src/lib/featuredTabsTransform.ts
@@ -1,0 +1,85 @@
+import { DEFAULT_LOCALE, normalizeLocale } from '@/lib/i18n/config';
+import type { FunnelcakeResponse, FunnelcakeVideoRaw } from '@/types/funnelcake';
+import type {
+  DiscoveryTabName,
+  FeaturedTabPosition,
+  FeaturedTabVideosResponseRaw,
+  FeaturedTabVideoRaw,
+} from '@/types/featuredTabs';
+
+const MAX_LABEL_LENGTH = 24;
+const MAX_DISCLOSURE_LENGTH = 16;
+const DISCOVERY_TAB_NAMES = new Set<DiscoveryTabName>(['foryou', 'classics', 'hot', 'hashtags']);
+
+function cleanShortString(value: string, maxLength: number): string {
+  return value.trim().replace(/\s+/g, ' ').slice(0, maxLength);
+}
+
+function parseDiscoveryTabName(value: unknown): DiscoveryTabName | null {
+  if (typeof value !== 'string') return null;
+  return DISCOVERY_TAB_NAMES.has(value as DiscoveryTabName)
+    ? (value as DiscoveryTabName)
+    : null;
+}
+
+export function pickFeaturedTabLabel(
+  label: Record<string, string> | null | undefined,
+  locale: string | null | undefined
+): string | null {
+  if (!label || typeof label.default !== 'string') return null;
+
+  const normalizedLocale = normalizeLocale(locale) ?? DEFAULT_LOCALE;
+  const localized = typeof label[normalizedLocale] === 'string'
+    ? label[normalizedLocale]
+    : label.default;
+  const cleaned = cleanShortString(localized, MAX_LABEL_LENGTH);
+
+  return cleaned || null;
+}
+
+export function parseFeaturedTabPosition(value: unknown): FeaturedTabPosition | null {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) return null;
+
+  const web = (value as { web?: unknown }).web;
+  if (typeof web !== 'object' || web === null || Array.isArray(web)) return null;
+
+  const after = parseDiscoveryTabName((web as { after?: unknown }).after);
+  const before = parseDiscoveryTabName((web as { before?: unknown }).before);
+
+  if (!after && !before) return null;
+
+  return {
+    ...(after ? { after } : {}),
+    ...(before ? { before } : {}),
+  };
+}
+
+export function parseFeaturedTabDisclosure(value: unknown): string | null {
+  if (typeof value !== 'string') return null;
+
+  const cleaned = cleanShortString(value, MAX_DISCLOSURE_LENGTH);
+  return cleaned || null;
+}
+
+export function toFunnelcakeVideo(raw: FeaturedTabVideoRaw): FunnelcakeVideoRaw {
+  const createdAt = typeof raw.created_at === 'string'
+    ? Math.floor(new Date(raw.created_at).getTime() / 1000)
+    : raw.created_at;
+
+  return {
+    ...raw,
+    created_at: Number.isFinite(createdAt) ? createdAt : 0,
+  };
+}
+
+export function transformFeaturedTabVideosResponse(
+  response: FeaturedTabVideosResponseRaw
+): FunnelcakeResponse {
+  return {
+    videos: Array.isArray(response.data)
+      ? response.data.map(toFunnelcakeVideo)
+      : [],
+    next_cursor: response.pagination.next_cursor ?? undefined,
+    has_more: response.pagination.has_more,
+  };
+}

--- a/src/lib/featuredTabsTransform.ts
+++ b/src/lib/featuredTabsTransform.ts
@@ -46,12 +46,13 @@ export function parseFeaturedTabPosition(value: unknown): FeaturedTabPosition | 
   const after = parseDiscoveryTabName((web as { after?: unknown }).after);
   const before = parseDiscoveryTabName((web as { before?: unknown }).before);
 
-  if (!after && !before) return null;
+  // `after` and `before` are mutually exclusive anchors. Keeping both would let
+  // a placement contradict itself (anchor from one key, side from the other),
+  // so resolve the conflict here rather than in the insertion code.
+  if (after) return { after };
+  if (before) return { before };
 
-  return {
-    ...(after ? { after } : {}),
-    ...(before ? { before } : {}),
-  };
+  return null;
 }
 
 export function parseFeaturedTabDisclosure(value: unknown): string | null {

--- a/src/lib/featuredTabsTransform.ts
+++ b/src/lib/featuredTabsTransform.ts
@@ -10,6 +10,11 @@ import type {
 const MAX_LABEL_LENGTH = 24;
 const MAX_DISCLOSURE_LENGTH = 16;
 const DISCOVERY_TAB_NAMES = new Set<DiscoveryTabName>(['foryou', 'classics', 'hot', 'hashtags']);
+// The slug is both the `/discovery/:tab` route segment and the Radix Tabs value.
+// The route comparison lowercases `params.tab`, so anything outside this shape
+// either breaks the URL or renders a tab that cannot be resolved on reload.
+const FEATURED_TAB_SLUG_PATTERN = /^[a-z0-9][a-z0-9-]{0,31}$/;
+const RESERVED_TAB_SLUGS = new Set<string>([...DISCOVERY_TAB_NAMES, 'top']);
 
 function cleanShortString(value: string, maxLength: number): string {
   return value.trim().replace(/\s+/g, ' ').slice(0, maxLength);
@@ -20,6 +25,19 @@ function parseDiscoveryTabName(value: unknown): DiscoveryTabName | null {
   return DISCOVERY_TAB_NAMES.has(value as DiscoveryTabName)
     ? (value as DiscoveryTabName)
     : null;
+}
+
+export function parseFeaturedTabSlug(value: unknown): string | null {
+  if (typeof value !== 'string') return null;
+
+  const slug = value.trim();
+  if (!FEATURED_TAB_SLUG_PATTERN.test(slug)) return null;
+  // A slug that shadows a built-in tab would collide on the Tabs value, so the
+  // built-in wins the lookup and the featured panel never renders. `top` is the
+  // legacy alias Discovery rewrites to `classics`, so it is unroutable too.
+  if (RESERVED_TAB_SLUGS.has(slug)) return null;
+
+  return slug;
 }
 
 export function pickFeaturedTabLabel(

--- a/src/lib/featuredTabsTransform.ts
+++ b/src/lib/featuredTabsTransform.ts
@@ -94,11 +94,18 @@ export function toFunnelcakeVideo(raw: FeaturedTabVideoRaw): FunnelcakeVideoRaw 
 export function transformFeaturedTabVideosResponse(
   response: FeaturedTabVideosResponseRaw
 ): FunnelcakeResponse {
+  // `pagination` is guarded like `data`: a payload missing it would otherwise
+  // throw outside the client's try/catch, so the circuit breaker never sees it.
+  const pagination = response.pagination ?? {};
+  const nextCursor = typeof pagination.next_cursor === 'string' && pagination.next_cursor
+    ? pagination.next_cursor
+    : undefined;
+
   return {
     videos: Array.isArray(response.data)
       ? response.data.map(toFunnelcakeVideo)
       : [],
-    next_cursor: response.pagination.next_cursor ?? undefined,
-    has_more: response.pagination.has_more,
+    next_cursor: nextCursor,
+    has_more: pagination.has_more === true && !!nextCursor,
   };
 }

--- a/src/lib/featuredTabsTransform.ts
+++ b/src/lib/featuredTabsTransform.ts
@@ -19,14 +19,36 @@ const DISCOVERY_TAB_NAMES = new Set<DiscoveryTabName>(['foryou', 'classics', 'ho
 const FEATURED_TAB_SLUG_PATTERN = /^[a-z0-9][a-z0-9-]{0,31}$/;
 const RESERVED_TAB_SLUGS = new Set<string>([...DISCOVERY_TAB_NAMES, 'top']);
 
-// Bidi overrides and other invisible formatting characters would let a
-// server-supplied string reorder or hide the text around it in the tab bar.
-// eslint-disable-next-line no-control-regex
-const INVISIBLE_FORMATTING = /[\u0000-\u001f\u007f\u200b-\u200f\u202a-\u202e\u2066-\u2069\ufeff]/g;
+/**
+ * Bidi overrides and other invisible formatting characters would let a
+ * server-supplied string reorder or hide the text around it in the tab bar, so
+ * they are dropped before the string is measured or rendered. Control
+ * characters collapse to a space instead of vanishing, so a label carrying a
+ * newline stays two words. Written as a codepoint test rather than a character
+ * class because the repository sets `noInlineConfig`, which leaves no way to
+ * silence `no-control-regex` on the equivalent literal.
+ */
+function isInvisibleFormatting(code: number): boolean {
+  return (code >= 0x200b && code <= 0x200f)   // zero-width and directional marks
+    || (code >= 0x202a && code <= 0x202e)     // bidi embedding and override
+    || (code >= 0x2066 && code <= 0x2069)     // bidi isolates
+    || code === 0xfeff;                       // zero-width no-break space
+}
+
+function stripInvisibleFormatting(value: string): string {
+  let out = '';
+
+  for (const char of value) {
+    const code = char.codePointAt(0) ?? 0;
+    if (isInvisibleFormatting(code)) continue;
+    out += code < 0x20 || code === 0x7f ? ' ' : char;
+  }
+
+  return out;
+}
 
 function cleanShortString(value: string, maxLength: number): string {
-  return value
-    .replace(INVISIBLE_FORMATTING, '')
+  return stripInvisibleFormatting(value)
     .trim()
     .replace(/\s+/g, ' ')
     .slice(0, maxLength);

--- a/src/lib/funnelcakeTransform.test.ts
+++ b/src/lib/funnelcakeTransform.test.ts
@@ -521,6 +521,29 @@ describe('transformToVideoPage', () => {
   });
 });
 
+describe('transformFunnelcakeVideo sha256', () => {
+  const urlHash = '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef';
+  const bodyHash = 'fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210';
+
+  it('prefers a well-formed backend hash over the URL-derived one', () => {
+    expect(transformFunnelcakeVideo(makeRawVideo({ sha256: bodyHash })).sha256).toBe(bodyHash);
+    expect(transformFunnelcakeVideo(makeRawVideo({ sha256: bodyHash.toUpperCase() })).sha256).toBe(bodyHash);
+  });
+
+  it('falls back to the URL when the backend hash is malformed', () => {
+    // A truthy non-hash must not shadow the derivation: moderation lookups
+    // return null for anything that is not 64 hex, so the age-gate check
+    // would silently no-op.
+    expect(transformFunnelcakeVideo(makeRawVideo({ sha256: 'not-a-hash' })).sha256).toBe(urlHash);
+    expect(transformFunnelcakeVideo(makeRawVideo({ sha256: bodyHash.slice(0, 63) })).sha256).toBe(urlHash);
+    expect(transformFunnelcakeVideo(makeRawVideo({ sha256: '  ' })).sha256).toBe(urlHash);
+  });
+
+  it('still derives from the URL when the backend sends no hash', () => {
+    expect(transformFunnelcakeVideo(makeRawVideo()).sha256).toBe(urlHash);
+  });
+});
+
 describe('mergeVideoStats', () => {
   it('refreshes native Divine loop counts from stats', () => {
     const video = transformFunnelcakeVideo(makeRawVideo({

--- a/src/lib/funnelcakeTransform.ts
+++ b/src/lib/funnelcakeTransform.ts
@@ -6,7 +6,7 @@ import { SHORT_VIDEO_KIND, type ParsedVideoData, type ProofModeData, type ProofM
 import type { FunnelcakeVideoRaw, FunnelcakeResponse } from '@/types/funnelcake';
 import { debugLog } from './debug';
 import { getProofModeData } from './videoParser';
-import { extractSha256FromVideoUrl } from './videoVerification';
+import { extractSha256FromVideoUrl, normalizeSha256 } from './videoVerification';
 import type { NostrEvent } from '@nostrify/nostrify';
 
 /**
@@ -191,7 +191,10 @@ export function transformFunnelcakeVideo(raw: FunnelcakeVideoRaw): ParsedVideoDa
     blurhash: raw.blurhash,
     title: raw.title,
     dimensions: raw.dim ?? raw.dimensions, // Video dimensions from API (e.g., "1080x1920"); v2 uses `dimensions`
-    sha256: raw.sha256 || extractSha256FromVideoUrl(raw.video_url),
+    // Validated before it wins: a truthy but malformed backend hash would
+    // otherwise shadow the URL-derived one, and downstream moderation lookups
+    // silently no-op on anything that is not 64 hex.
+    sha256: normalizeSha256(raw.sha256) ?? extractSha256FromVideoUrl(raw.video_url),
     ageRestricted: raw.age_restricted === true || raw.moderation_status === 'age_restricted',
     hashtags,
 

--- a/src/lib/funnelcakeTransform.ts
+++ b/src/lib/funnelcakeTransform.ts
@@ -191,7 +191,7 @@ export function transformFunnelcakeVideo(raw: FunnelcakeVideoRaw): ParsedVideoDa
     blurhash: raw.blurhash,
     title: raw.title,
     dimensions: raw.dim ?? raw.dimensions, // Video dimensions from API (e.g., "1080x1920"); v2 uses `dimensions`
-    sha256: extractSha256FromVideoUrl(raw.video_url),
+    sha256: raw.sha256 || extractSha256FromVideoUrl(raw.video_url),
     ageRestricted: raw.age_restricted === true || raw.moderation_status === 'age_restricted',
     hashtags,
 

--- a/src/lib/protectedMinor.ts
+++ b/src/lib/protectedMinor.ts
@@ -32,6 +32,16 @@ export function isMinorKeyHandoverRestricted(state: ProtectedMinorState): boolea
   return state !== 'not_protected';
 }
 
+/**
+ * Featured tab audience verdict. The Funnelcake public response is cacheable
+ * and only carries an advisory `visible_to_minors` flag, so web must enforce
+ * the rule for Divine sessions with a known minor state. Session-less visitors
+ * resolve to `not_protected` upstream because web has no age-band signal there.
+ */
+export function isFeaturedTabMinorRestricted(state: ProtectedMinorState): boolean {
+  return state !== 'not_protected';
+}
+
 // Frozen so this shared sentinel can't be mutated by a consumer and poisoned
 // for every other caller (it's returned by reference from the lib and hook).
 export const NOT_PROTECTED: ProtectedMinorStatus = Object.freeze({

--- a/src/pages/DiscoveryPage.test.tsx
+++ b/src/pages/DiscoveryPage.test.tsx
@@ -6,13 +6,18 @@ import { LOCALE_STORAGE_KEY } from '@/lib/i18n/config';
 import { initializeI18n } from '@/lib/i18n';
 import DiscoveryPage from './DiscoveryPage';
 import type { CategoryWithConfig } from '@/hooks/useCategories';
+import type { ResolvedFeaturedTab } from '@/types/featuredTabs';
 
 const {
   mockNavigate,
   mockCategories,
+  mockFeaturedTab,
+  mockCurrentUser,
 } = vi.hoisted(() => ({
   mockNavigate: vi.fn(),
   mockCategories: [] as CategoryWithConfig[],
+  mockFeaturedTab: { current: null as ResolvedFeaturedTab | null },
+  mockCurrentUser: { current: null as { pubkey: string } | null },
 }));
 
 vi.mock('@/hooks/useSubdomainNavigate', () => ({
@@ -20,16 +25,24 @@ vi.mock('@/hooks/useSubdomainNavigate', () => ({
 }));
 
 vi.mock('@/hooks/useCurrentUser', () => ({
-  useCurrentUser: () => ({ user: null }),
+  useCurrentUser: () => ({ user: mockCurrentUser.current }),
 }));
 
 vi.mock('@/hooks/useCategories', () => ({
   useCategories: () => ({ data: mockCategories }),
 }));
 
+vi.mock('@/hooks/useFeaturedTab', () => ({
+  useFeaturedTab: () => mockFeaturedTab.current,
+}));
+
+vi.mock('@/lib/analytics', () => ({
+  trackEvent: vi.fn(),
+}));
+
 vi.mock('@/components/VideoFeed', () => ({
-  VideoFeed: ({ feedType }: { feedType: string }) => (
-    <div data-testid={`video-feed-${feedType}`} />
+  VideoFeed: ({ feedType, featuredTabId }: { feedType: string; featuredTabId?: string }) => (
+    <div data-testid={`video-feed-${feedType}`} data-featured-tab-id={featuredTabId} />
   ),
 }));
 
@@ -60,6 +73,8 @@ describe('DiscoveryPage', () => {
 
     mockNavigate.mockReset();
     mockCategories.length = 0;
+    mockFeaturedTab.current = null;
+    mockCurrentUser.current = null;
   });
 
   it('renders localized discovery copy and category pills', () => {
@@ -98,5 +113,63 @@ describe('DiscoveryPage', () => {
 
     expect(screen.queryByRole('tab', { name: 'Nuevo' })).not.toBeInTheDocument();
     expect(screen.queryByTestId('video-feed-recent')).not.toBeInTheDocument();
+  });
+
+  it('renders no featured tab or content feed when no configuration is eligible', () => {
+    render(
+      <MemoryRouter initialEntries={['/discovery/classics']}>
+        <Routes>
+          <Route path="/discovery/:tab" element={<DiscoveryPage />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    expect(screen.queryByTestId('video-feed-featured')).not.toBeInTheDocument();
+    expect(screen.getAllByRole('tab').map((tab) => tab.getAttribute('data-state'))).toHaveLength(3);
+  });
+
+  it('inserts an eligible featured tab after the configured tab and renders disclosure text', () => {
+    mockFeaturedTab.current = {
+      id: 'ft_1234abcd',
+      slug: 'seasonal-theme',
+      label: 'Especial',
+      position: { after: 'hot' },
+      disclosureLabel: 'New',
+    };
+
+    render(
+      <MemoryRouter initialEntries={['/discovery/classics']}>
+        <Routes>
+          <Route path="/discovery/:tab" element={<DiscoveryPage />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    expect(screen.getAllByRole('tab').map((tab) => tab.textContent)).toEqual([
+      'Clasico',
+      'Popular',
+      'EspecialNew',
+      'Etiquetas',
+    ]);
+  });
+
+  it('resolves direct navigation to the configured featured slug', () => {
+    mockFeaturedTab.current = {
+      id: 'ft_1234abcd',
+      slug: 'seasonal-theme',
+      label: 'Especial',
+      position: { after: 'hot' },
+      disclosureLabel: null,
+    };
+
+    render(
+      <MemoryRouter initialEntries={['/discovery/seasonal-theme']}>
+        <Routes>
+          <Route path="/discovery/:tab" element={<DiscoveryPage />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByTestId('video-feed-featured')).toHaveAttribute('data-featured-tab-id', 'ft_1234abcd');
   });
 });

--- a/src/pages/DiscoveryPage.test.tsx
+++ b/src/pages/DiscoveryPage.test.tsx
@@ -15,6 +15,7 @@ const {
   mockCurrentUser,
   mockTrackEvent,
   mockFeaturedResolved,
+  mockResolvingJwt,
 } = vi.hoisted(() => ({
   mockNavigate: vi.fn(),
   mockTrackEvent: vi.fn(),
@@ -22,6 +23,7 @@ const {
   mockFeaturedTab: { current: null as ResolvedFeaturedTab | null },
   mockFeaturedResolved: { current: true },
   mockCurrentUser: { current: null as { pubkey: string } | null },
+  mockResolvingJwt: { current: false },
 }));
 
 vi.mock('@/hooks/useSubdomainNavigate', () => ({
@@ -29,7 +31,10 @@ vi.mock('@/hooks/useSubdomainNavigate', () => ({
 }));
 
 vi.mock('@/hooks/useCurrentUser', () => ({
-  useCurrentUser: () => ({ user: mockCurrentUser.current }),
+  useCurrentUser: () => ({
+    user: mockCurrentUser.current,
+    isResolvingJwt: mockResolvingJwt.current,
+  }),
 }));
 
 vi.mock('@/hooks/useCategories', () => ({
@@ -83,6 +88,7 @@ describe('DiscoveryPage', () => {
     mockCategories.length = 0;
     mockFeaturedTab.current = null;
     mockFeaturedResolved.current = true;
+    mockResolvingJwt.current = false;
     mockCurrentUser.current = null;
   });
 
@@ -211,6 +217,22 @@ describe('DiscoveryPage', () => {
 
     render(
       <MemoryRouter initialEntries={['/discovery/seasonal-theme']}>
+        <Routes>
+          <Route path="/discovery/:tab" element={<DiscoveryPage />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
+  it('keeps a logged-in foryou deep link while the hosted session is still resolving', () => {
+    // The JWT has not resolved, so there is no user yet and `foryou` is briefly
+    // absent from the tab list. Redirecting here would replace the bookmark.
+    mockResolvingJwt.current = true;
+
+    render(
+      <MemoryRouter initialEntries={['/discovery/foryou']}>
         <Routes>
           <Route path="/discovery/:tab" element={<DiscoveryPage />} />
         </Routes>

--- a/src/pages/DiscoveryPage.test.tsx
+++ b/src/pages/DiscoveryPage.test.tsx
@@ -16,6 +16,8 @@ const {
   mockTrackEvent,
   mockFeaturedResolved,
   mockResolvingJwt,
+  mockFeaturedApiUrl,
+  mockUseFeaturedTabArgs,
 } = vi.hoisted(() => ({
   mockNavigate: vi.fn(),
   mockTrackEvent: vi.fn(),
@@ -24,6 +26,8 @@ const {
   mockFeaturedResolved: { current: true },
   mockCurrentUser: { current: null as { pubkey: string } | null },
   mockResolvingJwt: { current: false },
+  mockFeaturedApiUrl: { current: 'https://api.divine.video' },
+  mockUseFeaturedTabArgs: [] as Array<{ apiUrl?: string } | undefined>,
 }));
 
 vi.mock('@/hooks/useSubdomainNavigate', () => ({
@@ -42,9 +46,20 @@ vi.mock('@/hooks/useCategories', () => ({
 }));
 
 vi.mock('@/hooks/useFeaturedTab', () => ({
-  useFeaturedTab: () => ({
-    tab: mockFeaturedTab.current,
-    isResolved: mockFeaturedResolved.current,
+  useFeaturedTab: (args?: { apiUrl?: string }) => {
+    mockUseFeaturedTabArgs.push(args);
+    return {
+      tab: mockFeaturedTab.current,
+      isResolved: mockFeaturedResolved.current,
+    };
+  },
+}));
+
+vi.mock('@/hooks/useVideoProvider', () => ({
+  useFunnelcakeSupport: () => ({
+    apiUrl: mockFeaturedApiUrl.current,
+    supported: true,
+    enabled: true,
   }),
 }));
 
@@ -90,6 +105,8 @@ describe('DiscoveryPage', () => {
     mockFeaturedResolved.current = true;
     mockResolvingJwt.current = false;
     mockCurrentUser.current = null;
+    mockFeaturedApiUrl.current = 'https://api.divine.video';
+    mockUseFeaturedTabArgs.length = 0;
   });
 
   it('renders localized discovery copy and category pills', () => {
@@ -141,6 +158,22 @@ describe('DiscoveryPage', () => {
 
     expect(screen.queryByTestId('video-feed-featured')).not.toBeInTheDocument();
     expect(screen.getAllByRole('tab').map((tab) => tab.getAttribute('data-state'))).toHaveLength(3);
+  });
+
+  it('uses the same Funnelcake host for featured config that feeds use for featured videos', () => {
+    mockFeaturedApiUrl.current = 'https://api.staging.divine.video';
+
+    render(
+      <MemoryRouter initialEntries={['/discovery/classics']}>
+        <Routes>
+          <Route path="/discovery/:tab" element={<DiscoveryPage />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    expect(mockUseFeaturedTabArgs.at(-1)).toEqual({
+      apiUrl: 'https://api.staging.divine.video',
+    });
   });
 
   it('inserts an eligible featured tab after the configured tab and renders disclosure text', () => {
@@ -226,6 +259,35 @@ describe('DiscoveryPage', () => {
     expect(mockNavigate).not.toHaveBeenCalled();
   });
 
+  it('keeps the active featured route while the cached config is temporarily unresolved', () => {
+    mockFeaturedTab.current = {
+      id: 'ft_1234abcd',
+      slug: 'seasonal-theme',
+      label: 'Especial',
+      position: { after: 'hot' },
+      disclosureLabel: null,
+    };
+
+    const tree = () => (
+      <MemoryRouter initialEntries={['/discovery/seasonal-theme']}>
+        <Routes>
+          <Route path="/discovery/:tab" element={<DiscoveryPage />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    const { rerender } = render(tree());
+
+    expect(screen.getByTestId('video-feed-featured')).toHaveAttribute('data-featured-tab-id', 'ft_1234abcd');
+    mockNavigate.mockReset();
+
+    mockFeaturedTab.current = null;
+    mockFeaturedResolved.current = false;
+    rerender(tree());
+
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
   it('keeps a logged-in foryou deep link while the hosted session is still resolving', () => {
     // The JWT has not resolved, so there is no user yet and `foryou` is briefly
     // absent from the tab list. Redirecting here would replace the bookmark.
@@ -261,5 +323,30 @@ describe('DiscoveryPage', () => {
 
     expect(screen.getByTestId('video-feed-featured')).toHaveAttribute('data-featured-tab-id', 'ft_1234abcd');
     expect(screen.getAllByText('Sponsored')).not.toHaveLength(0);
+  });
+
+  it('names every tab trigger when labels are visually hidden on mobile', () => {
+    mockFeaturedTab.current = {
+      id: 'ft_1234abcd',
+      slug: 'seasonal-theme',
+      label: 'Especial',
+      position: { after: 'hot' },
+      disclosureLabel: 'Sponsored',
+    };
+
+    render(
+      <MemoryRouter initialEntries={['/discovery/classics']}>
+        <Routes>
+          <Route path="/discovery/:tab" element={<DiscoveryPage />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    expect(screen.getAllByRole('tab').map((tab) => tab.getAttribute('aria-label'))).toEqual([
+      'Clasico',
+      'Popular',
+      'Especial: Sponsored',
+      'Etiquetas',
+    ]);
   });
 });

--- a/src/pages/DiscoveryPage.test.tsx
+++ b/src/pages/DiscoveryPage.test.tsx
@@ -248,7 +248,7 @@ describe('DiscoveryPage', () => {
       slug: 'seasonal-theme',
       label: 'Especial',
       position: { after: 'hot' },
-      disclosureLabel: null,
+      disclosureLabel: 'Sponsored',
     };
 
     render(
@@ -260,5 +260,6 @@ describe('DiscoveryPage', () => {
     );
 
     expect(screen.getByTestId('video-feed-featured')).toHaveAttribute('data-featured-tab-id', 'ft_1234abcd');
+    expect(screen.getAllByText('Sponsored')).not.toHaveLength(0);
   });
 });

--- a/src/pages/DiscoveryPage.test.tsx
+++ b/src/pages/DiscoveryPage.test.tsx
@@ -13,8 +13,10 @@ const {
   mockCategories,
   mockFeaturedTab,
   mockCurrentUser,
+  mockTrackEvent,
 } = vi.hoisted(() => ({
   mockNavigate: vi.fn(),
+  mockTrackEvent: vi.fn(),
   mockCategories: [] as CategoryWithConfig[],
   mockFeaturedTab: { current: null as ResolvedFeaturedTab | null },
   mockCurrentUser: { current: null as { pubkey: string } | null },
@@ -37,7 +39,7 @@ vi.mock('@/hooks/useFeaturedTab', () => ({
 }));
 
 vi.mock('@/lib/analytics', () => ({
-  trackEvent: vi.fn(),
+  trackEvent: mockTrackEvent,
 }));
 
 vi.mock('@/components/VideoFeed', () => ({
@@ -72,6 +74,7 @@ describe('DiscoveryPage', () => {
     await initializeI18n({ force: true, languages: ['en-US'] });
 
     mockNavigate.mockReset();
+    mockTrackEvent.mockReset();
     mockCategories.length = 0;
     mockFeaturedTab.current = null;
     mockCurrentUser.current = null;
@@ -151,6 +154,36 @@ describe('DiscoveryPage', () => {
       'EspecialNew',
       'Etiquetas',
     ]);
+  });
+
+  it('counts one featured tab impression across configuration refreshes', () => {
+    const config = (): ResolvedFeaturedTab => ({
+      id: 'ft_1234abcd',
+      slug: 'seasonal-theme',
+      label: 'Especial',
+      position: { after: 'hot' },
+      disclosureLabel: null,
+    });
+    mockFeaturedTab.current = config();
+
+    const tree = () => (
+      <MemoryRouter initialEntries={['/discovery/seasonal-theme']}>
+        <Routes>
+          <Route path="/discovery/:tab" element={<DiscoveryPage />} />
+        </Routes>
+      </MemoryRouter>
+    );
+    const { rerender } = render(tree());
+
+    expect(mockTrackEvent).toHaveBeenCalledExactlyOnceWith('featured_tab_impression', {
+      featured_tab_id: 'ft_1234abcd',
+    });
+
+    // The 5-minute config poll resolves the same tab into a fresh object.
+    mockFeaturedTab.current = config();
+    rerender(tree());
+
+    expect(mockTrackEvent).toHaveBeenCalledTimes(1);
   });
 
   it('resolves direct navigation to the configured featured slug', () => {

--- a/src/pages/DiscoveryPage.test.tsx
+++ b/src/pages/DiscoveryPage.test.tsx
@@ -14,11 +14,13 @@ const {
   mockFeaturedTab,
   mockCurrentUser,
   mockTrackEvent,
+  mockFeaturedResolved,
 } = vi.hoisted(() => ({
   mockNavigate: vi.fn(),
   mockTrackEvent: vi.fn(),
   mockCategories: [] as CategoryWithConfig[],
   mockFeaturedTab: { current: null as ResolvedFeaturedTab | null },
+  mockFeaturedResolved: { current: true },
   mockCurrentUser: { current: null as { pubkey: string } | null },
 }));
 
@@ -35,7 +37,10 @@ vi.mock('@/hooks/useCategories', () => ({
 }));
 
 vi.mock('@/hooks/useFeaturedTab', () => ({
-  useFeaturedTab: () => mockFeaturedTab.current,
+  useFeaturedTab: () => ({
+    tab: mockFeaturedTab.current,
+    isResolved: mockFeaturedResolved.current,
+  }),
 }));
 
 vi.mock('@/lib/analytics', () => ({
@@ -77,6 +82,7 @@ describe('DiscoveryPage', () => {
     mockTrackEvent.mockReset();
     mockCategories.length = 0;
     mockFeaturedTab.current = null;
+    mockFeaturedResolved.current = true;
     mockCurrentUser.current = null;
   });
 
@@ -184,6 +190,34 @@ describe('DiscoveryPage', () => {
     rerender(tree());
 
     expect(mockTrackEvent).toHaveBeenCalledTimes(1);
+  });
+
+  it('sends a slug no configuration claims back to the default tab', () => {
+    render(
+      <MemoryRouter initialEntries={['/discovery/expired-campaign']}>
+        <Routes>
+          <Route path="/discovery/:tab" element={<DiscoveryPage />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    expect(mockNavigate).toHaveBeenCalledWith('/discovery/classics', { replace: true });
+  });
+
+  it('leaves an unknown slug alone while the featured configuration is still loading', () => {
+    // The slug may still turn out to be a valid featured tab, so redirecting
+    // here would break a deep link into a live campaign.
+    mockFeaturedResolved.current = false;
+
+    render(
+      <MemoryRouter initialEntries={['/discovery/seasonal-theme']}>
+        <Routes>
+          <Route path="/discovery/:tab" element={<DiscoveryPage />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    expect(mockNavigate).not.toHaveBeenCalled();
   });
 
   it('resolves direct navigation to the configured featured slug', () => {

--- a/src/pages/DiscoveryPage.tsx
+++ b/src/pages/DiscoveryPage.tsx
@@ -249,7 +249,13 @@ export function DiscoveryPage() {
                 <Icon className="h-4 w-4 shrink-0" />
                 <span className="hidden min-w-0 truncate sm:inline" title={label}>{label}</span>
                 {disclosureLabel && (
-                  <span className="max-w-12 shrink-0 truncate rounded-full bg-background/80 px-1.5 py-0.5 text-[10px] leading-none text-foreground">
+                  // Rendered whole, not clipped: this marks a paid or sponsored
+                  // placement, and a disclosure the reader cannot finish reading
+                  // is not a disclosure. The parser already caps its length.
+                  <span
+                    className="shrink-0 whitespace-nowrap rounded-full bg-background/80 px-1.5 py-0.5 text-[10px] leading-none text-foreground"
+                    title={disclosureLabel}
+                  >
                     {disclosureLabel}
                   </span>
                 )}

--- a/src/pages/DiscoveryPage.tsx
+++ b/src/pages/DiscoveryPage.tsx
@@ -2,7 +2,7 @@
 // ABOUTME: Each video tab uses a moderated or curated feed source
 // ABOUTME: For You tab shows personalized recommendations when user is logged in
 
-import { useEffect, useMemo, useState } from 'react';
+import { type ComponentType, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useParams } from 'react-router-dom';
 import { useSubdomainNavigate } from '@/hooks/useSubdomainNavigate';
@@ -12,15 +12,54 @@ import { HashtagExplorer } from '@/components/HashtagExplorer';
 import { ClassicVinersRow } from '@/components/ClassicVinersRow';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { Star, Hash, Flame, Sparkle as Sparkles } from '@phosphor-icons/react';
-// Zap temporarily unused - will be needed when Rising tab is re-enabled
 import { useCurrentUser } from '@/hooks/useCurrentUser';
 import { useCategories } from '@/hooks/useCategories';
+import { useFeaturedTab } from '@/hooks/useFeaturedTab';
 import { getTranslatedCategoryLabel } from '@/lib/constants/categories';
+import { trackEvent } from '@/lib/analytics';
+import type { DiscoveryTabName, ResolvedFeaturedTab } from '@/types/featuredTabs';
 
 // All possible tab values (foryou only shown when logged in)
-type AllowedTab = 'foryou' | 'classics' | 'hot' | 'hashtags';
-const ALL_TABS: AllowedTab[] = ['foryou', 'classics', 'hot', 'hashtags'];
-const BASE_TABS: AllowedTab[] = ['classics', 'hot', 'hashtags'];
+type AllowedTab = DiscoveryTabName | string;
+
+interface DiscoveryTabItem {
+  value: AllowedTab;
+  label: string;
+  Icon: ComponentType<{ className?: string }>;
+  disclosureLabel?: string | null;
+  featuredTab?: ResolvedFeaturedTab;
+}
+
+function insertFeaturedTab(
+  tabs: DiscoveryTabItem[],
+  featuredTab: ResolvedFeaturedTab | null
+): DiscoveryTabItem[] {
+  if (!featuredTab) return tabs;
+
+  const item: DiscoveryTabItem = {
+    value: featuredTab.slug,
+    label: featuredTab.label,
+    Icon: Hash,
+    disclosureLabel: featuredTab.disclosureLabel,
+    featuredTab,
+  };
+  const position = featuredTab.position;
+  const target = position?.after ?? position?.before;
+  const targetIndex = target
+    ? tabs.findIndex((tab) => tab.value === target)
+    : -1;
+
+  if (targetIndex === -1) {
+    return [...tabs, item];
+  }
+
+  const insertAt = position?.before ? targetIndex : targetIndex + 1;
+  return [
+    ...tabs.slice(0, insertAt),
+    item,
+    ...tabs.slice(insertAt),
+  ];
+}
 
 export function DiscoveryPage() {
   const navigate = useSubdomainNavigate();
@@ -29,12 +68,47 @@ export function DiscoveryPage() {
   const { user } = useCurrentUser();
   const isLoggedIn = !!user?.pubkey;
   const { data: categories } = useCategories();
+  const featuredTab = useFeaturedTab();
 
-  // Tabs include 'foryou' only when logged in
-  // Note: 'rising' temporarily removed
+  const baseTabs = useMemo<DiscoveryTabItem[]>(() => {
+    const tabs: DiscoveryTabItem[] = [
+      {
+        value: 'classics',
+        label: t('discovery.classic'),
+        Icon: Star,
+      },
+      {
+        value: 'hot',
+        label: t('discovery.hot'),
+        Icon: Flame,
+      },
+      {
+        value: 'hashtags',
+        label: t('discovery.tags'),
+        Icon: Hash,
+      },
+    ];
+
+    return isLoggedIn
+      ? [
+          {
+            value: 'foryou',
+            label: t('discovery.forYou'),
+            Icon: Sparkles,
+          },
+          ...tabs,
+        ]
+      : tabs;
+  }, [isLoggedIn, t]);
+
+  const tabItems = useMemo(
+    () => insertFeaturedTab(baseTabs, featuredTab),
+    [baseTabs, featuredTab]
+  );
+
   const allowedTabs = useMemo(() => {
-    return isLoggedIn ? ALL_TABS : BASE_TABS;
-  }, [isLoggedIn]);
+    return tabItems.map((tab) => tab.value);
+  }, [tabItems]);
 
   const routeTab = (params.tab || '').toLowerCase();
   // Support legacy 'top' route by mapping to 'classics'
@@ -61,6 +135,13 @@ export function DiscoveryPage() {
     }
   }, [routeTab, normalizedTab, allowedTabs, navigate]);
 
+  useEffect(() => {
+    if (!allowedTabs.includes(activeTab)) {
+      setActiveTab(defaultTab);
+      navigate(`/discovery/${defaultTab}`, { replace: true });
+    }
+  }, [activeTab, allowedTabs, defaultTab, navigate]);
+
   // Handle edge case: user logs out while on 'foryou' tab
   useEffect(() => {
     if (!isLoggedIn && activeTab === 'foryou') {
@@ -75,6 +156,16 @@ export function DiscoveryPage() {
       navigate(`/discovery/${defaultTab}`, { replace: true });
     }
   }, [params.tab, navigate, defaultTab]);
+
+  useEffect(() => {
+    if (featuredTab && activeTab === featuredTab.slug) {
+      trackEvent('featured_tab_impression', {
+        featured_tab_id: featuredTab.id,
+      });
+    }
+  }, [activeTab, featuredTab]);
+
+  const activeTabItem = tabItems.find((tab) => tab.value === activeTab);
 
   return (
     <div className="container mx-auto px-4 py-6">
@@ -115,38 +206,28 @@ export function DiscoveryPage() {
         <Tabs
           value={activeTab}
           onValueChange={(val) => {
-            if (allowedTabs.includes(val as AllowedTab)) {
-              setActiveTab(val as AllowedTab);
+            if (allowedTabs.includes(val)) {
+              setActiveTab(val);
               navigate(`/discovery/${val}`);
             }
           }}
           className="space-y-6"
         >
-          <TabsList className={`w-full grid gap-1 ${isLoggedIn ? 'grid-cols-4' : 'grid-cols-3'}`}>
-            {isLoggedIn && (
-              <TabsTrigger value="foryou" className="gap-1.5 sm:gap-2">
-                <Sparkles className="h-4 w-4" />
-                <span className="hidden sm:inline">{t('discovery.forYou')}</span>
+          <TabsList
+            className="grid w-full gap-1"
+            style={{ gridTemplateColumns: `repeat(${tabItems.length}, minmax(0, 1fr))` }}
+          >
+            {tabItems.map(({ value, label, Icon, disclosureLabel }) => (
+              <TabsTrigger key={value} value={value} className="min-w-0 gap-1.5 px-2 sm:gap-2 sm:px-4">
+                <Icon className="h-4 w-4 shrink-0" />
+                <span className="hidden min-w-0 truncate sm:inline" title={label}>{label}</span>
+                {disclosureLabel && (
+                  <span className="max-w-12 shrink-0 truncate rounded-full bg-background/80 px-1.5 py-0.5 text-[10px] leading-none text-foreground">
+                    {disclosureLabel}
+                  </span>
+                )}
               </TabsTrigger>
-            )}
-            <TabsTrigger value="classics" className="gap-1.5 sm:gap-2">
-              <Star className="h-4 w-4" />
-              <span className="hidden sm:inline">{t('discovery.classic')}</span>
-            </TabsTrigger>
-            <TabsTrigger value="hot" className="gap-1.5 sm:gap-2">
-              <Flame className="h-4 w-4" />
-              <span className="hidden sm:inline">{t('discovery.hot')}</span>
-            </TabsTrigger>
-            {/* Rising tab temporarily disabled
-            <TabsTrigger value="rising" className="gap-1.5 sm:gap-2">
-              <Zap className="h-4 w-4" />
-              <span className="hidden sm:inline">Rising</span>
-            </TabsTrigger>
-            */}
-            <TabsTrigger value="hashtags" className="gap-1.5 sm:gap-2">
-              <Hash className="h-4 w-4" />
-              <span className="hidden sm:inline">{t('discovery.tags')}</span>
-            </TabsTrigger>
+            ))}
           </TabsList>
 
           {isLoggedIn && (
@@ -188,22 +269,22 @@ export function DiscoveryPage() {
             />
           </TabsContent>
 
-          {/* Rising tab temporarily disabled
-          <TabsContent value="rising" className="mt-0 space-y-6">
-            <VideoFeed
-              feedType="trending"
-              sortMode="rising"
-              verifiedOnly={verifiedOnly}
-              data-testid="video-feed-rising"
-              className="space-y-6"
-              key="rising"
-            />
-          </TabsContent>
-          */}
-
           <TabsContent value="hashtags" className="mt-0 space-y-6">
             <HashtagExplorer />
           </TabsContent>
+
+          {activeTabItem?.featuredTab && (
+            <TabsContent value={activeTabItem.featuredTab.slug} className="mt-0 space-y-6">
+              <VideoFeed
+                feedType="featured"
+                featuredTabId={activeTabItem.featuredTab.id}
+                verifiedOnly={verifiedOnly}
+                data-testid="video-feed-featured"
+                className="space-y-6"
+                key={activeTabItem.featuredTab.id}
+              />
+            </TabsContent>
+          )}
         </Tabs>
       </div>
     </div>

--- a/src/pages/DiscoveryPage.tsx
+++ b/src/pages/DiscoveryPage.tsx
@@ -11,7 +11,7 @@ import { VerifiedOnlyToggle } from '@/components/VerifiedOnlyToggle';
 import { HashtagExplorer } from '@/components/HashtagExplorer';
 import { ClassicVinersRow } from '@/components/ClassicVinersRow';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
-import { Star, Hash, Flame, Sparkle as Sparkles } from '@phosphor-icons/react';
+import { Star, Hash, Flame, Sparkle as Sparkles, Confetti } from '@phosphor-icons/react';
 import { useCurrentUser } from '@/hooks/useCurrentUser';
 import { useCategories } from '@/hooks/useCategories';
 import { useFeaturedTab } from '@/hooks/useFeaturedTab';
@@ -39,7 +39,10 @@ function insertFeaturedTab(
   const item: DiscoveryTabItem = {
     value: featuredTab.slug,
     label: featuredTab.label,
-    Icon: Hash,
+    // Not Hash: the hashtags tab already owns that glyph, and below `sm` the
+    // labels are hidden, so a second Hash would make the editorial tab
+    // indistinguishable from it on mobile.
+    Icon: Confetti,
     disclosureLabel: featuredTab.disclosureLabel,
     featuredTab,
   };
@@ -68,7 +71,7 @@ export function DiscoveryPage() {
   const { user } = useCurrentUser();
   const isLoggedIn = !!user?.pubkey;
   const { data: categories } = useCategories();
-  const featuredTab = useFeaturedTab();
+  const { tab: featuredTab, isResolved: isFeaturedConfigResolved } = useFeaturedTab();
 
   const baseTabs = useMemo<DiscoveryTabItem[]>(() => {
     const tabs: DiscoveryTabItem[] = [
@@ -141,6 +144,25 @@ export function DiscoveryPage() {
       navigate(`/discovery/${defaultTab}`, { replace: true });
     }
   }, [activeTab, allowedTabs, defaultTab, navigate]);
+
+  // A slug that no configuration claims — expired campaign, shared link, typo —
+  // otherwise renders the default tab while the address bar keeps the dead
+  // route, so a reload or a re-share carries the phantom slug onward. Wait for
+  // the featured config to resolve first: before then, an unknown slug may
+  // still turn out to be a valid featured tab.
+  useEffect(() => {
+    if (!routeTab || !isFeaturedConfigResolved) return;
+    if (allowedTabs.includes(normalizedTab as AllowedTab)) return;
+
+    navigate(`/discovery/${defaultTab}`, { replace: true });
+  }, [
+    routeTab,
+    normalizedTab,
+    allowedTabs,
+    defaultTab,
+    isFeaturedConfigResolved,
+    navigate,
+  ]);
 
   // Handle edge case: user logs out while on 'foryou' tab
   useEffect(() => {

--- a/src/pages/DiscoveryPage.tsx
+++ b/src/pages/DiscoveryPage.tsx
@@ -157,13 +157,18 @@ export function DiscoveryPage() {
     }
   }, [params.tab, navigate, defaultTab]);
 
+  // Keyed on the identifiers rather than the resolved object: the config poll
+  // hands back a fresh object every refresh, which would otherwise re-count an
+  // impression every few minutes for a viewer who never left the tab.
+  const featuredTabId = featuredTab?.id;
+  const featuredTabSlug = featuredTab?.slug;
   useEffect(() => {
-    if (featuredTab && activeTab === featuredTab.slug) {
+    if (featuredTabId && activeTab === featuredTabSlug) {
       trackEvent('featured_tab_impression', {
-        featured_tab_id: featuredTab.id,
+        featured_tab_id: featuredTabId,
       });
     }
-  }, [activeTab, featuredTab]);
+  }, [activeTab, featuredTabId, featuredTabSlug]);
 
   const activeTabItem = tabItems.find((tab) => tab.value === activeTab);
 

--- a/src/pages/DiscoveryPage.tsx
+++ b/src/pages/DiscoveryPage.tsx
@@ -68,7 +68,7 @@ export function DiscoveryPage() {
   const navigate = useSubdomainNavigate();
   const { t } = useTranslation();
   const params = useParams<{ tab?: string }>();
-  const { user } = useCurrentUser();
+  const { user, isResolvingJwt } = useCurrentUser();
   const isLoggedIn = !!user?.pubkey;
   const { data: categories } = useCategories();
   const { tab: featuredTab, isResolved: isFeaturedConfigResolved } = useFeaturedTab();
@@ -147,11 +147,17 @@ export function DiscoveryPage() {
 
   // A slug that no configuration claims — expired campaign, shared link, typo —
   // otherwise renders the default tab while the address bar keeps the dead
-  // route, so a reload or a re-share carries the phantom slug onward. Wait for
-  // the featured config to resolve first: before then, an unknown slug may
-  // still turn out to be a valid featured tab.
+  // route, so a reload or a re-share carries the phantom slug onward.
+  //
+  // Both guards below are about not mistaking "still loading" for "no such
+  // tab", because this navigates with `replace` and so destroys the original
+  // URL. An unknown slug may still be a live featured tab until the config
+  // resolves; and a hosted session reports no user while the JWT resolves, so
+  // `foryou` is briefly absent from `allowedTabs` — redirecting then would
+  // replace a logged-in reader's bookmark. AppRouter and AnalyticsPage guard
+  // that same transient state.
   useEffect(() => {
-    if (!routeTab || !isFeaturedConfigResolved) return;
+    if (!routeTab || !isFeaturedConfigResolved || isResolvingJwt) return;
     if (allowedTabs.includes(normalizedTab as AllowedTab)) return;
 
     navigate(`/discovery/${defaultTab}`, { replace: true });
@@ -161,6 +167,7 @@ export function DiscoveryPage() {
     allowedTabs,
     defaultTab,
     isFeaturedConfigResolved,
+    isResolvingJwt,
     navigate,
   ]);
 
@@ -245,15 +252,23 @@ export function DiscoveryPage() {
             style={{ gridTemplateColumns: `repeat(${tabItems.length}, minmax(0, 1fr))` }}
           >
             {tabItems.map(({ value, label, Icon, disclosureLabel }) => (
-              <TabsTrigger key={value} value={value} className="min-w-0 gap-1.5 px-2 sm:gap-2 sm:px-4">
+              <TabsTrigger
+                key={value}
+                value={value}
+                className="min-w-0 gap-1.5 px-2 sm:gap-2 sm:px-4"
+                aria-label={disclosureLabel ? `${label} — ${disclosureLabel}` : undefined}
+              >
                 <Icon className="h-4 w-4 shrink-0" />
                 <span className="hidden min-w-0 truncate sm:inline" title={label}>{label}</span>
                 {disclosureLabel && (
-                  // Rendered whole, not clipped: this marks a paid or sponsored
-                  // placement, and a disclosure the reader cannot finish reading
-                  // is not a disclosure. The parser already caps its length.
+                  // This marks a paid or sponsored placement, so the full text
+                  // has to stay reachable: the parser no longer pre-clips it,
+                  // `title` and the trigger's aria-label carry it whole. The
+                  // width bound is still needed because neither TabsTrigger nor
+                  // TabsList clips overflow, so an unbounded pill would spill
+                  // the tab bar at narrow widths.
                   <span
-                    className="shrink-0 whitespace-nowrap rounded-full bg-background/80 px-1.5 py-0.5 text-[10px] leading-none text-foreground"
+                    className="max-w-[7rem] shrink truncate rounded-full bg-background/80 px-1.5 py-0.5 text-[10px] leading-none text-foreground"
                     title={disclosureLabel}
                   >
                     {disclosureLabel}

--- a/src/pages/DiscoveryPage.tsx
+++ b/src/pages/DiscoveryPage.tsx
@@ -256,19 +256,13 @@ export function DiscoveryPage() {
                 key={value}
                 value={value}
                 className="min-w-0 gap-1.5 px-2 sm:gap-2 sm:px-4"
-                aria-label={disclosureLabel ? `${label} — ${disclosureLabel}` : undefined}
+                aria-label={disclosureLabel ? `${label}: ${disclosureLabel}` : undefined}
               >
                 <Icon className="h-4 w-4 shrink-0" />
                 <span className="hidden min-w-0 truncate sm:inline" title={label}>{label}</span>
                 {disclosureLabel && (
-                  // This marks a paid or sponsored placement, so the full text
-                  // has to stay reachable: the parser no longer pre-clips it,
-                  // `title` and the trigger's aria-label carry it whole. The
-                  // width bound is still needed because neither TabsTrigger nor
-                  // TabsList clips overflow, so an unbounded pill would spill
-                  // the tab bar at narrow widths.
                   <span
-                    className="max-w-[7rem] shrink truncate rounded-full bg-background/80 px-1.5 py-0.5 text-[10px] leading-none text-foreground"
+                    className="hidden max-w-[7rem] shrink truncate rounded-full bg-background/80 px-1.5 py-0.5 text-[10px] leading-none text-foreground sm:inline"
                     title={disclosureLabel}
                   >
                     {disclosureLabel}
@@ -323,6 +317,13 @@ export function DiscoveryPage() {
 
           {activeTabItem?.featuredTab && (
             <TabsContent value={activeTabItem.featuredTab.slug} className="mt-0 space-y-6">
+              {activeTabItem.featuredTab.disclosureLabel && (
+                <div className="flex justify-center">
+                  <span className="inline-flex max-w-full rounded-full border border-border bg-background px-3 py-1 text-sm font-medium text-foreground">
+                    {activeTabItem.featuredTab.disclosureLabel}
+                  </span>
+                </div>
+              )}
               <VideoFeed
                 feedType="featured"
                 featuredTabId={activeTabItem.featuredTab.id}

--- a/src/pages/DiscoveryPage.tsx
+++ b/src/pages/DiscoveryPage.tsx
@@ -15,15 +15,13 @@ import { Star, Hash, Flame, Sparkle as Sparkles, Confetti } from '@phosphor-icon
 import { useCurrentUser } from '@/hooks/useCurrentUser';
 import { useCategories } from '@/hooks/useCategories';
 import { useFeaturedTab } from '@/hooks/useFeaturedTab';
+import { useFunnelcakeSupport } from '@/hooks/useVideoProvider';
 import { getTranslatedCategoryLabel } from '@/lib/constants/categories';
 import { trackEvent } from '@/lib/analytics';
-import type { DiscoveryTabName, ResolvedFeaturedTab } from '@/types/featuredTabs';
-
-// All possible tab values (foryou only shown when logged in)
-type AllowedTab = DiscoveryTabName | string;
+import type { ResolvedFeaturedTab } from '@/types/featuredTabs';
 
 interface DiscoveryTabItem {
-  value: AllowedTab;
+  value: string;
   label: string;
   Icon: ComponentType<{ className?: string }>;
   disclosureLabel?: string | null;
@@ -71,7 +69,10 @@ export function DiscoveryPage() {
   const { user, isResolvingJwt } = useCurrentUser();
   const isLoggedIn = !!user?.pubkey;
   const { data: categories } = useCategories();
-  const { tab: featuredTab, isResolved: isFeaturedConfigResolved } = useFeaturedTab();
+  const { apiUrl: featuredApiUrl } = useFunnelcakeSupport();
+  const { tab: featuredTab, isResolved: isFeaturedConfigResolved } = useFeaturedTab({
+    apiUrl: featuredApiUrl,
+  });
 
   const baseTabs = useMemo<DiscoveryTabItem[]>(() => {
     const tabs: DiscoveryTabItem[] = [
@@ -117,9 +118,9 @@ export function DiscoveryPage() {
   // Support legacy 'top' route by mapping to 'classics'
   const normalizedTab = routeTab === 'top' ? 'classics' : routeTab;
   // Default to 'foryou' for logged-in users, 'classics' for anonymous
-  const defaultTab: AllowedTab = isLoggedIn ? 'foryou' : 'classics';
-  const initialTab: AllowedTab = allowedTabs.includes(normalizedTab as AllowedTab) ? (normalizedTab as AllowedTab) : defaultTab;
-  const [activeTab, setActiveTab] = useState<AllowedTab>(initialTab);
+  const defaultTab = isLoggedIn ? 'foryou' : 'classics';
+  const initialTab = allowedTabs.includes(normalizedTab) ? normalizedTab : defaultTab;
+  const [activeTab, setActiveTab] = useState(initialTab);
   const [verifiedOnly, setVerifiedOnly] = useState(false);
 
   // Note: We no longer force relay changes here as it causes navigation delays
@@ -133,17 +134,25 @@ export function DiscoveryPage() {
       navigate('/discovery/classics', { replace: true });
       return;
     }
-    if (allowedTabs.includes(normalizedTab as AllowedTab)) {
-      setActiveTab(normalizedTab as AllowedTab);
+    if (allowedTabs.includes(normalizedTab)) {
+      setActiveTab(normalizedTab);
     }
   }, [routeTab, normalizedTab, allowedTabs, navigate]);
 
   useEffect(() => {
+    if (!isFeaturedConfigResolved || isResolvingJwt) return;
     if (!allowedTabs.includes(activeTab)) {
       setActiveTab(defaultTab);
       navigate(`/discovery/${defaultTab}`, { replace: true });
     }
-  }, [activeTab, allowedTabs, defaultTab, navigate]);
+  }, [
+    activeTab,
+    allowedTabs,
+    defaultTab,
+    isFeaturedConfigResolved,
+    isResolvingJwt,
+    navigate,
+  ]);
 
   // A slug that no configuration claims — expired campaign, shared link, typo —
   // otherwise renders the default tab while the address bar keeps the dead
@@ -158,7 +167,7 @@ export function DiscoveryPage() {
   // that same transient state.
   useEffect(() => {
     if (!routeTab || !isFeaturedConfigResolved || isResolvingJwt) return;
-    if (allowedTabs.includes(normalizedTab as AllowedTab)) return;
+    if (allowedTabs.includes(normalizedTab)) return;
 
     navigate(`/discovery/${defaultTab}`, { replace: true });
   }, [
@@ -170,14 +179,6 @@ export function DiscoveryPage() {
     isResolvingJwt,
     navigate,
   ]);
-
-  // Handle edge case: user logs out while on 'foryou' tab
-  useEffect(() => {
-    if (!isLoggedIn && activeTab === 'foryou') {
-      setActiveTab('classics');
-      navigate('/discovery/classics', { replace: true });
-    }
-  }, [isLoggedIn, activeTab, navigate]);
 
   // Redirect bare /discovery to default tab (foryou for logged in, classics for anonymous)
   useEffect(() => {
@@ -256,7 +257,7 @@ export function DiscoveryPage() {
                 key={value}
                 value={value}
                 className="min-w-0 gap-1.5 px-2 sm:gap-2 sm:px-4"
-                aria-label={disclosureLabel ? `${label}: ${disclosureLabel}` : undefined}
+                aria-label={disclosureLabel ? `${label}: ${disclosureLabel}` : label}
               >
                 <Icon className="h-4 w-4 shrink-0" />
                 <span className="hidden min-w-0 truncate sm:inline" title={label}>{label}</span>

--- a/src/types/featuredTabs.ts
+++ b/src/types/featuredTabs.ts
@@ -38,9 +38,11 @@ export interface FeaturedTabVideoRaw extends Omit<FunnelcakeVideoRaw, 'created_a
 
 export interface FeaturedTabVideosResponseRaw {
   data: FeaturedTabVideoRaw[];
-  pagination: {
+  // Optional because the transform treats a malformed envelope as "no more
+  // pages" rather than throwing.
+  pagination?: {
     next_cursor?: string | null;
-    has_more: boolean;
+    has_more?: boolean;
   };
 }
 

--- a/src/types/featuredTabs.ts
+++ b/src/types/featuredTabs.ts
@@ -1,0 +1,47 @@
+import type { FunnelcakeVideoRaw } from '@/types/funnelcake';
+
+export interface FeaturedTabsResponse {
+  poll_interval_seconds: number;
+  featured_tabs: FeaturedTabConfigRaw[];
+}
+
+export interface FeaturedTabConfigRaw {
+  id: string;
+  slug: string;
+  label: Record<string, string>;
+  position: unknown;
+  starts_at: string;
+  ends_at: string;
+  enabled: boolean;
+  visible_to_minors: boolean;
+  disclosure_label: unknown;
+  has_content: boolean;
+}
+
+export interface FeaturedTabPosition {
+  after?: DiscoveryTabName;
+  before?: DiscoveryTabName;
+}
+
+export interface ResolvedFeaturedTab {
+  id: string;
+  slug: string;
+  label: string;
+  position: FeaturedTabPosition | null;
+  disclosureLabel: string | null;
+}
+
+export interface FeaturedTabVideoRaw extends Omit<FunnelcakeVideoRaw, 'created_at'> {
+  created_at: string | number;
+  sha256?: string;
+}
+
+export interface FeaturedTabVideosResponseRaw {
+  data: FeaturedTabVideoRaw[];
+  pagination: {
+    next_cursor?: string | null;
+    has_more: boolean;
+  };
+}
+
+export type DiscoveryTabName = 'foryou' | 'classics' | 'hot' | 'hashtags';

--- a/src/types/funnelcake.ts
+++ b/src/types/funnelcake.ts
@@ -38,6 +38,7 @@ export interface FunnelcakeVideoRaw {
   content?: string;       // Video content/description (user videos endpoint)
   thumbnail?: string;     // Thumbnail URL
   video_url: string;      // Primary video URL
+  sha256?: string;        // Blossom/media SHA-256 when supplied by compact endpoints
   blurhash?: string;      // Progressive loading placeholder
   dim?: string;           // Video dimensions, v1 (e.g., "1080x1920")
   dimensions?: string;    // Video dimensions, v2 (e.g., "1080x1920")


### PR DESCRIPTION
## Summary

- Adds Funnelcake-driven featured Discovery tab configuration and REST-only featured video pagination.
- Refactors Discovery tabs into a data-driven list so the featured tab can join routing, placement, disclosure, and dynamic sizing only while eligible.
- Adds defensive parsing for backend-supplied labels, slugs, ids, positions, disclosures, minor eligibility, poll interval, and compact featured video payloads. The audience gate and the kill switch require a literal `true`, and featured requests read the shared Funnelcake circuit breaker without writing to it, so a fault on this optional surface cannot push the core feeds onto the relay.
- Stabilizes the featured tab route so config and videos use the same Funnelcake host, unresolved config/JWT state does not replace active deep links, and icon-only mobile tab triggers keep accessible names.

> Avoid naming corporate partners, customers, or other sensitive external brands in this PR title or body. Use generic descriptors unless a maintainer explicitly approves the public reference.

## Also changed

- Validates backend-provided video `sha256` values before they override URL-derived hashes. This affects all Funnelcake-backed feeds, not only featured tabs, and prevents malformed hashes from shadowing usable media hashes.

## Motivation

- Editorial featured hashtag tabs need to appear, move, localize, and disappear through server config without a web deploy.
- Funnelcake now owns the hidden hashtag and ordered content list, so web should fetch by opaque config id and avoid relay fallback.

## Related Issue

- Closes #527
- Follow-up: #559

## Testing

- [x] `npm run test`
- [x] Targeted Vitest: `vitest run src/pages/DiscoveryPage.test.tsx src/hooks/useFeaturedTab.test.ts src/hooks/useFeaturedTabVideos.test.ts src/hooks/useVideoProvider.test.ts`
- [ ] Manual verification completed

## Visuals

- [ ] UI change with screenshots/video attached
- [ ] No visual change
- [x] Visuals and text avoid sensitive external brand or partner names unless explicitly approved

Note: production currently serves an empty `featured_tabs` array, so the default visible Discovery UI remains unchanged until config is enabled.
