### PR TITLE
fix(discovery): preserve featured navigation order

### DIFF
--- a/src/components/VideoFeed.test.tsx
+++ b/src/components/VideoFeed.test.tsx
@@ -15,6 +15,8 @@ const {
   mockUseVideoPrefetch,
   mockInfiniteScroll,
   mockTrackEvent,
+  mockVideoCardWithMetrics,
+  mockVideoGrid,
 } = vi.hoisted(() => ({
   mockTrackEvent: vi.fn(),
   mockNavigate: vi.fn(),
@@ -24,6 +26,8 @@ const {
   mockUpdateVideos: vi.fn(),
   mockUseVideoPrefetch: vi.fn(),
   mockInfiniteScroll: vi.fn(),
+  mockVideoCardWithMetrics: vi.fn(),
+  mockVideoGrid: vi.fn(),
 }));
 
 vi.mock('@/hooks/useVideoProvider', () => ({
@@ -90,11 +94,17 @@ vi.mock('@/lib/performanceMonitoring', () => ({
 }));
 
 vi.mock('@/components/VideoCardWithMetrics', () => ({
-  VideoCardWithMetrics: () => <div data-testid="video-card" />,
+  VideoCardWithMetrics: (props: unknown) => {
+    mockVideoCardWithMetrics(props);
+    return <div data-testid="video-card" />;
+  },
 }));
 
 vi.mock('@/components/VideoGrid', () => ({
-  VideoGrid: () => <div data-testid="video-grid" />,
+  VideoGrid: (props: unknown) => {
+    mockVideoGrid(props);
+    return <div data-testid="video-grid" />;
+  },
 }));
 
 vi.mock('@/components/AddToListDialog', () => ({
@@ -258,6 +268,40 @@ describe('VideoFeed', () => {
       null,
       [expect.objectContaining({ id: 'video-1' })],
       { prefetchVideos: false },
+    );
+  });
+
+  it('passes featured tab context to feed cards', () => {
+    render(
+      <MemoryRouter initialEntries={['/discovery/seasonal-theme']}>
+        <VideoFeed feedType="featured" featuredTabId="ft_1234abcd" />
+      </MemoryRouter>
+    );
+
+    expect(mockVideoCardWithMetrics).toHaveBeenCalledWith(
+      expect.objectContaining({
+        navigationContext: expect.objectContaining({
+          source: 'featured',
+          featuredTabId: 'ft_1234abcd',
+        }),
+      })
+    );
+  });
+
+  it('passes featured tab context to grid cards', () => {
+    render(
+      <MemoryRouter initialEntries={['/discovery/seasonal-theme']}>
+        <VideoFeed feedType="featured" featuredTabId="ft_1234abcd" viewMode="grid" />
+      </MemoryRouter>
+    );
+
+    expect(mockVideoGrid).toHaveBeenCalledWith(
+      expect.objectContaining({
+        navigationContext: expect.objectContaining({
+          source: 'featured',
+          featuredTabId: 'ft_1234abcd',
+        }),
+      })
     );
   });
 

--- a/src/components/VideoFeed.tsx
+++ b/src/components/VideoFeed.tsx
@@ -10,7 +10,7 @@ import { VideoCardWithMetrics } from '@/components/VideoCardWithMetrics';
 import { VideoGrid } from '@/components/VideoGrid';
 import { AddToListDialog } from '@/components/AddToListDialog';
 import { useVideoProvider } from '@/hooks/useVideoProvider';
-import { FEATURED_TAB_PAGE_SIZE } from '@/hooks/useFeaturedTabVideos';
+import { FEED_PAGE_SIZE } from '@/config/feed';
 import { useBatchedAuthors } from '@/hooks/useBatchedAuthors';
 import { useContentModeration } from '@/hooks/useModeration';
 import { useFeedPerformanceInstrumentation } from '@/hooks/useFeedPerformanceInstrumentation';
@@ -64,7 +64,7 @@ export function VideoFeed({
   category,
   featuredTabId,
   pubkey,
-  limit = FEATURED_TAB_PAGE_SIZE, // Smaller first page improves initial paint on REST-backed feeds
+  limit = FEED_PAGE_SIZE, // Smaller first page improves initial paint on REST-backed feeds
   sortMode,
   popularSource,
   popularPeriod,

--- a/src/components/VideoFeed.tsx
+++ b/src/components/VideoFeed.tsx
@@ -10,6 +10,7 @@ import { VideoCardWithMetrics } from '@/components/VideoCardWithMetrics';
 import { VideoGrid } from '@/components/VideoGrid';
 import { AddToListDialog } from '@/components/AddToListDialog';
 import { useVideoProvider } from '@/hooks/useVideoProvider';
+import { FEATURED_TAB_PAGE_SIZE } from '@/hooks/useFeaturedTabVideos';
 import { useBatchedAuthors } from '@/hooks/useBatchedAuthors';
 import { useContentModeration } from '@/hooks/useModeration';
 import { useFeedPerformanceInstrumentation } from '@/hooks/useFeedPerformanceInstrumentation';
@@ -63,7 +64,7 @@ export function VideoFeed({
   category,
   featuredTabId,
   pubkey,
-  limit = 12, // Smaller first page improves initial paint on REST-backed feeds
+  limit = FEATURED_TAB_PAGE_SIZE, // Smaller first page improves initial paint on REST-backed feeds
   sortMode,
   popularSource,
   popularPeriod,
@@ -505,6 +506,7 @@ export function VideoFeed({
               source: feedType,
               hashtag,
               pubkey,
+              featuredTabId,
             }}
           />
         </InfiniteScroll>
@@ -570,6 +572,7 @@ export function VideoFeed({
                 source: feedType,
                 hashtag,
                 pubkey,
+                featuredTabId,
               }}
             />
           ))}

--- a/src/config/feed.ts
+++ b/src/config/feed.ts
@@ -1,1 +1,4 @@
+// ABOUTME: Shared feed pagination defaults for REST-backed video lists
+// ABOUTME: Keeps feed and detail navigation page-size math aligned
+
 export const FEED_PAGE_SIZE = 12;

--- a/src/config/feed.ts
+++ b/src/config/feed.ts
@@ -1,0 +1,1 @@
+export const FEED_PAGE_SIZE = 12;

--- a/src/hooks/useFeaturedTab.ts
+++ b/src/hooks/useFeaturedTab.ts
@@ -58,8 +58,10 @@ function getFreshCachedConfig(
 
 export function useFeaturedTab({
   apiUrl = getFunnelcakeBaseUrl(),
+  enabled = true,
 }: {
   apiUrl?: string;
+  enabled?: boolean;
 } = {}): FeaturedTabState {
   const { i18n } = useTranslation();
   const minorStatus = useProtectedMinorStatus();
@@ -67,6 +69,7 @@ export function useFeaturedTab({
   const { data, dataUpdatedAt } = useQuery({
     queryKey: ['featured-tabs', apiUrl],
     queryFn: ({ signal }) => fetchFeaturedTabs(apiUrl, signal),
+    enabled,
     staleTime: 60 * 1000,
     gcTime: GC_TIME_MS,
     refetchOnWindowFocus: true,

--- a/src/hooks/useFeaturedTabVideos.ts
+++ b/src/hooks/useFeaturedTabVideos.ts
@@ -11,10 +11,12 @@ export interface FeaturedTabVideoPage {
   hasMore: boolean;
 }
 
+export const FEATURED_TAB_PAGE_SIZE = 12;
+
 export function useFeaturedTabVideos({
   configId,
   apiUrl = getFunnelcakeBaseUrl(),
-  pageSize = 12,
+  pageSize = FEATURED_TAB_PAGE_SIZE,
   enabled = true,
 }: {
   configId?: string;

--- a/src/hooks/useFeaturedTabVideos.ts
+++ b/src/hooks/useFeaturedTabVideos.ts
@@ -1,5 +1,6 @@
 import { useInfiniteQuery } from '@tanstack/react-query';
 import { getFunnelcakeBaseUrl } from '@/config/api';
+import { FEED_PAGE_SIZE } from '@/config/feed';
 import { fetchFeaturedTabVideos } from '@/lib/featuredTabsClient';
 import { transformToVideoPage } from '@/lib/funnelcakeTransform';
 import type { ParsedVideoData } from '@/types/video';
@@ -11,12 +12,10 @@ export interface FeaturedTabVideoPage {
   hasMore: boolean;
 }
 
-export const FEATURED_TAB_PAGE_SIZE = 12;
-
 export function useFeaturedTabVideos({
   configId,
   apiUrl = getFunnelcakeBaseUrl(),
-  pageSize = FEATURED_TAB_PAGE_SIZE,
+  pageSize = FEED_PAGE_SIZE,
   enabled = true,
 }: {
   configId?: string;

--- a/src/hooks/useInfiniteSearchVideos.ts
+++ b/src/hooks/useInfiniteSearchVideos.ts
@@ -14,6 +14,7 @@ import { debugLog } from '@/lib/debug';
 import { transformToVideoPage } from '@/lib/funnelcakeTransform';
 import { isAbortError, reportFunnelcakeFallback } from '@/lib/funnelcakeFallbackReporting';
 import { isUrlLikeQuery } from '@/lib/searchUtils';
+import { FEED_PAGE_SIZE } from '@/config/feed';
 
 interface UseInfiniteSearchVideosOptions {
   query: string;
@@ -84,7 +85,7 @@ export function useInfiniteSearchVideos({
   query,
   searchType = 'auto',
   sortMode = 'relevance',
-  pageSize = 12,
+  pageSize = FEED_PAGE_SIZE,
 }: UseInfiniteSearchVideosOptions) {
   const { nostr } = useNostr();
   const apiUrl = API_CONFIG.funnelcake.baseUrl;

--- a/src/hooks/useInfiniteVideosFunnelcake.ts
+++ b/src/hooks/useInfiniteVideosFunnelcake.ts
@@ -4,6 +4,7 @@
 import { useInfiniteQuery } from '@tanstack/react-query';
 import { useState } from 'react';
 import { getFunnelcakeBaseUrl } from '@/config/api';
+import { FEED_PAGE_SIZE } from '@/config/feed';
 import { useCurrentUser } from '@/hooks/useCurrentUser';
 import type { ParsedVideoData } from '@/types/video';
 import type { FunnelcakeFetchOptions } from '@/types/funnelcake';
@@ -200,7 +201,7 @@ export function useInfiniteVideosFunnelcake({
   hashtag,
   category,
   pubkey,
-  pageSize = 12,
+  pageSize = FEED_PAGE_SIZE,
   enabled = true,
   randomizeWithinTop,
 }: UseInfiniteVideosFunnelcakeOptions) {

--- a/src/hooks/useVideoByIdFunnelcake.test.ts
+++ b/src/hooks/useVideoByIdFunnelcake.test.ts
@@ -1,6 +1,6 @@
 import React from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { renderHook, waitFor } from '@testing-library/react';
+import { act, renderHook, waitFor } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 
 const mockFetchUserVideos = vi.fn();
@@ -399,5 +399,77 @@ describe('useVideoByIdFunnelcake', () => {
     expect(mockSearchVideos).not.toHaveBeenCalled();
     expect(mockFetchUserVideos).not.toHaveBeenCalled();
     expect(result.current.videos).toBeNull();
+  });
+
+  it('skips a fully-blocked featured page when paging for the next neighbor', async () => {
+    const blockedPubkey = 'b'.repeat(64);
+    mockBlocklist.add(blockedPubkey);
+    mockUseFeaturedTab.mockReturnValue({
+      tab: { id: 'ft_1234abcd' },
+      isResolved: true,
+    });
+    // Page 2 is entirely blocked authors; the visible neighbor is on page 3.
+    // A single-page fetch would filter to nothing and dead-end the boundary.
+    mockFetchFeaturedTabVideos.mockImplementation((_apiUrl, _configId, cursor) => {
+      if (!cursor) {
+        return Promise.resolve({
+          videos: [{ id: 'target-video', pubkey: 'p'.repeat(64), d_tag: 'target-video' }],
+          has_more: true,
+          next_cursor: 'cursor-2',
+        });
+      }
+      if (cursor === 'cursor-2') {
+        return Promise.resolve({
+          videos: [
+            { id: 'blocked-a', pubkey: blockedPubkey, d_tag: 'blocked-a' },
+            { id: 'blocked-b', pubkey: blockedPubkey, d_tag: 'blocked-b' },
+          ],
+          has_more: true,
+          next_cursor: 'cursor-3',
+        });
+      }
+      if (cursor === 'cursor-3') {
+        return Promise.resolve({
+          videos: [{ id: 'visible-next', pubkey: 'v'.repeat(64), d_tag: 'visible-next' }],
+          has_more: false,
+        });
+      }
+      return Promise.resolve({ videos: [], has_more: false });
+    });
+
+    const { result } = renderHook(
+      () => useVideoByIdFunnelcake({
+        videoId: 'target-video',
+        featuredTabId: 'ft_1234abcd',
+      }),
+      { wrapper: createWrapper() }
+    );
+
+    await waitFor(() => {
+      expect(result.current.videos?.map(video => video.id)).toEqual(['target-video']);
+    });
+
+    let pagedIds: string[] | undefined;
+    await act(async () => {
+      const paged = await result.current.fetchNextPage();
+      pagedIds = paged?.map(video => video.id);
+    });
+
+    // The all-blocked page is walked past, not surfaced as a dead-end.
+    expect(pagedIds).toEqual(['target-video', 'visible-next']);
+    expect(mockFetchFeaturedTabVideos).toHaveBeenCalledWith(
+      'https://api.divine.video',
+      'ft_1234abcd',
+      'cursor-2',
+      12,
+      expect.any(AbortSignal)
+    );
+    expect(mockFetchFeaturedTabVideos).toHaveBeenCalledWith(
+      'https://api.divine.video',
+      'ft_1234abcd',
+      'cursor-3',
+      12,
+      expect.any(AbortSignal)
+    );
   });
 });

--- a/src/hooks/useVideoByIdFunnelcake.test.ts
+++ b/src/hooks/useVideoByIdFunnelcake.test.ts
@@ -7,6 +7,7 @@ const mockFetchUserVideos = vi.fn();
 const mockSearchVideos = vi.fn();
 const mockFetchVideoById = vi.fn();
 const mockFetchFeaturedTabVideos = vi.fn();
+const mockBlocklist = new Set<string>();
 const mockTransformToVideoPage = vi.fn((response: {
   videos: Array<{ id: string; pubkey: string; d_tag?: string }>;
   has_more?: boolean;
@@ -70,6 +71,10 @@ vi.mock('@/hooks/useFeaturedTab', () => ({
   useFeaturedTab: mockUseFeaturedTab,
 }));
 
+vi.mock('@/hooks/useFeedBlocklist', () => ({
+  useFeedBlocklist: () => mockBlocklist,
+}));
+
 vi.mock('@/lib/debug', () => ({
   debugLog: vi.fn(),
 }));
@@ -94,6 +99,7 @@ describe('useVideoByIdFunnelcake', () => {
   beforeEach(async () => {
     vi.resetModules();
     vi.clearAllMocks();
+    mockBlocklist.clear();
     mockUseFeaturedTab.mockReturnValue({
       tab: null,
       isResolved: true,
@@ -293,6 +299,36 @@ describe('useVideoByIdFunnelcake', () => {
       'featured-3',
     ]);
     expect(result.current.windowOffset).toBe(0);
+  });
+
+  it('filters blocked authors out of featured navigation candidates', async () => {
+    const blockedPubkey = 'b'.repeat(64);
+    mockBlocklist.add(blockedPubkey);
+    mockUseFeaturedTab.mockReturnValue({
+      tab: { id: 'ft_1234abcd' },
+      isResolved: true,
+    });
+    mockFetchFeaturedTabVideos.mockResolvedValueOnce({
+      videos: [
+        { id: 'target-video', pubkey: 'p'.repeat(64), d_tag: 'target-video' },
+        { id: 'blocked-video', pubkey: blockedPubkey, d_tag: 'blocked-video' },
+        { id: 'visible-video', pubkey: 'v'.repeat(64), d_tag: 'visible-video' },
+      ],
+      has_more: false,
+    });
+
+    const { result } = renderHook(
+      () => useVideoByIdFunnelcake({
+        videoId: 'target-video',
+        featuredTabId: 'ft_1234abcd',
+        currentIndex: 0,
+      }),
+      { wrapper: createWrapper() }
+    );
+
+    await waitFor(() => {
+      expect(result.current.videos?.map(video => video.id)).toEqual(['target-video', 'visible-video']);
+    });
   });
 
   it('walks featured cursor pages up to the index-derived budget for cold links', async () => {

--- a/src/hooks/useVideoByIdFunnelcake.test.ts
+++ b/src/hooks/useVideoByIdFunnelcake.test.ts
@@ -6,6 +6,28 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 const mockFetchUserVideos = vi.fn();
 const mockSearchVideos = vi.fn();
 const mockFetchVideoById = vi.fn();
+const mockFetchFeaturedTabVideos = vi.fn();
+const mockTransformToVideoPage = vi.fn((response: {
+  videos: Array<{ id: string; pubkey: string; d_tag?: string }>;
+  has_more?: boolean;
+  next_cursor?: string;
+}) => ({
+  videos: response.videos.map((video) => ({
+    id: video.id,
+    pubkey: video.pubkey,
+    kind: 34236,
+    createdAt: 1,
+    content: '',
+    videoUrl: 'https://example.com/video.mp4',
+    hashtags: [],
+    vineId: video.d_tag || video.id,
+    reposts: [],
+  })),
+  nextCursor: undefined,
+  rawCursor: response.next_cursor,
+  hasMore: Boolean(response.has_more),
+}));
+const mockUseFeaturedTab = vi.fn();
 const mockTransformFunnelcakeVideo = vi.fn((video: { id: string; pubkey: string; d_tag?: string }) => ({
   id: video.id,
   pubkey: video.pubkey,
@@ -35,8 +57,17 @@ vi.mock('@/lib/funnelcakeClient', () => ({
   fetchVideoById: mockFetchVideoById,
 }));
 
+vi.mock('@/lib/featuredTabsClient', () => ({
+  fetchFeaturedTabVideos: mockFetchFeaturedTabVideos,
+}));
+
 vi.mock('@/lib/funnelcakeTransform', () => ({
   transformFunnelcakeVideo: mockTransformFunnelcakeVideo,
+  transformToVideoPage: mockTransformToVideoPage,
+}));
+
+vi.mock('@/hooks/useFeaturedTab', () => ({
+  useFeaturedTab: mockUseFeaturedTab,
 }));
 
 vi.mock('@/lib/debug', () => ({
@@ -63,6 +94,10 @@ describe('useVideoByIdFunnelcake', () => {
   beforeEach(async () => {
     vi.resetModules();
     vi.clearAllMocks();
+    mockUseFeaturedTab.mockReturnValue({
+      tab: null,
+      isResolved: true,
+    });
 
     ({ useVideoByIdFunnelcake } = await import('./useVideoByIdFunnelcake'));
   });
@@ -215,5 +250,118 @@ describe('useVideoByIdFunnelcake', () => {
       expect.any(AbortSignal)
     );
     expect(result.current.videos?.map(video => video.id)).toEqual(['neighbor-1', 'target-video']);
+  });
+
+  it('uses eligible featured tab videos for navigation in server order', async () => {
+    mockUseFeaturedTab.mockReturnValue({
+      tab: { id: 'ft_1234abcd' },
+      isResolved: true,
+    });
+    mockFetchFeaturedTabVideos.mockResolvedValueOnce({
+      videos: [
+        { id: 'featured-1', pubkey: 'p'.repeat(64), d_tag: 'featured-1' },
+        { id: 'target-video', pubkey: 'p'.repeat(64), d_tag: 'target-video' },
+        { id: 'featured-3', pubkey: 'p'.repeat(64), d_tag: 'featured-3' },
+      ],
+      has_more: true,
+      next_cursor: 'cursor-2',
+    });
+
+    const { result } = renderHook(
+      () => useVideoByIdFunnelcake({
+        videoId: 'target-video',
+        featuredTabId: 'ft_1234abcd',
+        currentIndex: 1,
+      }),
+      { wrapper: createWrapper() }
+    );
+
+    await waitFor(() => {
+      expect(result.current.video?.id).toBe('target-video');
+    });
+
+    expect(mockFetchFeaturedTabVideos).toHaveBeenCalledWith(
+      'https://api.divine.video',
+      'ft_1234abcd',
+      undefined,
+      12,
+      expect.any(AbortSignal)
+    );
+    expect(result.current.videos?.map(video => video.id)).toEqual([
+      'featured-1',
+      'target-video',
+      'featured-3',
+    ]);
+    expect(result.current.windowOffset).toBe(0);
+  });
+
+  it('walks featured cursor pages up to the index-derived budget for cold links', async () => {
+    mockUseFeaturedTab.mockReturnValue({
+      tab: { id: 'ft_1234abcd' },
+      isResolved: true,
+    });
+    mockFetchFeaturedTabVideos
+      .mockResolvedValueOnce({
+        videos: [{ id: 'featured-1', pubkey: 'p'.repeat(64), d_tag: 'featured-1' }],
+        has_more: true,
+        next_cursor: 'cursor-2',
+      })
+      .mockResolvedValueOnce({
+        videos: [{ id: 'target-video', pubkey: 'p'.repeat(64), d_tag: 'target-video' }],
+        has_more: false,
+        next_cursor: undefined,
+      });
+
+    const { result } = renderHook(
+      () => useVideoByIdFunnelcake({
+        videoId: 'target-video',
+        featuredTabId: 'ft_1234abcd',
+        currentIndex: 12,
+      }),
+      { wrapper: createWrapper() }
+    );
+
+    await waitFor(() => {
+      expect(result.current.videos?.map(video => video.id)).toEqual(['featured-1', 'target-video']);
+    });
+
+    expect(mockFetchFeaturedTabVideos).toHaveBeenNthCalledWith(
+      2,
+      'https://api.divine.video',
+      'ft_1234abcd',
+      'cursor-2',
+      12,
+      expect.any(AbortSignal)
+    );
+  });
+
+  it('does not fetch featured neighbors when the URL tab is not currently eligible', async () => {
+    mockUseFeaturedTab.mockReturnValue({
+      tab: { id: 'ft_other' },
+      isResolved: true,
+    });
+    mockFetchVideoById.mockResolvedValueOnce({
+      id: 'target-video',
+      pubkey: 'p'.repeat(64),
+      d_tag: 'target-video',
+    });
+
+    const { result } = renderHook(
+      () => useVideoByIdFunnelcake({
+        videoId: 'target-video',
+        featuredTabId: 'ft_1234abcd',
+        currentIndex: 1,
+      }),
+      { wrapper: createWrapper() }
+    );
+
+    await waitFor(() => {
+      expect(result.current.video?.id).toBe('target-video');
+    });
+
+    expect(mockFetchFeaturedTabVideos).not.toHaveBeenCalled();
+    expect(mockSearchVideos).not.toHaveBeenCalled();
+    expect(mockFetchUserVideos).not.toHaveBeenCalled();
+    expect(result.current.videos).toBeNull();
   });
 });

--- a/src/hooks/useVideoByIdFunnelcake.ts
+++ b/src/hooks/useVideoByIdFunnelcake.ts
@@ -9,7 +9,10 @@ import { transformFunnelcakeVideo } from '@/lib/funnelcakeTransform';
 import { getFunnelcakeUrl } from '@/config/relays';
 import { useAppContext } from '@/hooks/useAppContext';
 import { useFeaturedTab } from '@/hooks/useFeaturedTab';
-import { FEATURED_TAB_PAGE_SIZE, useFeaturedTabVideos } from '@/hooks/useFeaturedTabVideos';
+import { useFeaturedTabVideos } from '@/hooks/useFeaturedTabVideos';
+import { useFeedBlocklist } from '@/hooks/useFeedBlocklist';
+import { FEED_PAGE_SIZE } from '@/config/feed';
+import { filterBlockedVideoPages } from '@/lib/blocklistFilter';
 import { debugLog } from '@/lib/debug';
 import type { ParsedVideoData } from '@/types/video';
 import type { FunnelcakeVideoRaw } from '@/types/funnelcake';
@@ -38,6 +41,8 @@ interface UseVideoByIdResult {
 }
 
 const NAVIGATION_WINDOW_SIZE = 16;
+// Cold featured links must page forward by cursor to rebuild enough filtered
+// server-order context, but the detail page should not drain an unbounded tab.
 const FEATURED_NAVIGATION_PAGE_BUDGET = 5;
 
 /** Drop rows the transform refuses — a video with no `d` tag has no coordinate. */
@@ -78,7 +83,7 @@ function getFeaturedNavigationPageBudget(currentIndex?: number): number {
 
   return Math.min(
     FEATURED_NAVIGATION_PAGE_BUDGET,
-    Math.ceil((currentIndex + 1) / FEATURED_TAB_PAGE_SIZE) + 1
+    Math.ceil((currentIndex + 1) / FEED_PAGE_SIZE) + 1
   );
 }
 
@@ -92,6 +97,7 @@ function getFeaturedNavigationPageBudget(currentIndex?: number): number {
 export function useVideoByIdFunnelcake(options: UseVideoByIdOptions): UseVideoByIdResult {
   const { videoId, pubkey, hashtag, query, featuredTabId, sortMode = 'relevance', currentIndex, enabled = true } = options;
   const { config } = useAppContext();
+  const blockedPubkeys = useFeedBlocklist();
   const windowOffset = getNavigationWindowOffset(currentIndex);
   const featuredPageBudget = getFeaturedNavigationPageBudget(currentIndex);
   const trimmedQuery = query?.trim();
@@ -177,7 +183,7 @@ export function useVideoByIdFunnelcake(options: UseVideoByIdOptions): UseVideoBy
   const featuredVideosQuery = useFeaturedTabVideos({
     configId: eligibleFeaturedTabId,
     apiUrl: funnelcakeUrl,
-    pageSize: FEATURED_TAB_PAGE_SIZE,
+    pageSize: FEED_PAGE_SIZE,
     enabled: enabled && !!eligibleFeaturedTabId && !pubkey && !hashtag && !searchValue,
   });
   const {
@@ -188,16 +194,23 @@ export function useVideoByIdFunnelcake(options: UseVideoByIdOptions): UseVideoBy
     isFetchingNextPage: isFetchingNextFeaturedPage,
     isLoading: isFeaturedVideosLoading,
   } = featuredVideosQuery;
+  const filteredFeaturedVideosData = useMemo(
+    () => filterBlockedVideoPages(featuredVideosData, blockedPubkeys),
+    [featuredVideosData, blockedPubkeys]
+  );
   const featuredVideos = useMemo(
-    () => featuredVideosData?.pages.flatMap((page) => page.videos) ?? null,
-    [featuredVideosData]
+    () => filteredFeaturedVideosData?.pages.flatMap((page) => page.videos) ?? null,
+    [filteredFeaturedVideosData]
   );
   const featuredContextVideo = featuredVideos?.find(v => v.id === videoId || v.vineId === videoId) || null;
+  const hasEnoughFeaturedNeighbors = currentIndex === undefined || currentIndex < 0
+    ? Boolean(featuredContextVideo)
+    : Boolean(featuredVideos && featuredVideos.length > currentIndex + 1);
 
   useEffect(() => {
     if (
       !eligibleFeaturedTabId ||
-      featuredContextVideo ||
+      (featuredContextVideo && hasEnoughFeaturedNeighbors) ||
       !featuredHasNextPage ||
       isFetchingNextFeaturedPage ||
       (featuredVideosData?.pages.length ?? 0) >= featuredPageBudget
@@ -209,6 +222,7 @@ export function useVideoByIdFunnelcake(options: UseVideoByIdOptions): UseVideoBy
   }, [
     eligibleFeaturedTabId,
     featuredContextVideo,
+    hasEnoughFeaturedNeighbors,
     featuredHasNextPage,
     isFetchingNextFeaturedPage,
     featuredVideosData,
@@ -273,7 +287,8 @@ export function useVideoByIdFunnelcake(options: UseVideoByIdOptions): UseVideoBy
       if (!eligibleFeaturedTabId || !featuredHasNextPage) return featuredVideos;
 
       const result = await fetchNextFeaturedPage();
-      return result.data?.pages.flatMap((page) => page.videos) ?? featuredVideos;
+      return filterBlockedVideoPages(result.data, blockedPubkeys)
+        ?.pages.flatMap((page) => page.videos) ?? featuredVideos;
     },
     isLoading,
     error,

--- a/src/hooks/useVideoByIdFunnelcake.ts
+++ b/src/hooks/useVideoByIdFunnelcake.ts
@@ -232,24 +232,27 @@ export function useVideoByIdFunnelcake(options: UseVideoByIdOptions): UseVideoBy
 
   const contextVideos = userVideosQuery.data ?? hashtagVideosQuery.data ?? searchVideosQuery.data ?? featuredVideos ?? null;
   const contextVideo = contextVideos?.find(v => v.id === videoId || v.vineId === videoId) || null;
-  const contextLoading = pubkey
-    ? userVideosQuery.isLoading
-    : hashtag
-      ? hashtagVideosQuery.isLoading
-      : searchValue
-        ? searchVideosQuery.isLoading
-        : eligibleFeaturedTabId
-          ? isFeaturedVideosLoading || isFetchingNextFeaturedPage
-        : false;
-  const contextError = pubkey
-    ? (userVideosQuery.error as Error | null)
-    : hashtag
-      ? (hashtagVideosQuery.error as Error | null)
-      : searchValue
-        ? (searchVideosQuery.error as Error | null)
-        : eligibleFeaturedTabId
-          ? (featuredVideosError as Error | null)
-        : null;
+  let contextLoading = false;
+  if (pubkey) {
+    contextLoading = userVideosQuery.isLoading;
+  } else if (hashtag) {
+    contextLoading = hashtagVideosQuery.isLoading;
+  } else if (searchValue) {
+    contextLoading = searchVideosQuery.isLoading;
+  } else if (eligibleFeaturedTabId) {
+    contextLoading = isFeaturedVideosLoading || isFetchingNextFeaturedPage;
+  }
+
+  let contextError: Error | null = null;
+  if (pubkey) {
+    contextError = userVideosQuery.error as Error | null;
+  } else if (hashtag) {
+    contextError = hashtagVideosQuery.error as Error | null;
+  } else if (searchValue) {
+    contextError = searchVideosQuery.error as Error | null;
+  } else if (eligibleFeaturedTabId) {
+    contextError = featuredVideosError as Error | null;
+  }
   const shouldLookupSingleVideo = enabled && !!videoId && (
     !contextVideo
   );

--- a/src/hooks/useVideoByIdFunnelcake.ts
+++ b/src/hooks/useVideoByIdFunnelcake.ts
@@ -1,12 +1,15 @@
 // ABOUTME: Hook to fetch a single video by ID via Funnelcake REST API
 // ABOUTME: Provides fast video lookup for VideoPage with profile and hashtag context support
 
+import { useEffect, useMemo } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { getFunnelcakeBaseUrl } from '@/config/api';
 import { fetchVideoById, fetchUserVideos, searchVideos } from '@/lib/funnelcakeClient';
 import { transformFunnelcakeVideo } from '@/lib/funnelcakeTransform';
 import { getFunnelcakeUrl } from '@/config/relays';
 import { useAppContext } from '@/hooks/useAppContext';
+import { useFeaturedTab } from '@/hooks/useFeaturedTab';
+import { FEATURED_TAB_PAGE_SIZE, useFeaturedTabVideos } from '@/hooks/useFeaturedTabVideos';
 import { debugLog } from '@/lib/debug';
 import type { ParsedVideoData } from '@/types/video';
 import type { FunnelcakeVideoRaw } from '@/types/funnelcake';
@@ -17,6 +20,7 @@ interface UseVideoByIdOptions {
   pubkey?: string;   // Optional pubkey for profile context
   hashtag?: string;  // Optional hashtag for hashtag feed context
   query?: string;    // Optional search query for bounded search navigation
+  featuredTabId?: string;
   sortMode?: SortMode | 'relevance';
   currentIndex?: number; // Optional global index from feed context for neighbor windowing
   enabled?: boolean;
@@ -26,11 +30,15 @@ interface UseVideoByIdResult {
   video: ParsedVideoData | null;
   videos: ParsedVideoData[] | null;  // Neighboring videos for navigation
   windowOffset: number;
+  hasNextPage: boolean;
+  isFetchingNextPage: boolean;
+  fetchNextPage: () => Promise<ParsedVideoData[] | null>;
   isLoading: boolean;
   error: Error | null;
 }
 
 const NAVIGATION_WINDOW_SIZE = 16;
+const FEATURED_NAVIGATION_PAGE_BUDGET = 5;
 
 /** Drop rows the transform refuses — a video with no `d` tag has no coordinate. */
 function transformNavigationVideos(rawVideos: FunnelcakeVideoRaw[]): ParsedVideoData[] {
@@ -63,6 +71,17 @@ function mapSearchSortModeToFunnelcakeSort(sortMode: SortMode | 'relevance' = 'r
   }
 }
 
+function getFeaturedNavigationPageBudget(currentIndex?: number): number {
+  if (currentIndex === undefined || currentIndex < 0) {
+    return 1;
+  }
+
+  return Math.min(
+    FEATURED_NAVIGATION_PAGE_BUDGET,
+    Math.ceil((currentIndex + 1) / FEATURED_TAB_PAGE_SIZE) + 1
+  );
+}
+
 /**
  * Hook to fetch a single video by ID via Funnelcake REST API
  *
@@ -71,15 +90,23 @@ function mapSearchSortModeToFunnelcakeSort(sortMode: SortMode | 'relevance' = 'r
  * The single video lookup is faster than WebSocket queries.
  */
 export function useVideoByIdFunnelcake(options: UseVideoByIdOptions): UseVideoByIdResult {
-  const { videoId, pubkey, hashtag, query, sortMode = 'relevance', currentIndex, enabled = true } = options;
+  const { videoId, pubkey, hashtag, query, featuredTabId, sortMode = 'relevance', currentIndex, enabled = true } = options;
   const { config } = useAppContext();
   const windowOffset = getNavigationWindowOffset(currentIndex);
+  const featuredPageBudget = getFeaturedNavigationPageBudget(currentIndex);
   const trimmedQuery = query?.trim();
   const isHashtagSearch = !!trimmedQuery && trimmedQuery.startsWith('#');
   const searchValue = isHashtagSearch ? trimmedQuery?.slice(1).toLowerCase() : trimmedQuery;
 
   // Determine API URL from current relay
   const funnelcakeUrl = getFunnelcakeUrl(config.relayUrl) || getFunnelcakeBaseUrl();
+  const featuredTabState = useFeaturedTab({
+    apiUrl: funnelcakeUrl,
+    enabled: enabled && !!featuredTabId,
+  });
+  const eligibleFeaturedTabId = featuredTabState.tab?.id === featuredTabId
+    ? featuredTabId
+    : undefined;
 
   // If we have a pubkey, fetch all their videos for navigation context
   const userVideosQuery = useQuery({
@@ -147,7 +174,49 @@ export function useVideoByIdFunnelcake(options: UseVideoByIdOptions): UseVideoBy
     gcTime: 900000,
   });
 
-  const contextVideos = userVideosQuery.data ?? hashtagVideosQuery.data ?? searchVideosQuery.data ?? null;
+  const featuredVideosQuery = useFeaturedTabVideos({
+    configId: eligibleFeaturedTabId,
+    apiUrl: funnelcakeUrl,
+    pageSize: FEATURED_TAB_PAGE_SIZE,
+    enabled: enabled && !!eligibleFeaturedTabId && !pubkey && !hashtag && !searchValue,
+  });
+  const {
+    data: featuredVideosData,
+    error: featuredVideosError,
+    fetchNextPage: fetchNextFeaturedPage,
+    hasNextPage: featuredHasNextPage,
+    isFetchingNextPage: isFetchingNextFeaturedPage,
+    isLoading: isFeaturedVideosLoading,
+  } = featuredVideosQuery;
+  const featuredVideos = useMemo(
+    () => featuredVideosData?.pages.flatMap((page) => page.videos) ?? null,
+    [featuredVideosData]
+  );
+  const featuredContextVideo = featuredVideos?.find(v => v.id === videoId || v.vineId === videoId) || null;
+
+  useEffect(() => {
+    if (
+      !eligibleFeaturedTabId ||
+      featuredContextVideo ||
+      !featuredHasNextPage ||
+      isFetchingNextFeaturedPage ||
+      (featuredVideosData?.pages.length ?? 0) >= featuredPageBudget
+    ) {
+      return;
+    }
+
+    void fetchNextFeaturedPage();
+  }, [
+    eligibleFeaturedTabId,
+    featuredContextVideo,
+    featuredHasNextPage,
+    isFetchingNextFeaturedPage,
+    featuredVideosData,
+    featuredPageBudget,
+    fetchNextFeaturedPage,
+  ]);
+
+  const contextVideos = userVideosQuery.data ?? hashtagVideosQuery.data ?? searchVideosQuery.data ?? featuredVideos ?? null;
   const contextVideo = contextVideos?.find(v => v.id === videoId || v.vineId === videoId) || null;
   const contextLoading = pubkey
     ? userVideosQuery.isLoading
@@ -155,6 +224,8 @@ export function useVideoByIdFunnelcake(options: UseVideoByIdOptions): UseVideoBy
       ? hashtagVideosQuery.isLoading
       : searchValue
         ? searchVideosQuery.isLoading
+        : eligibleFeaturedTabId
+          ? isFeaturedVideosLoading || isFetchingNextFeaturedPage
         : false;
   const contextError = pubkey
     ? (userVideosQuery.error as Error | null)
@@ -162,6 +233,8 @@ export function useVideoByIdFunnelcake(options: UseVideoByIdOptions): UseVideoBy
       ? (hashtagVideosQuery.error as Error | null)
       : searchValue
         ? (searchVideosQuery.error as Error | null)
+        : eligibleFeaturedTabId
+          ? (featuredVideosError as Error | null)
         : null;
   const shouldLookupSingleVideo = enabled && !!videoId && (
     !contextVideo
@@ -193,7 +266,15 @@ export function useVideoByIdFunnelcake(options: UseVideoByIdOptions): UseVideoBy
   return {
     video,
     videos,
-    windowOffset,
+    windowOffset: eligibleFeaturedTabId ? 0 : windowOffset,
+    hasNextPage: Boolean(eligibleFeaturedTabId && featuredHasNextPage),
+    isFetchingNextPage: Boolean(eligibleFeaturedTabId && isFetchingNextFeaturedPage),
+    fetchNextPage: async () => {
+      if (!eligibleFeaturedTabId || !featuredHasNextPage) return featuredVideos;
+
+      const result = await fetchNextFeaturedPage();
+      return result.data?.pages.flatMap((page) => page.videos) ?? featuredVideos;
+    },
     isLoading,
     error,
   };

--- a/src/hooks/useVideoByIdFunnelcake.ts
+++ b/src/hooks/useVideoByIdFunnelcake.ts
@@ -286,9 +286,34 @@ export function useVideoByIdFunnelcake(options: UseVideoByIdOptions): UseVideoBy
     fetchNextPage: async () => {
       if (!eligibleFeaturedTabId || !featuredHasNextPage) return featuredVideos;
 
-      const result = await fetchNextFeaturedPage();
-      return filterBlockedVideoPages(result.data, blockedPubkeys)
+      const startCount = featuredVideos?.length ?? 0;
+      let result = await fetchNextFeaturedPage();
+      let visible = filterBlockedVideoPages(result.data, blockedPubkeys)
         ?.pages.flatMap((page) => page.videos) ?? featuredVideos;
+      let loadedPages = result.data?.pages.length ?? 0;
+
+      // A featured page can be entirely blocked/muted authors; filtered to
+      // nothing it would surface as a spurious "couldn't load next" toast at the
+      // boundary even though visible videos remain further in. Skip past
+      // fully-filtered pages until a visible neighbor appears or the tab ends.
+      // Bounded per keypress, and it stops the moment a fetch makes no progress
+      // (error or no-op) so a failing page can't spin the loop.
+      let skipped = 0;
+      while (
+        (visible?.length ?? 0) <= startCount &&
+        result.hasNextPage &&
+        skipped < FEATURED_NAVIGATION_PAGE_BUDGET
+      ) {
+        result = await fetchNextFeaturedPage();
+        const nextLoadedPages = result.data?.pages.length ?? 0;
+        if (nextLoadedPages <= loadedPages) break;
+        loadedPages = nextLoadedPages;
+        visible = filterBlockedVideoPages(result.data, blockedPubkeys)
+          ?.pages.flatMap((page) => page.videos) ?? visible;
+        skipped += 1;
+      }
+
+      return visible;
     },
     isLoading,
     error,

--- a/src/hooks/useVideoNavigation.test.ts
+++ b/src/hooks/useVideoNavigation.test.ts
@@ -56,16 +56,17 @@ describe('useVideoNavigation', () => {
     });
   });
 
-  it('does not map featured navigation to a websocket feed', () => {
+  it('falls featured navigation back to trending when featured neighbors are unavailable', () => {
     renderHook(
       () => useVideoNavigation('video-1'),
       { wrapper: createWrapper('/video/video-1?source=featured&featuredTabId=ft_1234abcd&index=0') }
     );
 
     expect(mockUseVideoEvents).toHaveBeenCalledWith({
-      filter: { ids: ['video-1'] },
-      limit: 1,
-      feedType: 'discovery',
+      feedType: 'trending',
+      hashtag: undefined,
+      pubkey: undefined,
+      limit: 50,
       enabled: true,
     });
   });

--- a/src/hooks/useVideoNavigation.test.ts
+++ b/src/hooks/useVideoNavigation.test.ts
@@ -1,0 +1,72 @@
+import React from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { buildVideoNavigationUrl, parseVideoNavigationContext, useVideoNavigation } from './useVideoNavigation';
+
+const { mockUseVideoEvents } = vi.hoisted(() => ({
+  mockUseVideoEvents: vi.fn(),
+}));
+
+vi.mock('./useVideoEvents', () => ({
+  useVideoEvents: mockUseVideoEvents,
+}));
+
+vi.mock('@/hooks/usePeopleLists', () => ({
+  usePeopleList: () => ({ data: null, isLoading: false }),
+}));
+
+vi.mock('@/hooks/usePeopleListVideos', () => ({
+  usePeopleListVideos: () => ({ data: null, isLoading: false }),
+}));
+
+function createWrapper(path: string) {
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return React.createElement(MemoryRouter, { initialEntries: [path] }, children);
+  };
+}
+
+describe('useVideoNavigation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseVideoEvents.mockReturnValue({
+      data: [],
+      isLoading: false,
+    });
+  });
+
+  it('round-trips featured tab context through video navigation urls', () => {
+    const url = buildVideoNavigationUrl('video-1', {
+      source: 'featured',
+      featuredTabId: 'ft_1234abcd',
+      currentIndex: 4,
+    }, 4);
+
+    const parsed = parseVideoNavigationContext(new URL(url, 'https://divine.video').searchParams);
+
+    expect(parsed).toEqual({
+      source: 'featured',
+      hashtag: undefined,
+      pubkey: undefined,
+      listId: undefined,
+      featuredTabId: 'ft_1234abcd',
+      query: undefined,
+      sortMode: undefined,
+      currentIndex: 4,
+    });
+  });
+
+  it('does not map featured navigation to a websocket feed', () => {
+    renderHook(
+      () => useVideoNavigation('video-1'),
+      { wrapper: createWrapper('/video/video-1?source=featured&featuredTabId=ft_1234abcd&index=0') }
+    );
+
+    expect(mockUseVideoEvents).toHaveBeenCalledWith({
+      filter: { ids: ['video-1'] },
+      limit: 1,
+      feedType: 'discovery',
+      enabled: true,
+    });
+  });
+});

--- a/src/hooks/useVideoNavigation.ts
+++ b/src/hooks/useVideoNavigation.ts
@@ -16,6 +16,7 @@ export interface VideoNavigationContext {
   hashtag?: string;
   pubkey?: string;
   listId?: string;
+  featuredTabId?: string;
   query?: string;
   sortMode?: SortMode | 'relevance';
   currentIndex?: number;
@@ -43,18 +44,7 @@ export function useVideoNavigation(videoId: string, options: UseVideoNavigationO
 
   // Parse navigation context from URL params
   const context: VideoNavigationContext | null = useMemo(() => {
-    const source = searchParams.get('source') as VideoNavigationContext['source'];
-    if (!source) return null;
-
-    return {
-      source,
-      hashtag: searchParams.get('hashtag') || undefined,
-      pubkey: searchParams.get('pubkey') || undefined,
-      listId: searchParams.get('listId') || undefined,
-      query: searchParams.get('q') || undefined,
-      sortMode: searchParams.get('sort') as VideoNavigationContext['sortMode'],
-      currentIndex: searchParams.get('index') ? parseInt(searchParams.get('index')!) : undefined,
-    };
+    return parseVideoNavigationContext(searchParams);
   }, [searchParams]);
 
   const isPeopleListContext = context?.source === 'people-list';
@@ -76,7 +66,8 @@ export function useVideoNavigation(videoId: string, options: UseVideoNavigationO
   const feedTypeForWebSocket: WebSocketFeedType | undefined = (() => {
     if (!context) return undefined;
     if (isPeopleListContext) return 'discovery';
-    if (context.source === 'foryou' || context.source === 'popular' || context.source === 'featured') return 'trending';
+    if (context.source === 'foryou' || context.source === 'popular') return 'trending';
+    if (context.source === 'featured') return undefined;
     if (context.source === 'search') return 'discovery';
     if (
       context.source === 'hashtag' ||
@@ -93,7 +84,7 @@ export function useVideoNavigation(videoId: string, options: UseVideoNavigationO
     return 'discovery';
   })();
   const { data: feedVideos, isLoading: feedVideosLoading } = useVideoEvents(
-    context && !isPeopleListContext ? {
+    context && !isPeopleListContext && feedTypeForWebSocket ? {
       feedType: feedTypeForWebSocket,
       hashtag: context.hashtag,
       pubkey: context.pubkey,
@@ -129,18 +120,7 @@ export function useVideoNavigation(videoId: string, options: UseVideoNavigationO
   const buildNavigationUrl = useCallback((video: ParsedVideoData, index: number) => {
     if (!context) return `/video/${video.id}`;
 
-    const params = new URLSearchParams({
-      source: context.source,
-      index: index.toString(),
-    });
-
-    if (context.hashtag) params.set('hashtag', context.hashtag);
-    if (context.pubkey) params.set('pubkey', context.pubkey);
-    if (context.listId) params.set('listId', context.listId);
-    if (context.query) params.set('q', context.query);
-    if (context.sortMode) params.set('sort', context.sortMode);
-
-    return `/video/${video.id}?${params.toString()}`;
+    return buildVideoNavigationUrl(video.id, context, index);
   }, [context]);
 
   const goToNext = useCallback(() => {
@@ -167,6 +147,26 @@ export function useVideoNavigation(videoId: string, options: UseVideoNavigationO
   };
 }
 
+export function parseVideoNavigationContext(searchParams: URLSearchParams): VideoNavigationContext | null {
+  const source = searchParams.get('source') as VideoNavigationContext['source'];
+  if (!source) return null;
+
+  const rawIndex = searchParams.get('index');
+  const sortMode = searchParams.get('sort') as VideoNavigationContext['sortMode'] | null;
+  const currentIndex = rawIndex ? parseInt(rawIndex, 10) : undefined;
+
+  return {
+    source,
+    hashtag: searchParams.get('hashtag') || undefined,
+    pubkey: searchParams.get('pubkey') || undefined,
+    listId: searchParams.get('listId') || undefined,
+    featuredTabId: searchParams.get('featuredTabId') || undefined,
+    query: searchParams.get('q') || undefined,
+    sortMode: sortMode || undefined,
+    currentIndex: Number.isFinite(currentIndex) ? currentIndex : undefined,
+  };
+}
+
 // Helper function to build navigation URL from context
 export function buildVideoNavigationUrl(
   videoId: string,
@@ -180,6 +180,7 @@ export function buildVideoNavigationUrl(
   if (context.hashtag) params.set('hashtag', context.hashtag);
   if (context.pubkey) params.set('pubkey', context.pubkey);
   if (context.listId) params.set('listId', context.listId);
+  if (context.featuredTabId) params.set('featuredTabId', context.featuredTabId);
   if (context.query) params.set('q', context.query);
   if (context.sortMode) params.set('sort', context.sortMode);
   if (index !== undefined) params.set('index', index.toString());

--- a/src/hooks/useVideoNavigation.ts
+++ b/src/hooks/useVideoNavigation.ts
@@ -66,8 +66,7 @@ export function useVideoNavigation(videoId: string, options: UseVideoNavigationO
   const feedTypeForWebSocket: WebSocketFeedType | undefined = (() => {
     if (!context) return undefined;
     if (isPeopleListContext) return 'discovery';
-    if (context.source === 'foryou' || context.source === 'popular') return 'trending';
-    if (context.source === 'featured') return undefined;
+    if (context.source === 'foryou' || context.source === 'popular' || context.source === 'featured') return 'trending';
     if (context.source === 'search') return 'discovery';
     if (
       context.source === 'hashtag' ||

--- a/src/hooks/useVideoNavigation.ts
+++ b/src/hooks/useVideoNavigation.ts
@@ -83,7 +83,7 @@ export function useVideoNavigation(videoId: string, options: UseVideoNavigationO
     return 'discovery';
   })();
   const { data: feedVideos, isLoading: feedVideosLoading } = useVideoEvents(
-    context && !isPeopleListContext && feedTypeForWebSocket ? {
+    context && !isPeopleListContext ? {
       feedType: feedTypeForWebSocket,
       hashtag: context.hashtag,
       pubkey: context.pubkey,

--- a/src/hooks/useVideoProvider.test.ts
+++ b/src/hooks/useVideoProvider.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { renderHook } from '@testing-library/react';
+import { FEED_PAGE_SIZE } from '@/config/feed';
 import type { RelayCapabilities } from '@/lib/relayCapabilities';
 
 const mockUseInfiniteVideos = vi.fn();
@@ -245,6 +246,7 @@ describe('useVideoProvider', () => {
     expect(mockUseFeaturedTabVideos).toHaveBeenCalledWith(expect.objectContaining({
       configId: 'ft_1234abcd',
       apiUrl: 'https://api.divine.video',
+      pageSize: FEED_PAGE_SIZE,
       enabled: true,
     }));
     expect(mockUseInfiniteVideos).toHaveBeenCalledWith(expect.objectContaining({

--- a/src/hooks/useVideoProvider.ts
+++ b/src/hooks/useVideoProvider.ts
@@ -9,6 +9,7 @@ import { useResolvedRelayCapabilities } from '@/hooks/useRelayCapabilities';
 import { useInfiniteVideosFunnelcake, type FunnelcakeFeedType, type FunnelcakeSortMode, type PopularPeriod, type PopularSource } from '@/hooks/useInfiniteVideosFunnelcake';
 import { useFeaturedTabVideos } from '@/hooks/useFeaturedTabVideos';
 import { useFeedBlocklist } from '@/hooks/useFeedBlocklist';
+import { FEED_PAGE_SIZE } from '@/config/feed';
 import { filterBlockedVideoPages } from '@/lib/blocklistFilter';
 import { hasFunnelcake, getFunnelcakeUrl } from '@/config/relays';
 import { debugLog } from '@/lib/debug';
@@ -228,7 +229,7 @@ export function useVideoProvider({
   category,
   featuredTabId,
   pubkey,
-  pageSize = 12,
+  pageSize = FEED_PAGE_SIZE,
   enabled = true,
 }: UseVideoProviderOptions): VideoProviderResult {
   const { config } = useAppContext();

--- a/src/lib/i18n/locales/ar/common.json
+++ b/src/lib/i18n/locales/ar/common.json
@@ -857,6 +857,7 @@
     "seoDescription": "شاهد هذا الفيديو على Divine",
     "seoDescriptionWithAuthor": "شاهد هذا الفيديو من {{name}} على Divine",
     "errorTitle": "خطأ",
+    "nextVideoUnavailableDescription": "لا توجد فيديوهات أخرى في هذه التبويبة.",
     "likedTitle": "أعجبني!",
     "likedDescription": "تم نشر تفاعلك",
     "likeFailedDescription": "فشل الإعجاب بالفيديو",

--- a/src/lib/i18n/locales/de/common.json
+++ b/src/lib/i18n/locales/de/common.json
@@ -813,6 +813,7 @@
     "seoDescription": "Schau dir dieses Video auf Divine an",
     "seoDescriptionWithAuthor": "Schau dir dieses Video von {{name}} auf Divine an",
     "errorTitle": "Fehler",
+    "nextVideoUnavailableDescription": "Keine weiteren Videos in diesem Tab.",
     "likedTitle": "Geliked!",
     "likedDescription": "Deine Reaktion wurde veröffentlicht",
     "likeFailedDescription": "Video konnte nicht geliked werden",

--- a/src/lib/i18n/locales/en/common.json
+++ b/src/lib/i18n/locales/en/common.json
@@ -813,6 +813,7 @@
     "seoDescription": "Watch this video on Divine",
     "seoDescriptionWithAuthor": "Watch this video by {{name}} on Divine",
     "errorTitle": "Error",
+    "nextVideoUnavailableDescription": "No more videos in this tab.",
     "likedTitle": "Liked!",
     "likedDescription": "Your reaction has been published",
     "likeFailedDescription": "Failed to like video",

--- a/src/lib/i18n/locales/es/common.json
+++ b/src/lib/i18n/locales/es/common.json
@@ -813,6 +813,7 @@
     "seoDescription": "Mira este video en Divine",
     "seoDescriptionWithAuthor": "Mira este video de {{name}} en Divine",
     "errorTitle": "Error",
+    "nextVideoUnavailableDescription": "No hay más videos en esta pestaña.",
     "likedTitle": "¡Me gusta!",
     "likedDescription": "Tu reacción se publicó",
     "likeFailedDescription": "Falló al dar me gusta al video",

--- a/src/lib/i18n/locales/fil/common.json
+++ b/src/lib/i18n/locales/fil/common.json
@@ -813,6 +813,7 @@
     "seoDescription": "Panoorin ang loop na 'to sa Divine",
     "seoDescriptionWithAuthor": "Panoorin ang loop na 'to ni {{name}} sa Divine",
     "errorTitle": "May Mali",
+    "nextVideoUnavailableDescription": "Wala nang ibang video sa tab na ito.",
     "likedTitle": "Na-like!",
     "likedDescription": "Na-publish na ang reaksyon mo",
     "likeFailedDescription": "Hindi na-like ang loop",

--- a/src/lib/i18n/locales/fr/common.json
+++ b/src/lib/i18n/locales/fr/common.json
@@ -813,6 +813,7 @@
     "seoDescription": "Regarde cette vidéo sur Divine",
     "seoDescriptionWithAuthor": "Regarde cette vidéo de {{name}} sur Divine",
     "errorTitle": "Erreur",
+    "nextVideoUnavailableDescription": "Plus de vidéos dans cet onglet.",
     "likedTitle": "Aimé !",
     "likedDescription": "Ta réaction a été publiée",
     "likeFailedDescription": "Échec du like",

--- a/src/lib/i18n/locales/id/common.json
+++ b/src/lib/i18n/locales/id/common.json
@@ -813,6 +813,7 @@
     "seoDescription": "Tonton video ini di Divine",
     "seoDescriptionWithAuthor": "Tonton video oleh {{name}} di Divine",
     "errorTitle": "Error",
+    "nextVideoUnavailableDescription": "Tidak ada video lagi di tab ini.",
     "likedTitle": "Disukai!",
     "likedDescription": "Reaksi kamu sudah dipublikasikan",
     "likeFailedDescription": "Gagal menyukai video",

--- a/src/lib/i18n/locales/it/common.json
+++ b/src/lib/i18n/locales/it/common.json
@@ -813,6 +813,7 @@
     "seoDescription": "Guarda questo video su Divine",
     "seoDescriptionWithAuthor": "Guarda questo video di {{name}} su Divine",
     "errorTitle": "Errore",
+    "nextVideoUnavailableDescription": "Non ci sono altri video in questa scheda.",
     "likedTitle": "Mi piace!",
     "likedDescription": "La tua reazione è stata pubblicata",
     "likeFailedDescription": "Impossibile mettere mi piace al video",

--- a/src/lib/i18n/locales/ja/common.json
+++ b/src/lib/i18n/locales/ja/common.json
@@ -813,6 +813,7 @@
     "seoDescription": "Divineでこの動画を視聴",
     "seoDescriptionWithAuthor": "Divineで{{name}}のこの動画を視聴",
     "errorTitle": "エラー",
+    "nextVideoUnavailableDescription": "このタブにはこれ以上動画がありません。",
     "likedTitle": "いいねしました！",
     "likedDescription": "リアクションが公開されました",
     "likeFailedDescription": "動画へのいいねに失敗しました",

--- a/src/lib/i18n/locales/ko/common.json
+++ b/src/lib/i18n/locales/ko/common.json
@@ -813,6 +813,7 @@
     "seoDescription": "Divine에서 이 비디오를 보세요",
     "seoDescriptionWithAuthor": "Divine에서 {{name}}님의 이 비디오를 보세요",
     "errorTitle": "오류",
+    "nextVideoUnavailableDescription": "이 탭에는 더 이상 동영상이 없어요.",
     "likedTitle": "좋아요!",
     "likedDescription": "반응이 발행됐어요",
     "likeFailedDescription": "비디오에 좋아요를 남길 수 없어요",

--- a/src/lib/i18n/locales/ms/common.json
+++ b/src/lib/i18n/locales/ms/common.json
@@ -813,6 +813,7 @@
     "seoDescription": "Tonton video ini di Divine",
     "seoDescriptionWithAuthor": "Tonton video oleh {{name}} di Divine",
     "errorTitle": "Ralat",
+    "nextVideoUnavailableDescription": "Tiada lagi video dalam tab ini.",
     "likedTitle": "Disukai!",
     "likedDescription": "Reaksi anda telah diterbitkan",
     "likeFailedDescription": "Gagal menyukai video",

--- a/src/lib/i18n/locales/nl/common.json
+++ b/src/lib/i18n/locales/nl/common.json
@@ -813,6 +813,7 @@
     "seoDescription": "Bekijk deze video op Divine",
     "seoDescriptionWithAuthor": "Bekijk deze video van {{name}} op Divine",
     "errorTitle": "Fout",
+    "nextVideoUnavailableDescription": "Geen verdere videos in dit tabblad.",
     "likedTitle": "Geliket!",
     "likedDescription": "Je reactie is gepubliceerd",
     "likeFailedDescription": "Video liken mislukt",

--- a/src/lib/i18n/locales/pl/common.json
+++ b/src/lib/i18n/locales/pl/common.json
@@ -813,6 +813,7 @@
     "seoDescription": "Obejrzyj to wideo na Divine",
     "seoDescriptionWithAuthor": "Obejrzyj to wideo od {{name}} na Divine",
     "errorTitle": "Błąd",
+    "nextVideoUnavailableDescription": "Nie ma więcej filmów w tej karcie.",
     "likedTitle": "Polubione!",
     "likedDescription": "Twoja reakcja została opublikowana",
     "likeFailedDescription": "Nie udało się polubić wideo",

--- a/src/lib/i18n/locales/pt/common.json
+++ b/src/lib/i18n/locales/pt/common.json
@@ -813,6 +813,7 @@
     "seoDescription": "Assista a este vídeo na Divine",
     "seoDescriptionWithAuthor": "Assista a este vídeo de {{name}} na Divine",
     "errorTitle": "Erro",
+    "nextVideoUnavailableDescription": "Não há mais vídeos nesta aba.",
     "likedTitle": "Curtido!",
     "likedDescription": "Sua reação foi publicada",
     "likeFailedDescription": "Falha ao curtir o vídeo",

--- a/src/lib/i18n/locales/ro/common.json
+++ b/src/lib/i18n/locales/ro/common.json
@@ -813,6 +813,7 @@
     "seoDescription": "Vezi acest videoclip pe Divine",
     "seoDescriptionWithAuthor": "Vezi acest videoclip de la {{name}} pe Divine",
     "errorTitle": "Eroare",
+    "nextVideoUnavailableDescription": "Nu mai sunt videoclipuri în această filă.",
     "likedTitle": "Apreciat!",
     "likedDescription": "Reacția ta a fost publicată",
     "likeFailedDescription": "Aprecierea videoclipului a eșuat",

--- a/src/lib/i18n/locales/sv/common.json
+++ b/src/lib/i18n/locales/sv/common.json
@@ -813,6 +813,7 @@
     "seoDescription": "Titta på den här videon på Divine",
     "seoDescriptionWithAuthor": "Titta på den här videon av {{name}} på Divine",
     "errorTitle": "Fel",
+    "nextVideoUnavailableDescription": "Inga fler videor i den här fliken.",
     "likedTitle": "Gillad!",
     "likedDescription": "Din reaktion har publicerats",
     "likeFailedDescription": "Kunde inte gilla videon",

--- a/src/lib/i18n/locales/tr/common.json
+++ b/src/lib/i18n/locales/tr/common.json
@@ -813,6 +813,7 @@
     "seoDescription": "Bu videoyu Divine'da izle",
     "seoDescriptionWithAuthor": "{{name}} tarafından bu videoyu Divine'da izle",
     "errorTitle": "Hata",
+    "nextVideoUnavailableDescription": "Bu sekmede başka video yok.",
     "likedTitle": "Beğenildi!",
     "likedDescription": "Tepkin yayınlandı",
     "likeFailedDescription": "Video beğenilemedi",

--- a/src/lib/i18n/locales/ur/common.json
+++ b/src/lib/i18n/locales/ur/common.json
@@ -813,6 +813,7 @@
     "seoDescription": "Divine پر یہ ویڈیو دیکھیں",
     "seoDescriptionWithAuthor": "Divine پر {{name}} کی یہ ویڈیو دیکھیں",
     "errorTitle": "خرابی",
+    "nextVideoUnavailableDescription": "اس ٹیب میں مزید ویڈیوز نہیں ہیں۔",
     "likedTitle": "پسند کیا!",
     "likedDescription": "آپ کا ردِ عمل شائع ہو گیا",
     "likeFailedDescription": "ویڈیو پسند نہیں کی جا سکی",

--- a/src/lib/i18n/locales/vi/common.json
+++ b/src/lib/i18n/locales/vi/common.json
@@ -813,6 +813,7 @@
     "seoDescription": "Xem video này trên Divine",
     "seoDescriptionWithAuthor": "Xem video này của {{name}} trên Divine",
     "errorTitle": "Lỗi",
+    "nextVideoUnavailableDescription": "Không còn video nào trong tab này.",
     "likedTitle": "Đã thích!",
     "likedDescription": "Cảm xúc của bạn đã được đăng",
     "likeFailedDescription": "Không thích được video",

--- a/src/lib/i18n/locales/zh/common.json
+++ b/src/lib/i18n/locales/zh/common.json
@@ -813,6 +813,7 @@
     "seoDescription": "在 Divine 上观看这个视频",
     "seoDescriptionWithAuthor": "在 Divine 上观看 {{name}} 的视频",
     "errorTitle": "出错",
+    "nextVideoUnavailableDescription": "这个标签页里没有更多视频了。",
     "likedTitle": "已点赞！",
     "likedDescription": "你的反应已发布",
     "likeFailedDescription": "点赞失败",

--- a/src/pages/VideoPage.test.tsx
+++ b/src/pages/VideoPage.test.tsx
@@ -130,51 +130,23 @@ vi.mock('@/hooks/useVideoByIdFunnelcake', () => ({
   },
 }));
 
-vi.mock('@/hooks/useVideoNavigation', () => ({
-  buildVideoNavigationUrl: (videoId: string, context: {
-    source: string;
-    hashtag?: string;
-    pubkey?: string;
-    listId?: string;
-    featuredTabId?: string;
-    query?: string;
-    sortMode?: string;
-  }, index?: number) => {
-    const params = new URLSearchParams({ source: context.source });
-    if (context.hashtag) params.set('hashtag', context.hashtag);
-    if (context.pubkey) params.set('pubkey', context.pubkey);
-    if (context.listId) params.set('listId', context.listId);
-    if (context.featuredTabId) params.set('featuredTabId', context.featuredTabId);
-    if (context.query) params.set('q', context.query);
-    if (context.sortMode) params.set('sort', context.sortMode);
-    if (index !== undefined) params.set('index', String(index));
-    return `/video/${videoId}?${params.toString()}`;
-  },
-  parseVideoNavigationContext: (searchParams: URLSearchParams) => {
-    const source = searchParams.get('source');
-    if (!source) return null;
-    return {
-      source,
-      hashtag: searchParams.get('hashtag') || undefined,
-      pubkey: searchParams.get('pubkey') || undefined,
-      listId: searchParams.get('listId') || undefined,
-      featuredTabId: searchParams.get('featuredTabId') || undefined,
-      query: searchParams.get('q') || undefined,
-      sortMode: searchParams.get('sort') || undefined,
-      currentIndex: searchParams.get('index') ? parseInt(searchParams.get('index')!, 10) : undefined,
-    };
-  },
-  useVideoNavigation: () => ({
-    context: null,
-    currentVideo: null,
-    videos: null,
-    hasNext: false,
-    hasPrevious: false,
-    goToNext: vi.fn(),
-    goToPrevious: vi.fn(),
-    isLoading: false,
-  }),
-}));
+vi.mock('@/hooks/useVideoNavigation', async () => {
+  const actual = await vi.importActual<typeof import('@/hooks/useVideoNavigation')>('@/hooks/useVideoNavigation');
+
+  return {
+    ...actual,
+    useVideoNavigation: () => ({
+      context: null,
+      currentVideo: null,
+      videos: null,
+      hasNext: false,
+      hasPrevious: false,
+      goToNext: vi.fn(),
+      goToPrevious: vi.fn(),
+      isLoading: false,
+    }),
+  };
+});
 
 vi.mock('@/hooks/useAuthor', () => ({
   useAuthor: () => ({
@@ -389,6 +361,7 @@ describe('VideoPage', () => {
 
     await waitFor(() => {
       expect(mockToast).toHaveBeenCalledWith(expect.objectContaining({
+        description: 'No more videos in this tab.',
         variant: 'destructive',
       }));
     });

--- a/src/pages/VideoPage.test.tsx
+++ b/src/pages/VideoPage.test.tsx
@@ -12,8 +12,9 @@ const { VIDEO_1_AUTHOR_PK, VIDEO_2_AUTHOR_PK, VIDEO_3_AUTHOR_PK, VIEWER_PK } = v
   VIEWER_PK: 'f'.repeat(64),
 }));
 
-const { mockNavigate } = vi.hoisted(() => ({
+const { mockNavigate, mockFetchNextFunnelcakePage } = vi.hoisted(() => ({
   mockNavigate: vi.fn(),
+  mockFetchNextFunnelcakePage: vi.fn(),
 }));
 
 const { openLoginDialogMock } = vi.hoisted(() => ({
@@ -35,7 +36,7 @@ vi.mock('@/hooks/useSubdomainNavigate', () => ({
 }));
 
 vi.mock('@/hooks/useVideoByIdFunnelcake', () => ({
-  useVideoByIdFunnelcake: (options: { videoId: string; query?: string }) => {
+  useVideoByIdFunnelcake: (options: { videoId: string; query?: string; featuredTabId?: string }) => {
     const videos = [
       {
         id: 'video-1',
@@ -79,6 +80,24 @@ vi.mock('@/hooks/useVideoByIdFunnelcake', () => ({
         video,
         videos,
         windowOffset: 0,
+        hasNextPage: false,
+        isFetchingNextPage: false,
+        fetchNextPage: vi.fn(),
+        isLoading: false,
+        error: null,
+      };
+    }
+
+    if (options.featuredTabId === 'ft_1234abcd') {
+      mockFetchNextFunnelcakePage.mockResolvedValueOnce([videos[1], videos[2]]);
+
+      return {
+        video: videos[1],
+        videos: [videos[1]],
+        windowOffset: 1,
+        hasNextPage: true,
+        isFetchingNextPage: false,
+        fetchNextPage: mockFetchNextFunnelcakePage,
         isLoading: false,
         error: null,
       };
@@ -88,6 +107,9 @@ vi.mock('@/hooks/useVideoByIdFunnelcake', () => ({
       video,
       videos: null,
       windowOffset: 0,
+      hasNextPage: false,
+      isFetchingNextPage: false,
+      fetchNextPage: vi.fn(),
       isLoading: false,
       error: null,
     };
@@ -95,6 +117,39 @@ vi.mock('@/hooks/useVideoByIdFunnelcake', () => ({
 }));
 
 vi.mock('@/hooks/useVideoNavigation', () => ({
+  buildVideoNavigationUrl: (videoId: string, context: {
+    source: string;
+    hashtag?: string;
+    pubkey?: string;
+    listId?: string;
+    featuredTabId?: string;
+    query?: string;
+    sortMode?: string;
+  }, index?: number) => {
+    const params = new URLSearchParams({ source: context.source });
+    if (context.hashtag) params.set('hashtag', context.hashtag);
+    if (context.pubkey) params.set('pubkey', context.pubkey);
+    if (context.listId) params.set('listId', context.listId);
+    if (context.featuredTabId) params.set('featuredTabId', context.featuredTabId);
+    if (context.query) params.set('q', context.query);
+    if (context.sortMode) params.set('sort', context.sortMode);
+    if (index !== undefined) params.set('index', String(index));
+    return `/video/${videoId}?${params.toString()}`;
+  },
+  parseVideoNavigationContext: (searchParams: URLSearchParams) => {
+    const source = searchParams.get('source');
+    if (!source) return null;
+    return {
+      source,
+      hashtag: searchParams.get('hashtag') || undefined,
+      pubkey: searchParams.get('pubkey') || undefined,
+      listId: searchParams.get('listId') || undefined,
+      featuredTabId: searchParams.get('featuredTabId') || undefined,
+      query: searchParams.get('q') || undefined,
+      sortMode: searchParams.get('sort') || undefined,
+      currentIndex: searchParams.get('index') ? parseInt(searchParams.get('index')!, 10) : undefined,
+    };
+  },
   useVideoNavigation: () => ({
     context: null,
     currentVideo: null,
@@ -208,6 +263,7 @@ function renderPage(path: string) {
 describe('VideoPage', () => {
   beforeEach(async () => {
     vi.clearAllMocks();
+    mockFetchNextFunnelcakePage.mockReset();
     currentUser.value = null;
     publishAsyncMock.mockResolvedValue({ id: 'like-event-id' });
     const storage = new Map<string, string>();
@@ -237,6 +293,24 @@ describe('VideoPage', () => {
     expect(url.searchParams.get('source')).toBe('search');
     expect(url.searchParams.get('q')).toBe('twerking');
     expect(url.searchParams.get('sort')).toBe('top');
+    expect(url.searchParams.get('index')).toBe('2');
+  });
+
+  it('fetches the next featured page at the boundary while preserving featured params', async () => {
+    renderPage('/video/video-2?source=featured&featuredTabId=ft_1234abcd&index=1');
+
+    fireEvent.keyDown(document.body, { key: 'ArrowDown' });
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledTimes(1);
+    });
+    expect(mockFetchNextFunnelcakePage).toHaveBeenCalledTimes(1);
+
+    const [target] = mockNavigate.mock.calls[0] ?? [];
+    const url = new URL(String(target), 'https://divine.video');
+    expect(url.pathname).toBe('/video/video-3');
+    expect(url.searchParams.get('source')).toBe('featured');
+    expect(url.searchParams.get('featuredTabId')).toBe('ft_1234abcd');
     expect(url.searchParams.get('index')).toBe('2');
   });
 

--- a/src/pages/VideoPage.test.tsx
+++ b/src/pages/VideoPage.test.tsx
@@ -12,9 +12,10 @@ const { VIDEO_1_AUTHOR_PK, VIDEO_2_AUTHOR_PK, VIDEO_3_AUTHOR_PK, VIEWER_PK } = v
   VIEWER_PK: 'f'.repeat(64),
 }));
 
-const { mockNavigate, mockFetchNextFunnelcakePage } = vi.hoisted(() => ({
+const { mockNavigate, mockFetchNextFunnelcakePage, mockToast } = vi.hoisted(() => ({
   mockNavigate: vi.fn(),
   mockFetchNextFunnelcakePage: vi.fn(),
+  mockToast: vi.fn(),
 }));
 
 const { openLoginDialogMock } = vi.hoisted(() => ({
@@ -91,6 +92,19 @@ vi.mock('@/hooks/useVideoByIdFunnelcake', () => ({
     if (options.featuredTabId === 'ft_1234abcd') {
       mockFetchNextFunnelcakePage.mockResolvedValueOnce([videos[1], videos[2]]);
 
+      return {
+        video: videos[1],
+        videos: [videos[1]],
+        windowOffset: 1,
+        hasNextPage: true,
+        isFetchingNextPage: false,
+        fetchNextPage: mockFetchNextFunnelcakePage,
+        isLoading: false,
+        error: null,
+      };
+    }
+
+    if (options.featuredTabId === 'ft_slow' || options.featuredTabId === 'ft_empty') {
       return {
         video: videos[1],
         videos: [videos[1]],
@@ -211,7 +225,7 @@ vi.mock('@tanstack/react-query', async () => {
 
 vi.mock('@/hooks/useToast', () => ({
   useToast: () => ({
-    toast: vi.fn(),
+    toast: mockToast,
   }),
 }));
 
@@ -264,6 +278,7 @@ describe('VideoPage', () => {
   beforeEach(async () => {
     vi.clearAllMocks();
     mockFetchNextFunnelcakePage.mockReset();
+    mockToast.mockReset();
     currentUser.value = null;
     publishAsyncMock.mockResolvedValue({ id: 'like-event-id' });
     const storage = new Map<string, string>();
@@ -312,6 +327,72 @@ describe('VideoPage', () => {
     expect(url.searchParams.get('source')).toBe('featured');
     expect(url.searchParams.get('featuredTabId')).toBe('ft_1234abcd');
     expect(url.searchParams.get('index')).toBe('2');
+  });
+
+  it('ignores repeated next navigation while a boundary fetch is in flight', async () => {
+    let resolveNextPage: (videos: Array<{ id: string; pubkey: string; kind: number; createdAt: number; content: string; videoUrl: string; vineId: string | null; hashtags: string[]; reposts: unknown[] }>) => void;
+    mockFetchNextFunnelcakePage.mockImplementationOnce(() => new Promise(resolve => {
+      resolveNextPage = resolve;
+    }));
+
+    renderPage('/video/video-2?source=featured&featuredTabId=ft_slow&index=1');
+
+    fireEvent.keyDown(document.body, { key: 'ArrowDown' });
+    fireEvent.keyDown(document.body, { key: 'ArrowDown' });
+
+    expect(mockFetchNextFunnelcakePage).toHaveBeenCalledTimes(1);
+    expect(mockNavigate).not.toHaveBeenCalled();
+
+    resolveNextPage!([{
+      id: 'video-2',
+      pubkey: VIDEO_2_AUTHOR_PK,
+      kind: 34236,
+      createdAt: 2,
+      content: 'two',
+      videoUrl: 'https://example.com/2.mp4',
+      vineId: 'vine-two',
+      hashtags: [],
+      reposts: [],
+    }, {
+      id: 'video-3',
+      pubkey: VIDEO_3_AUTHOR_PK,
+      kind: 34236,
+      createdAt: 3,
+      content: 'three',
+      videoUrl: 'https://example.com/3.mp4',
+      vineId: 'vine-three',
+      hashtags: [],
+      reposts: [],
+    }]);
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it('shows feedback when a visible next page produces no next video', async () => {
+    mockFetchNextFunnelcakePage.mockResolvedValueOnce([{
+      id: 'video-2',
+      pubkey: VIDEO_2_AUTHOR_PK,
+      kind: 34236,
+      createdAt: 2,
+      content: 'two',
+      videoUrl: 'https://example.com/2.mp4',
+      vineId: 'vine-two',
+      hashtags: [],
+      reposts: [],
+    }]);
+
+    renderPage('/video/video-2?source=featured&featuredTabId=ft_empty&index=1');
+
+    fireEvent.keyDown(document.body, { key: 'ArrowDown' });
+
+    await waitFor(() => {
+      expect(mockToast).toHaveBeenCalledWith(expect.objectContaining({
+        variant: 'destructive',
+      }));
+    });
+    expect(mockNavigate).not.toHaveBeenCalled();
   });
 
   it('opens the login dialog when a signed-out viewer likes or reposts', () => {

--- a/src/pages/VideoPage.tsx
+++ b/src/pages/VideoPage.tsx
@@ -126,7 +126,7 @@ export function VideoPage() {
     if (!nextVideo) {
       toast({
         title: t('videoPage.errorTitle'),
-        description: "Couldn't load the next video. Try again?",
+        description: t('videoPage.nextVideoUnavailableDescription'),
         variant: 'destructive',
       });
       return;

--- a/src/pages/VideoPage.tsx
+++ b/src/pages/VideoPage.tsx
@@ -9,7 +9,7 @@ import { Card, CardContent } from '@/components/ui/card';
 import { Skeleton } from '@/components/ui/skeleton';
 import { Button } from '@/components/ui/button';
 import { VideoCard } from '@/components/VideoCard';
-import { useVideoNavigation, type VideoNavigationContext } from '@/hooks/useVideoNavigation';
+import { buildVideoNavigationUrl, parseVideoNavigationContext, useVideoNavigation, type VideoNavigationContext } from '@/hooks/useVideoNavigation';
 import { useVideoByIdFunnelcake } from '@/hooks/useVideoByIdFunnelcake';
 import { useAuthor } from '@/hooks/useAuthor';
 import { useBatchedVideoInteractions } from '@/hooks/useBatchedVideoInteractions';
@@ -37,18 +37,7 @@ export function VideoPage() {
 
   // Parse navigation context from URL params
   const context: VideoNavigationContext | null = useMemo(() => {
-    const source = searchParams.get('source') as VideoNavigationContext['source'];
-    if (!source) return null;
-
-    return {
-      source,
-      hashtag: searchParams.get('hashtag') || undefined,
-      pubkey: searchParams.get('pubkey') || undefined,
-      listId: searchParams.get('listId') || undefined,
-      query: searchParams.get('q') || undefined,
-      sortMode: searchParams.get('sort') as VideoNavigationContext['sortMode'],
-      currentIndex: searchParams.get('index') ? parseInt(searchParams.get('index')!) : undefined,
-    };
+    return parseVideoNavigationContext(searchParams);
   }, [searchParams]);
   const profileContextPubkey = context?.source === 'profile' ? context.pubkey : undefined;
 
@@ -57,6 +46,8 @@ export function VideoPage() {
     video: funnelcakeVideo,
     videos: funnelcakeVideos,
     windowOffset: funnelcakeWindowOffset,
+    hasNextPage: funnelcakeHasNextPage,
+    fetchNextPage: fetchNextFunnelcakePage,
     isLoading: funnelcakeLoading,
     error: funnelcakeError,
   } = useVideoByIdFunnelcake({
@@ -64,6 +55,7 @@ export function VideoPage() {
     pubkey: profileContextPubkey,
     hashtag: context?.source === 'hashtag' ? context.hashtag : undefined,
     query: context?.source === 'search' ? context.query : undefined,
+    featuredTabId: context?.source === 'featured' ? context.featuredTabId : undefined,
     sortMode: context?.sortMode,
     currentIndex: context?.currentIndex,
     enabled: !!id,
@@ -97,32 +89,42 @@ export function VideoPage() {
   }, [videos, id]);
   const navigationIndexBase = videos === funnelcakeVideos ? funnelcakeWindowOffset : 0;
 
-  const hasNext = currentIndex >= 0 && currentIndex < (videos?.length || 0) - 1;
+  const isUsingFunnelcakeVideos = videos === funnelcakeVideos;
+  const hasNextLoaded = currentIndex >= 0 && currentIndex < (videos?.length || 0) - 1;
+  const hasNext = hasNextLoaded || (isUsingFunnelcakeVideos && currentIndex >= 0 && funnelcakeHasNextPage);
   const hasPrevious = currentIndex > 0;
 
   // Build navigation URL
   const buildNavigationUrl = useCallback((video: ParsedVideoData, index: number) => {
     if (!context) return `/video/${video.id}`;
 
-    const params = new URLSearchParams({
-      source: context.source,
-      index: index.toString(),
-    });
-
-    if (context.hashtag) params.set('hashtag', context.hashtag);
-    if (context.pubkey) params.set('pubkey', context.pubkey);
-    if (context.listId) params.set('listId', context.listId);
-    if (context.query) params.set('q', context.query);
-    if (context.sortMode) params.set('sort', context.sortMode);
-
-    return `/video/${video.id}?${params.toString()}`;
+    return buildVideoNavigationUrl(video.id, context, index);
   }, [context]);
 
-  const goToNext = useCallback(() => {
+  const goToNext = useCallback(async () => {
     if (!hasNext || !videos) return;
-    const nextVideo = videos[currentIndex + 1];
+    let nextVideos = videos;
+
+    if (!hasNextLoaded && isUsingFunnelcakeVideos && funnelcakeHasNextPage) {
+      nextVideos = await fetchNextFunnelcakePage() ?? videos;
+    }
+
+    const nextVideo = nextVideos[currentIndex + 1];
+    if (!nextVideo) return;
+
     navigate(buildNavigationUrl(nextVideo, navigationIndexBase + currentIndex + 1));
-  }, [hasNext, videos, currentIndex, navigate, buildNavigationUrl, navigationIndexBase]);
+  }, [
+    hasNext,
+    videos,
+    hasNextLoaded,
+    isUsingFunnelcakeVideos,
+    funnelcakeHasNextPage,
+    fetchNextFunnelcakePage,
+    currentIndex,
+    navigate,
+    buildNavigationUrl,
+    navigationIndexBase,
+  ]);
 
   const goToPrevious = useCallback(() => {
     if (!hasPrevious || !videos) return;

--- a/src/pages/VideoPage.tsx
+++ b/src/pages/VideoPage.tsx
@@ -31,6 +31,7 @@ import type { ParsedVideoData, UserInteractions } from '@/types/video';
 
 export function VideoPage() {
   const { t } = useTranslation();
+  const { toast } = useToast();
   const { id } = useParams<{ id: string }>();
   const [searchParams] = useSearchParams();
   const navigate = useSubdomainNavigate();
@@ -47,6 +48,7 @@ export function VideoPage() {
     videos: funnelcakeVideos,
     windowOffset: funnelcakeWindowOffset,
     hasNextPage: funnelcakeHasNextPage,
+    isFetchingNextPage: isFetchingNextFunnelcakePage,
     fetchNextPage: fetchNextFunnelcakePage,
     isLoading: funnelcakeLoading,
     error: funnelcakeError,
@@ -61,7 +63,10 @@ export function VideoPage() {
     enabled: !!id,
   });
 
-  const shouldEnableWebsocketNavigation = !!id && !funnelcakeLoading && !funnelcakeVideo;
+  const shouldEnableWebsocketNavigation = !!id && !funnelcakeLoading && (
+    !funnelcakeVideo ||
+    (context?.source === 'featured' && !funnelcakeVideos)
+  );
 
   // Fallback to WebSocket-based navigation (slower but handles all cases)
   const {
@@ -93,6 +98,7 @@ export function VideoPage() {
   const hasNextLoaded = currentIndex >= 0 && currentIndex < (videos?.length || 0) - 1;
   const hasNext = hasNextLoaded || (isUsingFunnelcakeVideos && currentIndex >= 0 && funnelcakeHasNextPage);
   const hasPrevious = currentIndex > 0;
+  const nextNavigationInFlightRef = useRef(false);
 
   // Build navigation URL
   const buildNavigationUrl = useCallback((video: ParsedVideoData, index: number) => {
@@ -102,15 +108,29 @@ export function VideoPage() {
   }, [context]);
 
   const goToNext = useCallback(async () => {
-    if (!hasNext || !videos) return;
+    if (!hasNext || !videos || nextNavigationInFlightRef.current || isFetchingNextFunnelcakePage) return;
     let nextVideos = videos;
 
     if (!hasNextLoaded && isUsingFunnelcakeVideos && funnelcakeHasNextPage) {
-      nextVideos = await fetchNextFunnelcakePage() ?? videos;
+      nextNavigationInFlightRef.current = true;
+      try {
+        nextVideos = await fetchNextFunnelcakePage() ?? videos;
+      } catch {
+        nextVideos = videos;
+      } finally {
+        nextNavigationInFlightRef.current = false;
+      }
     }
 
     const nextVideo = nextVideos[currentIndex + 1];
-    if (!nextVideo) return;
+    if (!nextVideo) {
+      toast({
+        title: t('videoPage.errorTitle'),
+        description: "Couldn't load the next video. Try again?",
+        variant: 'destructive',
+      });
+      return;
+    }
 
     navigate(buildNavigationUrl(nextVideo, navigationIndexBase + currentIndex + 1));
   }, [
@@ -120,10 +140,13 @@ export function VideoPage() {
     isUsingFunnelcakeVideos,
     funnelcakeHasNextPage,
     fetchNextFunnelcakePage,
+    isFetchingNextFunnelcakePage,
     currentIndex,
     navigate,
     buildNavigationUrl,
     navigationIndexBase,
+    toast,
+    t,
   ]);
 
   const goToPrevious = useCallback(() => {
@@ -222,7 +245,6 @@ export function VideoPage() {
     videosForInteractions,
     user?.pubkey
   );
-  const { toast } = useToast();
   const queryClient = useQueryClient();
   const { mutateAsync: publishEvent } = useNostrPublish();
   const { mutateAsync: repostVideo, isPending: isReposting } = useRepostVideo();


### PR DESCRIPTION
## Summary

- Preserve featured Discovery tab context in video navigation URLs.
- Resolve featured next/previous neighbors from the eligible Funnelcake featured tab order instead of the relay trending feed.
- Share featured page size and URL parse/build helpers so detail navigation stays aligned with feed links.

> Avoid naming corporate partners, customers, or other sensitive external brands in this PR title or body. Use generic descriptors unless a maintainer explicitly approves the public reference.

## Motivation

- Videos opened from featured Discovery tabs were losing the tab id and falling back to trending relay navigation, which broke server-ordered featured next/previous behavior.

## Related Issue

- Closes #559

## Testing

- [x] `npm run test`
- [ ] Manual verification completed

## Visuals

- [ ] UI change with screenshots/video attached
- [x] No visual change
- [x] Visuals and text avoid sensitive external brand or partner names unless explicitly approved
