### PR TITLE
test(lists): add people list regression guards

### DIFF
--- a/src/hooks/usePeopleLists.test.ts
+++ b/src/hooks/usePeopleLists.test.ts
@@ -48,6 +48,7 @@ describe('people list hooks', () => {
       peopleListEvent({ created_at: 10, tags: [['d', 'friends'], ['title', 'Old']] }),
       peopleListEvent({ created_at: 20, tags: [['d', 'friends'], ['title', 'New']] }),
       peopleListEvent({ created_at: 30, tags: [['d', 'block'], ['p', MEMBER]] }),
+      peopleListEvent({ created_at: 40, tags: [['d', 'mute'], ['title', 'Muted'], ['p', MEMBER]] }),
     ]);
     const { usePeopleLists } = await import('./usePeopleLists');
 

--- a/src/lib/parsePeopleListFromEvent.test.ts
+++ b/src/lib/parsePeopleListFromEvent.test.ts
@@ -54,6 +54,15 @@ describe('parsePeopleListFromEvent', () => {
     expect(parsePeopleListFromEvent(event)?.name).toBe('makers');
   });
 
+  it('accepts empty lists', () => {
+    expect(parsePeopleListFromEvent(peopleListEvent({
+      tags: [
+        ['d', 'makers'],
+        ['title', 'Makers'],
+      ],
+    }))?.memberPubkeys).toEqual([]);
+  });
+
   it('rejects missing d tags, the reserved block list, and other event kinds', () => {
     expect(parsePeopleListFromEvent(peopleListEvent({ tags: [] }))).toBeNull();
     expect(parsePeopleListFromEvent(peopleListEvent({ tags: [['d', 'block']] }))).toBeNull();


### PR DESCRIPTION
## Summary

- Add a parser regression test proving public people lists may be empty.
- Expand the people-list hook fixture to prove an additional reserved system list stays hidden from public surfaces.

> Avoid naming corporate partners, customers, or other sensitive external brands in this PR title or body. Use generic descriptors unless a maintainer explicitly approves the public reference.

## Motivation

- Preserve the small useful test-only coverage from superseded PR #545 while keeping the stronger #549 implementation on main.

## Related Issue

- Refs #505

## Testing

- [x] `npm run test`
- [x] Manual verification completed: reviewed the diff and confirmed it is test-only.

## Visuals

- [ ] UI change with screenshots/video attached
- [x] No visual change
- [x] Visuals and text avoid sensitive external brand or partner names unless explicitly approved