### PR TITLE
fix(lists): preserve people-list pagination boundaries

### DIFF
--- a/src/hooks/usePeopleListVideos.test.ts
+++ b/src/hooks/usePeopleListVideos.test.ts
@@ -107,9 +107,9 @@ describe('usePeopleListVideos', () => {
     await result.current.fetchNextPage();
     await waitFor(() => expect(mockNostrQuery).toHaveBeenCalledTimes(2));
 
-    // Cursor derives from the oldest raw event, not the deduped page size.
+    // Cursor derives from the oldest raw event, not the deduped page size, and stays inclusive.
     const secondFilters = mockNostrQuery.mock.calls[1][0];
-    expect(secondFilters[0].until).toBe(999);
+    expect(secondFilters[0].until).toBe(1000);
   });
 
   it('continues from the oldest retained video when raw results exceed the page cap', async () => {
@@ -129,7 +129,55 @@ describe('usePeopleListVideos', () => {
     await waitFor(() => expect(mockNostrQuery).toHaveBeenCalledTimes(2));
 
     const secondFilters = mockNostrQuery.mock.calls[1][0];
-    expect(secondFilters[0].until).toBe(940);
+    expect(secondFilters[0].until).toBe(941);
+  });
+
+  it('keeps same-timestamp boundary videos reachable across pages', async () => {
+    const firstPage = [
+      ...Array.from({ length: 59 }, (_, index) => (
+        videoEvent(ALICE, `first-${index}`, 1000 - index)
+      )),
+      videoEvent(ALICE, 'boundary-a', 941),
+    ];
+    const secondPage = [
+      videoEvent(ALICE, 'boundary-a', 941),
+      videoEvent(ALICE, 'boundary-b', 941),
+    ];
+    mockNostrQuery.mockResolvedValueOnce(firstPage).mockResolvedValueOnce(secondPage);
+    const { usePeopleListVideos } = await import('./usePeopleListVideos');
+
+    const { result } = renderHook(() => usePeopleListVideos([ALICE]), { wrapper: createWrapper() });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    await result.current.fetchNextPage();
+    await waitFor(() => expect(mockNostrQuery).toHaveBeenCalledTimes(2));
+
+    const secondFilters = mockNostrQuery.mock.calls[1][0];
+    expect(secondFilters[0].until).toBe(941);
+    const videos = result.current.data?.pages.flatMap((page) => page.videos) ?? [];
+    expect(videos.map((video) => video.vineId)).toContain('boundary-a');
+    expect(videos.map((video) => video.vineId)).toContain('boundary-b');
+  });
+
+  it('stops paginating when an inclusive boundary page adds no new videos', async () => {
+    const firstPage = Array.from({ length: 60 }, (_, index) => (
+      videoEvent(ALICE, `video-${index}`, 1000 - index)
+    ));
+    const duplicateBoundary = [videoEvent(ALICE, 'video-59', 941)];
+    mockNostrQuery.mockResolvedValueOnce(firstPage).mockResolvedValueOnce(duplicateBoundary);
+    const { usePeopleListVideos } = await import('./usePeopleListVideos');
+
+    const { result } = renderHook(() => usePeopleListVideos([ALICE]), { wrapper: createWrapper() });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.hasNextPage).toBe(true);
+
+    await result.current.fetchNextPage();
+    await waitFor(() => expect(mockNostrQuery).toHaveBeenCalledTimes(2));
+
+    expect(result.current.hasNextPage).toBe(false);
+    const videos = result.current.data?.pages.flatMap((page) => page.videos) ?? [];
+    expect(videos).toHaveLength(60);
   });
 
   it('stops paginating when the raw page comes back below the limit', async () => {

--- a/src/hooks/usePeopleListVideos.test.ts
+++ b/src/hooks/usePeopleListVideos.test.ts
@@ -159,12 +159,17 @@ describe('usePeopleListVideos', () => {
     expect(videos.map((video) => video.vineId)).toContain('boundary-b');
   });
 
-  it('stops paginating when an inclusive boundary page adds no new videos', async () => {
+  it('steps past an inclusive boundary page that adds no new videos', async () => {
     const firstPage = Array.from({ length: 60 }, (_, index) => (
       videoEvent(ALICE, `video-${index}`, 1000 - index)
     ));
-    const duplicateBoundary = [videoEvent(ALICE, 'video-59', 941)];
-    mockNostrQuery.mockResolvedValueOnce(firstPage).mockResolvedValueOnce(duplicateBoundary);
+    const duplicateBoundary = Array.from({ length: 60 }, (_, index) => (
+      videoEvent(ALICE, `video-${index}`, 941)
+    ));
+    mockNostrQuery
+      .mockResolvedValueOnce(firstPage)
+      .mockResolvedValueOnce(duplicateBoundary)
+      .mockResolvedValueOnce([]);
     const { usePeopleListVideos } = await import('./usePeopleListVideos');
 
     const { result } = renderHook(() => usePeopleListVideos([ALICE]), { wrapper: createWrapper() });
@@ -175,9 +180,15 @@ describe('usePeopleListVideos', () => {
     await result.current.fetchNextPage();
     await waitFor(() => expect(mockNostrQuery).toHaveBeenCalledTimes(2));
 
-    expect(result.current.hasNextPage).toBe(false);
+    expect(result.current.hasNextPage).toBe(true);
     const videos = result.current.data?.pages.flatMap((page) => page.videos) ?? [];
     expect(videos).toHaveLength(60);
+
+    await result.current.fetchNextPage();
+    await waitFor(() => expect(mockNostrQuery).toHaveBeenCalledTimes(3));
+
+    const thirdFilters = mockNostrQuery.mock.calls[2][0];
+    expect(thirdFilters[0].until).toBe(940);
   });
 
   it('stops paginating when the raw page comes back below the limit', async () => {

--- a/src/hooks/usePeopleListVideos.ts
+++ b/src/hooks/usePeopleListVideos.ts
@@ -101,10 +101,10 @@ export function usePeopleListVideos(memberPubkeys: string[], options: UsePeopleL
     },
     initialPageParam: undefined as number | undefined,
     getNextPageParam: (lastPage, allPages) => {
-      if (!lastPage.nextUntil) return undefined;
-      // If a single timestamp contains more than one relay page, stop at the
-      // duplicate boundary instead of looping forever.
-      if (!pageAddsNewVideos(lastPage, allPages)) return undefined;
+      if (lastPage.nextUntil === undefined) return undefined;
+      // If an inclusive boundary page repeats without adding videos, step past
+      // that timestamp so older videos stay reachable.
+      if (!pageAddsNewVideos(lastPage, allPages)) return lastPage.nextUntil - 1;
       return lastPage.nextUntil;
     },
     enabled: enabled && stableMembers.length > 0,

--- a/src/hooks/usePeopleListVideos.ts
+++ b/src/hooks/usePeopleListVideos.ts
@@ -3,11 +3,14 @@
 import { useMemo } from 'react';
 import { useNostr } from '@nostrify/react';
 import { useInfiniteQuery } from '@tanstack/react-query';
+import type { InfiniteData } from '@tanstack/react-query';
 import { parseVideoEvents } from '@/lib/videoParser';
 import {
   buildPeopleListVideoFilters,
   mergePeopleListVideoEvents,
+  peopleListVideoAddress,
   PEOPLE_LIST_VIDEO_PAGE_SIZE,
+  PEOPLE_LIST_VIDEO_RELAY_LIMIT,
 } from '@/lib/peopleListVideos';
 import { useFeedBlocklist } from '@/hooks/useFeedBlocklist';
 import { filterBlockedVideoPages } from '@/lib/blocklistFilter';
@@ -15,6 +18,7 @@ import type { ParsedVideoData } from '@/types/video';
 
 export interface PeopleListVideoPage {
   videos: ParsedVideoData[];
+  videoAddresses: string[];
   nextUntil?: number;
 }
 
@@ -24,14 +28,51 @@ interface UsePeopleListVideosOptions {
 
 function getNextUntil(events: { created_at: number }[], mergedEvents: { created_at: number }[]): number | undefined {
   if (mergedEvents.length >= PEOPLE_LIST_VIDEO_PAGE_SIZE) {
-    return mergedEvents[mergedEvents.length - 1].created_at - 1;
+    return mergedEvents[mergedEvents.length - 1].created_at;
   }
 
-  if (events.length >= PEOPLE_LIST_VIDEO_PAGE_SIZE && events.length > 0) {
-    return Math.min(...events.map((event) => event.created_at)) - 1;
+  if (events.length >= PEOPLE_LIST_VIDEO_RELAY_LIMIT && events.length > 0) {
+    return Math.min(...events.map((event) => event.created_at));
   }
 
   return undefined;
+}
+
+function videoDataAddress(video: ParsedVideoData): string | undefined {
+  if (!video.vineId) return undefined;
+  return `${video.pubkey}:${video.kind}:${video.vineId}`;
+}
+
+function pageAddsNewVideos(lastPage: PeopleListVideoPage, pages: PeopleListVideoPage[]): boolean {
+  const previousAddresses = new Set(
+    pages
+      .slice(0, -1)
+      .flatMap((page) => page.videoAddresses),
+  );
+
+  return lastPage.videoAddresses.some((address) => !previousAddresses.has(address));
+}
+
+function dedupeVideoPages(
+  data: InfiniteData<PeopleListVideoPage> | undefined,
+): InfiniteData<PeopleListVideoPage> | undefined {
+  if (!data) return data;
+
+  const seen = new Set<string>();
+
+  return {
+    ...data,
+    pages: data.pages.map((page) => ({
+      ...page,
+      videos: page.videos.filter((video) => {
+        const address = videoDataAddress(video);
+        if (!address) return true;
+        if (seen.has(address)) return false;
+        seen.add(address);
+        return true;
+      }),
+    })),
+  };
 }
 
 export function usePeopleListVideos(memberPubkeys: string[], options: UsePeopleListVideosOptions = {}) {
@@ -52,11 +93,20 @@ export function usePeopleListVideos(memberPubkeys: string[], options: UsePeopleL
 
       return {
         videos: parseVideoEvents(mergedEvents),
+        videoAddresses: mergedEvents
+          .map(peopleListVideoAddress)
+          .filter((address): address is string => Boolean(address)),
         nextUntil,
       };
     },
     initialPageParam: undefined as number | undefined,
-    getNextPageParam: (lastPage) => lastPage.nextUntil,
+    getNextPageParam: (lastPage, allPages) => {
+      if (!lastPage.nextUntil) return undefined;
+      // If a single timestamp contains more than one relay page, stop at the
+      // duplicate boundary instead of looping forever.
+      if (!pageAddsNewVideos(lastPage, allPages)) return undefined;
+      return lastPage.nextUntil;
+    },
     enabled: enabled && stableMembers.length > 0,
     staleTime: 60_000,
     gcTime: 300_000,
@@ -67,7 +117,7 @@ export function usePeopleListVideos(memberPubkeys: string[], options: UsePeopleL
   // from query results, same as the other WebSocket feeds.
   const blockedPubkeys = useFeedBlocklist();
   const data = useMemo(
-    () => filterBlockedVideoPages(query.data, blockedPubkeys),
+    () => dedupeVideoPages(filterBlockedVideoPages(query.data, blockedPubkeys)),
     [query.data, blockedPubkeys],
   );
 

--- a/src/lib/peopleListVideos.ts
+++ b/src/lib/peopleListVideos.ts
@@ -4,7 +4,15 @@ import type { NostrEvent, NostrFilter } from '@nostrify/nostrify';
 import { VIDEO_KINDS } from '@/types/video';
 
 const AUTHORS_PER_FILTER = 100;
+export const PEOPLE_LIST_VIDEO_RELAY_LIMIT = 60;
 export const PEOPLE_LIST_VIDEO_PAGE_SIZE = 60;
+
+export function peopleListVideoAddress(event: NostrEvent): string | undefined {
+  const dTag = event.tags.find((tag) => tag[0] === 'd')?.[1];
+  if (!dTag) return undefined;
+
+  return `${event.pubkey}:${event.kind}:${dTag}`;
+}
 
 export function buildPeopleListVideoFilters(
   pubkeys: string[],
@@ -17,7 +25,7 @@ export function buildPeopleListVideoFilters(
     filters.push({
       kinds: VIDEO_KINDS,
       authors: uniquePubkeys.slice(index, index + AUTHORS_PER_FILTER),
-      limit: PEOPLE_LIST_VIDEO_PAGE_SIZE,
+      limit: PEOPLE_LIST_VIDEO_RELAY_LIMIT,
       ...(until !== undefined ? { until } : {}),
     });
   }
@@ -32,10 +40,8 @@ export function mergePeopleListVideoEvents(events: NostrEvent[]): NostrEvent[] {
     .filter((event) => VIDEO_KINDS.includes(event.kind))
     .sort((a, b) => b.created_at - a.created_at)
     .forEach((event) => {
-      const dTag = event.tags.find((tag) => tag[0] === 'd')?.[1];
-      if (!dTag) return;
-
-      const address = `${event.pubkey}:${event.kind}:${dTag}`;
+      const address = peopleListVideoAddress(event);
+      if (!address) return;
       if (!newestByAddress.has(address)) {
         newestByAddress.set(address, event);
       }


### PR DESCRIPTION
## Summary

- Use inclusive Nostr pagination cursors for people-list video feeds so same-timestamp boundary videos remain reachable.
- Dedupe addressable videos across pages and stop when an inclusive boundary page adds no new videos.

## Motivation

People-list video pagination used `created_at - 1`, but Nostr `until` is inclusive. That skipped any additional videos sharing the oldest timestamp from the previous page.

## Related Issue

- Refs #503

## Testing

- [x] `npx vitest run src/hooks/usePeopleListVideos.test.ts`
- [x] `npm run test`
- [ ] Manual verification completed

## Visuals

- [ ] UI change with screenshots/video attached
- [x] No visual change
- [x] Visuals and text avoid sensitive external brand or partner names unless explicitly approved