### PR TITLE
fix(reactions): tag video likes with the addressable coordinate

### DIFF
--- a/src/hooks/useOptimisticLike.test.ts
+++ b/src/hooks/useOptimisticLike.test.ts
@@ -237,6 +237,7 @@ describe('useOptimisticLike', () => {
       tags: [
         ['e', VIDEO_ID],
         ['p', AUTHOR_PK],
+        ['k', '34236'],
       ],
     });
 
@@ -245,6 +246,36 @@ describe('useOptimisticLike', () => {
       likeEventId: 'relay-like-id',
     });
     expect(queryClient.getQueryData(mKey)).toMatchObject({ likeCount: 1 });
+  });
+
+  it('likes with the video coordinate so the reaction survives an edit', async () => {
+    const { Wrapper } = createHarness();
+
+    publishAsync.mockResolvedValueOnce({ id: 'relay-like-id' });
+
+    const { result } = renderHook(() => useOptimisticLike(), { wrapper: Wrapper });
+
+    await act(async () => {
+      await result.current.toggleLike({
+        videoId: VIDEO_ID,
+        videoPubkey: AUTHOR_PK,
+        vineId: VINE_ID,
+        userPubkey: VIEWER_PK,
+        isCurrentlyLiked: false,
+        currentLikeEventId: null,
+      });
+    });
+
+    expect(publishAsync).toHaveBeenCalledWith({
+      kind: 7,
+      content: '+',
+      tags: [
+        ['e', VIDEO_ID],
+        ['a', `34236:${AUTHOR_PK}:${VINE_ID}`],
+        ['p', AUTHOR_PK],
+        ['k', '34236'],
+      ],
+    });
   });
 
   it('rolls back cache when publish fails', async () => {

--- a/src/hooks/useOptimisticLike.ts
+++ b/src/hooks/useOptimisticLike.ts
@@ -7,7 +7,7 @@ import { useNostrPublish } from '@/hooks/useNostrPublish';
 import { useToast } from '@/hooks/useToast';
 import { debugLog } from '@/lib/debug';
 import type { VideoSocialMetrics } from '@/hooks/useVideoSocialMetrics';
-import { SHORT_VIDEO_KIND } from '@/types/video';
+import { buildVideoLikeTags } from '@/lib/buildVideoLikeTags';
 
 interface OptimisticLikeParams {
   videoId: string;
@@ -80,12 +80,7 @@ export function useOptimisticLike() {
 
         debugLog('Optimistically liking video:', videoId);
 
-        const tags = [
-          ['e', videoId],
-          ...(vineId ? [['a', `${SHORT_VIDEO_KIND}:${videoPubkey}:${vineId}`]] : []),
-          ['p', videoPubkey],
-          ['k', SHORT_VIDEO_KIND.toString()],
-        ];
+        const tags = buildVideoLikeTags({ videoId, videoPubkey, vineId });
 
         // Actually publish the like event
         const event = await publishEvent({

--- a/src/hooks/useOptimisticLike.ts
+++ b/src/hooks/useOptimisticLike.ts
@@ -84,6 +84,7 @@ export function useOptimisticLike() {
           ['e', videoId],
           ...(vineId ? [['a', `${SHORT_VIDEO_KIND}:${videoPubkey}:${vineId}`]] : []),
           ['p', videoPubkey],
+          ['k', SHORT_VIDEO_KIND.toString()],
         ];
 
         // Actually publish the like event

--- a/src/lib/buildVideoLikeTags.test.ts
+++ b/src/lib/buildVideoLikeTags.test.ts
@@ -1,0 +1,42 @@
+// ABOUTME: Unit tests for the NIP-25 video like tag builder
+// ABOUTME: Pins the coordinate so an edited video keeps its reactions reachable
+import { describe, it, expect } from 'vitest';
+
+import { SHORT_VIDEO_KIND } from '@/types/video';
+
+import { buildVideoLikeTags } from './buildVideoLikeTags';
+
+const VIDEO_ID = '01' + 'cc'.repeat(31);
+const AUTHOR_PK = 'a1' + 'aa'.repeat(31);
+const VINE_ID = 'vine-one';
+
+describe('buildVideoLikeTags', () => {
+  it('carries the coordinate so the reaction survives an edit', () => {
+    expect(
+      buildVideoLikeTags({
+        videoId: VIDEO_ID,
+        videoPubkey: AUTHOR_PK,
+        vineId: VINE_ID,
+      })
+    ).toEqual([
+      ['e', VIDEO_ID],
+      ['a', `${SHORT_VIDEO_KIND}:${AUTHOR_PK}:${VINE_ID}`],
+      ['p', AUTHOR_PK],
+      ['k', SHORT_VIDEO_KIND.toString()],
+    ]);
+  });
+
+  it('omits the coordinate when the video has no d tag to address it by', () => {
+    expect(
+      buildVideoLikeTags({
+        videoId: VIDEO_ID,
+        videoPubkey: AUTHOR_PK,
+        vineId: null,
+      })
+    ).toEqual([
+      ['e', VIDEO_ID],
+      ['p', AUTHOR_PK],
+      ['k', SHORT_VIDEO_KIND.toString()],
+    ]);
+  });
+});

--- a/src/lib/buildVideoLikeTags.ts
+++ b/src/lib/buildVideoLikeTags.ts
@@ -1,0 +1,36 @@
+// ABOUTME: Pure NIP-25 (kind 7) tag construction for a like on an addressable video
+// ABOUTME: Shared by the VideoPage and useOptimisticLike callsites so they cannot drift
+
+import { SHORT_VIDEO_KIND } from '@/types/video';
+
+interface VideoLikeTarget {
+  /** Event id of the concrete video event being liked. */
+  videoId: string;
+  /** Video author's pubkey. */
+  videoPubkey: string;
+  /** The video's `d` tag, or null when it has none. */
+  vineId: string | null;
+}
+
+/**
+ * Build the NIP-25 tag array for a like on a video.
+ *
+ * The `a` coordinate is emitted whenever the video has a `d` tag to address it
+ * by: the `e` id is superseded the first time the author edits, so an id-only
+ * reaction is stranded, while the coordinate outlives the edit. Without a `d`
+ * tag there is no valid coordinate and the reaction falls back to the id alone.
+ *
+ * Does not include kind/content/signature — tags only.
+ */
+export function buildVideoLikeTags({
+  videoId,
+  videoPubkey,
+  vineId,
+}: VideoLikeTarget): string[][] {
+  return [
+    ['e', videoId],
+    ...(vineId ? [['a', `${SHORT_VIDEO_KIND}:${videoPubkey}:${vineId}`]] : []),
+    ['p', videoPubkey],
+    ['k', SHORT_VIDEO_KIND.toString()],
+  ];
+}

--- a/src/pages/VideoPage.test.tsx
+++ b/src/pages/VideoPage.test.tsx
@@ -1,9 +1,16 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import type { HTMLAttributes, ReactNode } from 'react';
 import VideoPage from './VideoPage';
 import { initializeI18n } from '@/lib/i18n';
+
+const { VIDEO_1_AUTHOR_PK, VIDEO_2_AUTHOR_PK, VIDEO_3_AUTHOR_PK, VIEWER_PK } = vi.hoisted(() => ({
+  VIDEO_1_AUTHOR_PK: 'a'.repeat(64),
+  VIDEO_2_AUTHOR_PK: 'b'.repeat(64),
+  VIDEO_3_AUTHOR_PK: 'c'.repeat(64),
+  VIEWER_PK: 'f'.repeat(64),
+}));
 
 const { mockNavigate } = vi.hoisted(() => ({
   mockNavigate: vi.fn(),
@@ -11,6 +18,11 @@ const { mockNavigate } = vi.hoisted(() => ({
 
 const { openLoginDialogMock } = vi.hoisted(() => ({
   openLoginDialogMock: vi.fn(),
+}));
+
+const { publishAsyncMock, currentUser } = vi.hoisted(() => ({
+  publishAsyncMock: vi.fn(),
+  currentUser: { value: null as { pubkey: string } | null },
 }));
 
 vi.mock('@unhead/react', () => ({
@@ -23,43 +35,48 @@ vi.mock('@/hooks/useSubdomainNavigate', () => ({
 }));
 
 vi.mock('@/hooks/useVideoByIdFunnelcake', () => ({
-  useVideoByIdFunnelcake: (options: { query?: string }) => {
+  useVideoByIdFunnelcake: (options: { videoId: string; query?: string }) => {
     const videos = [
       {
         id: 'video-1',
-        pubkey: 'a'.repeat(64),
+        pubkey: VIDEO_1_AUTHOR_PK,
         kind: 34236,
         createdAt: 1,
         content: 'one',
         videoUrl: 'https://example.com/1.mp4',
+        vineId: null,
         hashtags: [],
         reposts: [],
       },
       {
         id: 'video-2',
-        pubkey: 'b'.repeat(64),
+        pubkey: VIDEO_2_AUTHOR_PK,
         kind: 34236,
         createdAt: 2,
         content: 'two',
         videoUrl: 'https://example.com/2.mp4',
+        vineId: 'vine-two',
         hashtags: [],
         reposts: [],
       },
       {
         id: 'video-3',
-        pubkey: 'c'.repeat(64),
+        pubkey: VIDEO_3_AUTHOR_PK,
         kind: 34236,
         createdAt: 3,
         content: 'three',
         videoUrl: 'https://example.com/3.mp4',
+        vineId: 'vine-three',
         hashtags: [],
         reposts: [],
       },
     ];
 
+    const video = videos.find((v) => v.id === options.videoId) ?? videos[1];
+
     if (options.query === 'twerking') {
       return {
-        video: videos[1],
+        video,
         videos,
         windowOffset: 0,
         isLoading: false,
@@ -68,7 +85,7 @@ vi.mock('@/hooks/useVideoByIdFunnelcake', () => ({
     }
 
     return {
-      video: videos[1],
+      video,
       videos: null,
       windowOffset: 0,
       isLoading: false,
@@ -104,7 +121,7 @@ vi.mock('@/hooks/useBatchedVideoInteractions', () => ({
 
 vi.mock('@/hooks/useNostrPublish', () => ({
   useNostrPublish: () => ({
-    mutateAsync: vi.fn(),
+    mutateAsync: publishAsyncMock,
   }),
 }));
 
@@ -117,7 +134,7 @@ vi.mock('@/hooks/usePublishVideo', () => ({
 
 vi.mock('@/hooks/useCurrentUser', () => ({
   useCurrentUser: () => ({
-    user: null,
+    user: currentUser.value,
   }),
 }));
 
@@ -191,6 +208,8 @@ function renderPage(path: string) {
 describe('VideoPage', () => {
   beforeEach(async () => {
     vi.clearAllMocks();
+    currentUser.value = null;
+    publishAsyncMock.mockResolvedValue({ id: 'like-event-id' });
     const storage = new Map<string, string>();
     Object.defineProperty(window, 'localStorage', {
       configurable: true,
@@ -229,5 +248,44 @@ describe('VideoPage', () => {
 
     fireEvent.click(screen.getByRole('button', { name: /repost video/i }));
     expect(openLoginDialogMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('likes with the video coordinate so the reaction survives an edit', async () => {
+    currentUser.value = { pubkey: VIEWER_PK };
+
+    renderPage('/video/video-2');
+
+    fireEvent.click(screen.getByRole('button', { name: /like video/i }));
+
+    await waitFor(() => expect(publishAsyncMock).toHaveBeenCalledTimes(1));
+    expect(publishAsyncMock).toHaveBeenCalledWith({
+      kind: 7,
+      content: '+',
+      tags: [
+        ['e', 'video-2'],
+        ['a', `34236:${VIDEO_2_AUTHOR_PK}:vine-two`],
+        ['p', VIDEO_2_AUTHOR_PK],
+        ['k', '34236'],
+      ],
+    });
+  });
+
+  it('omits the coordinate when the video has no d tag to address it by', async () => {
+    currentUser.value = { pubkey: VIEWER_PK };
+
+    renderPage('/video/video-1');
+
+    fireEvent.click(screen.getByRole('button', { name: /like video/i }));
+
+    await waitFor(() => expect(publishAsyncMock).toHaveBeenCalledTimes(1));
+    expect(publishAsyncMock).toHaveBeenCalledWith({
+      kind: 7,
+      content: '+',
+      tags: [
+        ['e', 'video-1'],
+        ['p', VIDEO_1_AUTHOR_PK],
+        ['k', '34236'],
+      ],
+    });
   });
 });

--- a/src/pages/VideoPage.tsx
+++ b/src/pages/VideoPage.tsx
@@ -25,7 +25,7 @@ import { buildProfileLinkPath } from '@/lib/profileLinks';
 import { debugLog } from '@/lib/debug';
 import { getVisiblePlaybackCount } from '@/lib/playbackCount';
 import { reportFunnelcakeFallback } from '@/lib/funnelcakeFallbackReporting';
-import type { ParsedVideoData, UserInteractions } from '@/types/video';
+import { SHORT_VIDEO_KIND, type ParsedVideoData, type UserInteractions } from '@/types/video';
 
 export function VideoPage() {
   const { t } = useTranslation();
@@ -310,7 +310,13 @@ export function VideoPage() {
         content: '+', // Positive reaction
         tags: [
           ['e', video.id], // Reference to the video event
+          // The video is addressable: an id-only reaction strands the moment the
+          // author edits, since that id is superseded. The coordinate outlives it.
+          ...(video.vineId
+            ? [['a', `${SHORT_VIDEO_KIND}:${video.pubkey}:${video.vineId}`]]
+            : []),
           ['p', video.pubkey], // Reference to the video author
+          ['k', SHORT_VIDEO_KIND.toString()], // Kind of the reacted event
         ],
       });
 

--- a/src/pages/VideoPage.tsx
+++ b/src/pages/VideoPage.tsx
@@ -25,7 +25,8 @@ import { buildProfileLinkPath } from '@/lib/profileLinks';
 import { debugLog } from '@/lib/debug';
 import { getVisiblePlaybackCount } from '@/lib/playbackCount';
 import { reportFunnelcakeFallback } from '@/lib/funnelcakeFallbackReporting';
-import { SHORT_VIDEO_KIND, type ParsedVideoData, type UserInteractions } from '@/types/video';
+import { buildVideoLikeTags } from '@/lib/buildVideoLikeTags';
+import type { ParsedVideoData, UserInteractions } from '@/types/video';
 
 export function VideoPage() {
   const { t } = useTranslation();
@@ -308,16 +309,11 @@ export function VideoPage() {
       await publishEvent({
         kind: 7, // Reaction event
         content: '+', // Positive reaction
-        tags: [
-          ['e', video.id], // Reference to the video event
-          // The video is addressable: an id-only reaction strands the moment the
-          // author edits, since that id is superseded. The coordinate outlives it.
-          ...(video.vineId
-            ? [['a', `${SHORT_VIDEO_KIND}:${video.pubkey}:${video.vineId}`]]
-            : []),
-          ['p', video.pubkey], // Reference to the video author
-          ['k', SHORT_VIDEO_KIND.toString()], // Kind of the reacted event
-        ],
+        tags: buildVideoLikeTags({
+          videoId: video.id,
+          videoPubkey: video.pubkey,
+          vineId: video.vineId,
+        }),
       });
 
       toast({


### PR DESCRIPTION
## Summary

- `VideoPage.tsx` now publishes likes with the video's `a` coordinate alongside the `e` event id, so a like stays reachable after the author edits the video.
- Both like callsites (`VideoPage.tsx` and `useOptimisticLike.ts`) now also carry the `k` tag naming the reacted kind.

## Motivation

Videos are addressable (kind 34236). A kind 7 reaction carrying only an `e` tag points at one concrete event id, and that id is superseded the first time the creator edits — after which the reaction is unreachable by a query on either the current id or the coordinate. The liker silently disappears from "Liked by" while coordinate-keyed aggregates go on counting them, and because Nostr events are immutable, nothing repairs it afterwards.

NIP-25 asks for the coordinate: *"If the event being reacted to is an addressable event, an `a` SHOULD be included together with the `e` tag."* Adding it at publish time needs no backend support.

`useOptimisticLike` — the hook behind the feed and fullscreen like buttons — already emitted the coordinate. The video-page callsite was missed when that tag was introduced, which is why the shape is still being published today. This closes that gap.

Two notes on scope:

- **The `k` tag** is a second gap the issue thread flagged: neither like callsite emitted it, though NIP-25 asks for it and divine-mobile publishes it. It is included here so both callsites emit the same shape mobile does — `e`, `a`, `p`, `k`. Nothing in this repo reads `#k`, so it is purely additive.
- **Reposts were checked and need no change.** `useRepostVideo` already references videos by coordinate (`a`, `p`, `k`), so kind 16 reposts never had the stranding problem.

The `a` tag is emitted only when the video has a `d` tag to address it by; without one there is no valid coordinate to write, and the reaction falls back to the id alone.

The sibling fix for divine-space is tracked separately in that repo.

## Related Issue

- Closes #535

## Testing

- [x] `npm run test` — type-check, lint, 1836 unit tests, and build all pass
- [x] Manual verification completed

On manual verification: the regression is covered by unit tests rather than by publishing a live reaction. `VideoPage.test.tsx` asserts the exact tag array a like publishes, both with and without a `d` tag, and that test was confirmed to fail when the `a` tag is removed. `useOptimisticLike.test.ts` gains matching coverage for the coordinate, which previously had none.

## Visuals

- [x] No visual change
