### PR TITLE
fix(funnelcake): refuse video rows with no addressable coordinate

### DIFF
--- a/src/components/collabs/ConfirmedTab.tsx
+++ b/src/components/collabs/ConfirmedTab.tsx
@@ -22,10 +22,17 @@ export function ConfirmedTab() {
       </div>
     );
   }
+  // The transform refuses a row with no `d` tag, since there is no coordinate to
+  // address it by — drop those rather than rendering a card nothing can act on.
+  const videos = data.flatMap((raw) => {
+    const video = transformFunnelcakeVideo(raw);
+    return video ? [video] : [];
+  });
+
   return (
     <div className="grid grid-cols-2 md:grid-cols-3 gap-3">
-      {data.map((raw) => (
-        <VideoCard key={raw.id} video={transformFunnelcakeVideo(raw)} />
+      {videos.map((video) => (
+        <VideoCard key={video.id} video={video} />
       ))}
     </div>
   );

--- a/src/hooks/useClassicVineArchiveStats.ts
+++ b/src/hooks/useClassicVineArchiveStats.ts
@@ -27,7 +27,7 @@ export function useClassicVineArchiveStats(pubkey: string, enabled: boolean = tr
 
         for (const rawVideo of response.videos) {
           const video = transformFunnelcakeVideo(rawVideo);
-          if (!video.isVineMigrated) {
+          if (!video?.isVineMigrated) {
             continue;
           }
 

--- a/src/hooks/useVideoByIdFunnelcake.ts
+++ b/src/hooks/useVideoByIdFunnelcake.ts
@@ -9,6 +9,7 @@ import { getFunnelcakeUrl } from '@/config/relays';
 import { useAppContext } from '@/hooks/useAppContext';
 import { debugLog } from '@/lib/debug';
 import type { ParsedVideoData } from '@/types/video';
+import type { FunnelcakeVideoRaw } from '@/types/funnelcake';
 import type { SortMode } from '@/types/nostr';
 
 interface UseVideoByIdOptions {
@@ -30,6 +31,14 @@ interface UseVideoByIdResult {
 }
 
 const NAVIGATION_WINDOW_SIZE = 16;
+
+/** Drop rows the transform refuses — a video with no `d` tag has no coordinate. */
+function transformNavigationVideos(rawVideos: FunnelcakeVideoRaw[]): ParsedVideoData[] {
+  return rawVideos.flatMap(raw => {
+    const video = transformFunnelcakeVideo(raw);
+    return video ? [video] : [];
+  });
+}
 
 function getNavigationWindowOffset(currentIndex?: number): number {
   if (currentIndex === undefined || currentIndex < 0) {
@@ -86,7 +95,7 @@ export function useVideoByIdFunnelcake(options: UseVideoByIdOptions): UseVideoBy
         signal,
       });
 
-      return response.videos.map(transformFunnelcakeVideo);
+      return transformNavigationVideos(response.videos);
     },
     enabled: enabled && !!pubkey,
     staleTime: 300000, // 5 minutes
@@ -107,7 +116,7 @@ export function useVideoByIdFunnelcake(options: UseVideoByIdOptions): UseVideoBy
         signal,
       });
 
-      return response.videos.map(transformFunnelcakeVideo);
+      return transformNavigationVideos(response.videos);
     },
     enabled: enabled && !!hashtag && !pubkey, // Only fetch if hashtag context and no pubkey
     staleTime: 300000, // 5 minutes
@@ -131,7 +140,7 @@ export function useVideoByIdFunnelcake(options: UseVideoByIdOptions): UseVideoBy
         signal,
       });
 
-      return response.videos.map(transformFunnelcakeVideo);
+      return transformNavigationVideos(response.videos);
     },
     enabled: enabled && !!searchValue && !pubkey && !hashtag,
     staleTime: 300000,

--- a/src/lib/funnelcakeTransform.test.ts
+++ b/src/lib/funnelcakeTransform.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
-import { mergeVideoStats, parseFullEvent, transformFunnelcakeVideo, transformToVideoPage } from './funnelcakeTransform';
+import { mergeVideoStats, parseFullEvent, transformFunnelcakeResponse, transformFunnelcakeVideo, transformToVideoPage } from './funnelcakeTransform';
 import type { FunnelcakeVideoRaw, FunnelcakeResponse } from '@/types/funnelcake';
+import type { ParsedVideoData } from '@/types/video';
 
 function makeRawVideo(overrides: Partial<FunnelcakeVideoRaw> = {}): FunnelcakeVideoRaw {
   return {
@@ -16,9 +17,20 @@ function makeRawVideo(overrides: Partial<FunnelcakeVideoRaw> = {}): FunnelcakeVi
   };
 }
 
+/**
+ * Unwrap a transform that is expected to succeed. The transform returns null for
+ * a row with no `d` tag; these cases all supply one, so unwrapping keeps the
+ * assertions flat. The guard itself is covered separately below.
+ */
+function transformOk(raw: FunnelcakeVideoRaw): ParsedVideoData {
+  const video = transformFunnelcakeVideo(raw);
+  if (!video) throw new Error('expected the row to transform');
+  return video;
+}
+
 describe('transformFunnelcakeVideo', () => {
   it('treats direct lookup videos with a platform tag as archived Vine imports', () => {
-    const video = transformFunnelcakeVideo(makeRawVideo({
+    const video = transformOk(makeRawVideo({
       tags: [
         ['platform', 'vine'],
         ['d', 'vine-id'],
@@ -33,7 +45,7 @@ describe('transformFunnelcakeVideo', () => {
   });
 
   it('prefers the Vine origin tag external id over the d tag', () => {
-    const video = transformFunnelcakeVideo(makeRawVideo({
+    const video = transformOk(makeRawVideo({
       d_tag: 'addressable-d-tag',
       tags: [
         ['origin', 'vine', 'origin-id', 'https://vine.co/v/origin-id'],
@@ -49,7 +61,7 @@ describe('transformFunnelcakeVideo', () => {
   });
 
   it('prefers archived Vine loop tags over current Divine loop fields', () => {
-    const video = transformFunnelcakeVideo(makeRawVideo({
+    const video = transformOk(makeRawVideo({
       platform: 'vine',
       loops: 28,
       content: 'Original stats: 296,752 loops - 5,753 likes',
@@ -64,7 +76,7 @@ describe('transformFunnelcakeVideo', () => {
   });
 
   it('preserves native Divine loop counts separately from view starts', () => {
-    const video = transformFunnelcakeVideo(makeRawVideo({
+    const video = transformOk(makeRawVideo({
       platform: '',
       classic: false,
       loops: 11,
@@ -77,7 +89,7 @@ describe('transformFunnelcakeVideo', () => {
   });
 
   it('preserves the age-restricted flag from the API payload', () => {
-    const video = transformFunnelcakeVideo(makeRawVideo({
+    const video = transformOk(makeRawVideo({
       age_restricted: true,
     }));
 
@@ -90,7 +102,7 @@ describe('transformFunnelcakeVideo', () => {
     // We sum them so the visible numbers reflect total activity (archive +
     // current), and native videos with no archive history still show real
     // current counts.
-    const native = transformFunnelcakeVideo(makeRawVideo({
+    const native = transformOk(makeRawVideo({
       embedded_likes: 0,
       embedded_comments: 0,
       embedded_reposts: 0,
@@ -103,7 +115,7 @@ describe('transformFunnelcakeVideo', () => {
     expect(native.commentCount).toBe(9);
     expect(native.repostCount).toBe(3);
 
-    const archived = transformFunnelcakeVideo(makeRawVideo({
+    const archived = transformOk(makeRawVideo({
       embedded_likes: 138577,
       embedded_comments: 3014,
       embedded_reposts: 37586,
@@ -122,12 +134,12 @@ describe('transformFunnelcakeVideo', () => {
   // verification dialog must lazy-fetch the single-video endpoint to recover
   // it. See VideoVerificationDetailsDialog.tsx.
   it('returns proofMode undefined when tags are absent (list endpoint shape)', () => {
-    const video = transformFunnelcakeVideo(makeRawVideo());
+    const video = transformOk(makeRawVideo());
     expect(video.proofMode).toBeUndefined();
   });
 
   it('maps compact proof summary when list endpoint omits tags', () => {
-    const video = transformFunnelcakeVideo(makeRawVideo({
+    const video = transformOk(makeRawVideo({
       proof: {
         status: 'present',
         level: 'basic_proof',
@@ -154,7 +166,7 @@ describe('transformFunnelcakeVideo', () => {
   });
 
   it('uses compact proof summary when full event tags contain no proof data', () => {
-    const video = transformFunnelcakeVideo(makeRawVideo({
+    const video = transformOk(makeRawVideo({
       tags: [
         ['d', 'vine-id-1'],
         ['title', 'Plain tagged video'],
@@ -179,7 +191,7 @@ describe('transformFunnelcakeVideo', () => {
   });
 
   it('ignores invalid compact proof summaries', () => {
-    const video = transformFunnelcakeVideo(makeRawVideo({
+    const video = transformOk(makeRawVideo({
       proof: {
         status: 'invalid',
         version: 1,
@@ -200,7 +212,7 @@ describe('transformFunnelcakeVideo', () => {
   });
 
   it('defaults verified compact proof summaries to verified_web when level is missing', () => {
-    const video = transformFunnelcakeVideo(makeRawVideo({
+    const video = transformOk(makeRawVideo({
       proof: {
         status: 'verified',
         checked_at: 1779494400,
@@ -226,7 +238,7 @@ describe('transformFunnelcakeVideo', () => {
   });
 
   it('caps verified_* summary levels to basic_proof when status is not verified', () => {
-    const present = transformFunnelcakeVideo(makeRawVideo({
+    const present = transformOk(makeRawVideo({
       proof: {
         status: 'present',
         level: 'verified_mobile',
@@ -240,7 +252,7 @@ describe('transformFunnelcakeVideo', () => {
 
     expect(present.proofMode?.level).toBe('basic_proof');
 
-    const partial = transformFunnelcakeVideo(makeRawVideo({
+    const partial = transformOk(makeRawVideo({
       proof: {
         status: 'partial',
         level: 'verified_web',
@@ -256,7 +268,7 @@ describe('transformFunnelcakeVideo', () => {
   });
 
   it('honors verified_* summary levels when status is verified', () => {
-    const video = transformFunnelcakeVideo(makeRawVideo({
+    const video = transformOk(makeRawVideo({
       proof: {
         status: 'verified',
         level: 'verified_mobile',
@@ -274,7 +286,7 @@ describe('transformFunnelcakeVideo', () => {
   });
 
   it('ignores verified summaries with no usable components', () => {
-    const video = transformFunnelcakeVideo(makeRawVideo({
+    const video = transformOk(makeRawVideo({
       proof: {
         status: 'verified',
         version: 1,
@@ -295,7 +307,7 @@ describe('transformFunnelcakeVideo', () => {
   });
 
   it('does not mark explicitly invalid proof components as present', () => {
-    const video = transformFunnelcakeVideo(makeRawVideo({
+    const video = transformOk(makeRawVideo({
       proof: {
         status: 'present',
         version: 1,
@@ -316,7 +328,7 @@ describe('transformFunnelcakeVideo', () => {
   });
 
   it('maps partial compact proof summaries only when a usable component is present', () => {
-    const video = transformFunnelcakeVideo(makeRawVideo({
+    const video = transformOk(makeRawVideo({
       proof: {
         status: 'partial',
         version: 1,
@@ -335,7 +347,7 @@ describe('transformFunnelcakeVideo', () => {
   });
 
   it('extracts proofMode when verification tags are present (single-video shape)', () => {
-    const video = transformFunnelcakeVideo(makeRawVideo({
+    const video = transformOk(makeRawVideo({
       tags: [
         ['d', 'vine-id'],
         ['verification', 'verified_mobile'],
@@ -351,7 +363,7 @@ describe('transformFunnelcakeVideo', () => {
   });
 
   it('maps the raw Nostr content (description) to video.content, not the title', () => {
-    const video = transformFunnelcakeVideo(makeRawVideo({
+    const video = transformOk(makeRawVideo({
       title: 'First Divine Compilation 2026!',
       content: 'I just made the world’s first divine compilation.\n\nLink: https://youtu.be/abc',
     }));
@@ -361,13 +373,63 @@ describe('transformFunnelcakeVideo', () => {
   });
 
   it('leaves video.content empty when the API response has no content field', () => {
-    const video = transformFunnelcakeVideo(makeRawVideo({
+    const video = transformOk(makeRawVideo({
       title: 'A title with no description',
       content: undefined,
     }));
 
     expect(video.title).toBe('A title with no description');
     expect(video.content).toBe('');
+  });
+});
+
+describe('transformFunnelcakeVideo addressable coordinate guard', () => {
+  it('drops a row with no d tag, matching the relay parse path', () => {
+    // videoParser skips kind-34236 events with no d tag; every row here becomes
+    // a kind 34236, so a row with no d tag has no coordinate to be addressed by.
+    expect(transformFunnelcakeVideo(makeRawVideo({ d_tag: '' }))).toBeNull();
+  });
+
+  it('drops a row that omits d_tag entirely', () => {
+    expect(transformFunnelcakeVideo(makeRawVideo({ d_tag: undefined }))).toBeNull();
+  });
+
+  it('recovers the d tag from top-level tags when the row omits d_tag', () => {
+    const video = transformFunnelcakeVideo(makeRawVideo({
+      d_tag: '',
+      tags: [['d', 'recovered-from-tags']],
+    }));
+
+    expect(video?.vineId).toBe('recovered-from-tags');
+  });
+
+  it('recovers the d tag from event_json when the row omits d_tag', () => {
+    const video = transformFunnelcakeVideo(makeRawVideo({
+      d_tag: '',
+      event_json: JSON.stringify({ tags: [['d', 'recovered-from-event-json']] }),
+    }));
+
+    expect(video?.vineId).toBe('recovered-from-event-json');
+  });
+
+  it('keeps the top-level d_tag when both sources carry one', () => {
+    const video = transformFunnelcakeVideo(makeRawVideo({
+      d_tag: 'top-level',
+      tags: [['d', 'from-tags']],
+    }));
+
+    expect(video?.vineId).toBe('top-level');
+  });
+});
+
+describe('transformFunnelcakeResponse', () => {
+  it('drops coordinate-less rows instead of surfacing unaddressable videos', () => {
+    const videos = transformFunnelcakeResponse([
+      makeRawVideo({ id: 'has-d-tag', d_tag: 'vine-a' }),
+      makeRawVideo({ id: 'no-d-tag', d_tag: '' }),
+    ]);
+
+    expect(videos.map(v => v.id)).toEqual(['has-d-tag']);
   });
 });
 
@@ -448,7 +510,7 @@ describe('parseFullEvent', () => {
   });
 
   it('feeds event_json tags into proofMode extraction', () => {
-    const video = transformFunnelcakeVideo(makeRawVideo({
+    const video = transformOk(makeRawVideo({
       event_json: JSON.stringify(fullEventPayload),
     }));
 
@@ -526,27 +588,27 @@ describe('transformFunnelcakeVideo sha256', () => {
   const bodyHash = 'fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210';
 
   it('prefers a well-formed backend hash over the URL-derived one', () => {
-    expect(transformFunnelcakeVideo(makeRawVideo({ sha256: bodyHash })).sha256).toBe(bodyHash);
-    expect(transformFunnelcakeVideo(makeRawVideo({ sha256: bodyHash.toUpperCase() })).sha256).toBe(bodyHash);
+    expect(transformOk(makeRawVideo({ sha256: bodyHash })).sha256).toBe(bodyHash);
+    expect(transformOk(makeRawVideo({ sha256: bodyHash.toUpperCase() })).sha256).toBe(bodyHash);
   });
 
   it('falls back to the URL when the backend hash is malformed', () => {
     // A truthy non-hash must not shadow the derivation: moderation lookups
     // return null for anything that is not 64 hex, so the age-gate check
     // would silently no-op.
-    expect(transformFunnelcakeVideo(makeRawVideo({ sha256: 'not-a-hash' })).sha256).toBe(urlHash);
-    expect(transformFunnelcakeVideo(makeRawVideo({ sha256: bodyHash.slice(0, 63) })).sha256).toBe(urlHash);
-    expect(transformFunnelcakeVideo(makeRawVideo({ sha256: '  ' })).sha256).toBe(urlHash);
+    expect(transformOk(makeRawVideo({ sha256: 'not-a-hash' })).sha256).toBe(urlHash);
+    expect(transformOk(makeRawVideo({ sha256: bodyHash.slice(0, 63) })).sha256).toBe(urlHash);
+    expect(transformOk(makeRawVideo({ sha256: '  ' })).sha256).toBe(urlHash);
   });
 
   it('still derives from the URL when the backend sends no hash', () => {
-    expect(transformFunnelcakeVideo(makeRawVideo()).sha256).toBe(urlHash);
+    expect(transformOk(makeRawVideo()).sha256).toBe(urlHash);
   });
 });
 
 describe('mergeVideoStats', () => {
   it('refreshes native Divine loop counts from stats', () => {
-    const video = transformFunnelcakeVideo(makeRawVideo({
+    const video = transformOk(makeRawVideo({
       platform: '',
       classic: false,
       loops: 2,

--- a/src/lib/funnelcakeTransform.ts
+++ b/src/lib/funnelcakeTransform.ts
@@ -5,7 +5,7 @@ import { parseByteArrayId } from './funnelcakeClient';
 import { SHORT_VIDEO_KIND, type ParsedVideoData, type ProofModeData, type ProofModeLevel } from '@/types/video';
 import type { FunnelcakeVideoRaw, FunnelcakeResponse } from '@/types/funnelcake';
 import { debugLog } from './debug';
-import { getProofModeData } from './videoParser';
+import { getProofModeData, getVineId } from './videoParser';
 import { extractSha256FromVideoUrl, normalizeSha256 } from './videoVerification';
 import type { NostrEvent } from '@nostrify/nostrify';
 
@@ -149,9 +149,17 @@ function proofSummaryToProofMode(raw: FunnelcakeVideoRaw): ProofModeData | undef
 }
 
 /**
- * Transform a single Funnelcake video to ParsedVideoData format
+ * Transform a single Funnelcake video to ParsedVideoData format.
+ *
+ * Returns null when the row carries no `d` tag. Every row here becomes a kind
+ * 34236 event, and an addressable event with no `d` has no coordinate to be
+ * addressed by, so anything keyed on that coordinate — likes, reposts, view
+ * events — silently narrows to the event id, which is superseded the first time
+ * the author edits. `videoParser` already refuses these on the relay path
+ * (`if (!vineId && event.kind === SHORT_VIDEO_KIND) continue`); this keeps the
+ * REST path from admitting what the relay path rejects.
  */
-export function transformFunnelcakeVideo(raw: FunnelcakeVideoRaw): ParsedVideoData {
+export function transformFunnelcakeVideo(raw: FunnelcakeVideoRaw): ParsedVideoData | null {
   // Handle byte array conversion for id and pubkey
   const id = Array.isArray(raw.id) ? parseByteArrayId(raw.id) : String(raw.id);
   const pubkey = Array.isArray(raw.pubkey) ? parseByteArrayId(raw.pubkey) : String(raw.pubkey);
@@ -178,6 +186,14 @@ export function transformFunnelcakeVideo(raw: FunnelcakeVideoRaw): ParsedVideoDa
   const fullEvent = parseFullEvent(raw, id, pubkey);
   const fullEventProofMode = fullEvent ? getProofModeData(fullEvent) : undefined;
 
+  // Thin list payloads can omit the top-level d_tag while still carrying the
+  // event's tags, so read those before giving up on the coordinate.
+  const vineId = raw.d_tag || (fullEvent ? getVineId(fullEvent) : null);
+  if (!vineId) {
+    debugLog('[FunnelcakeTransform] Dropping video with no d tag:', id);
+    return null;
+  }
+
   const video: ParsedVideoData = {
     id,
     pubkey,
@@ -199,7 +215,7 @@ export function transformFunnelcakeVideo(raw: FunnelcakeVideoRaw): ParsedVideoDa
     hashtags,
 
     // Vine-specific fields
-    vineId: raw.d_tag || null, // d_tag is the unique identifier
+    vineId, // The `d` tag: the addressable event's unique identifier
     // For Vine imports, `loopCount` is the original archive count. For native
     // Divine videos, it is the current playback loop count from Funnelcake.
     loopCount: isVineMigrated

--- a/src/types/funnelcake.ts
+++ b/src/types/funnelcake.ts
@@ -33,7 +33,7 @@ export interface FunnelcakeVideoRaw {
   pubkey: string;         // Hex string pubkey
   created_at: number;     // Unix timestamp
   kind: number;           // Nostr event kind (34236 for videos)
-  d_tag: string;          // Unique identifier for addressable event
+  d_tag?: string;         // Unique identifier for addressable event; thin list payloads can omit it
   title?: string;         // Video title
   content?: string;       // Video content/description (user videos endpoint)
   thumbnail?: string;     // Thumbnail URL


### PR DESCRIPTION
## Summary

- `transformFunnelcakeVideo` now returns `ParsedVideoData | null` and refuses a row with no `d` tag, matching what `videoParser` already does on the relay path.
- Recovers the coordinate from the parsed event's tags (via the same `getVineId` the relay path uses) before giving up, so a thin list payload that omits the top-level `d_tag` but still carries the event tags is kept, not dropped.
- `d_tag` is now optional on `FunnelcakeVideoRaw` — the wire shape can omit it, and the type claiming otherwise is why the gap was invisible.
- Callers updated to handle a refused row: `useVideoByIdFunnelcake` (three navigation queries), `ConfirmedTab`, `useClassicVineArchiveStats`. `transformFunnelcakeResponse` already filtered nulls, so the feed and `transformToVideoPage` paths needed no change.

## Motivation

- A kind 34236 with no `d` tag has no coordinate to be addressed by, so everything keyed on that coordinate — likes, reposts, view events — silently narrows to the event id. That id is superseded the first time the author edits, stranding whatever referenced it.
- The relay path already refuses these: `videoParser.ts:707`, `if (!vineId && event.kind === SHORT_VIDEO_KIND) continue`. The REST path had no equivalent — `funnelcakeTransform.ts:199` mapped `raw.d_tag || null` straight through — so it admitted what the relay path rejected.
- `VideoPage` reads `useVideoByIdFunnelcake`, i.e. the unguarded path. That is the residue left over from #555: with `vineId` null, the new `a` tag contributes nothing and the like publishes id-only again — now with a `k` tag claiming kind 34236 while carrying no coordinate.
- Fixing it here closes the class rather than one callsite, and makes the two parse paths agree. Returning `null` puts the decision in the type, so the compiler makes every consumer handle a refused row instead of the next callsite quietly drifting.

## Related Issue

- Refs #535
- Follow-up to #555

## Testing

- [x] `npm run test` — `tsc -p tsconfig.app.json --noEmit` clean, `eslint` 0 errors (17 pre-existing warnings, none in touched files), 1856 unit tests pass across 245 files, `vite build` succeeds.
- [x] Manual verification completed — new tests cover the guard directly: a row with `d_tag: ''`, a row omitting `d_tag`, recovery from top-level `tags`, recovery from `event_json`, top-level precedence when both carry one, and list-level dropping through `transformFunnelcakeResponse`. Removing the guard fails them.

## Visuals

- [ ] UI change with screenshots/video attached
- [x] No visual change
- [x] Visuals and text avoid sensitive external brand or partner names unless explicitly approved
