### PR TITLE
fix(badges): read profile badges from kind 10008

### DIFF
--- a/src/config/relays.ts
+++ b/src/config/relays.ts
@@ -116,7 +116,7 @@ export const PRESET_RELAYS: RelayConfig[] = [
 ];
 
 /**
- * Relays used for NIP-58 badge queries (kinds 30009, 8, 30008)
+ * Relays used for NIP-58 badge queries (kinds 30009, 8, 10008, 30008)
  * Badge events may not be accepted by all relays, so we query a broad set.
  * Includes Divine relay (once kinds are allowlisted) plus public relays.
  */

--- a/src/hooks/useBadges.test.ts
+++ b/src/hooks/useBadges.test.ts
@@ -5,6 +5,10 @@ import React from 'react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { act, renderHook, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { NostrEvent, NostrFilter } from '@nostrify/nostrify';
+
+import { BADGE_KINDS } from '@/lib/badges';
+
 import { useBadges } from './useBadges';
 
 const mockNostrQuery = vi.fn();
@@ -18,6 +22,60 @@ vi.mock('@nostrify/react', () => ({
 }));
 
 const TEST_PUBKEY = 'a'.repeat(64);
+const ISSUER_PUBKEY = 'b'.repeat(64);
+
+function makeEvent(opts: Partial<NostrEvent> = {}): NostrEvent {
+  return {
+    id: 'f'.repeat(64),
+    pubkey: TEST_PUBKEY,
+    created_at: 1_700_000_000,
+    kind: 1,
+    tags: [],
+    content: '',
+    sig: '0'.repeat(128),
+    ...opts,
+  };
+}
+
+function makeDefinition(dTag: string): NostrEvent {
+  return makeEvent({
+    id: `${dTag.length}`.repeat(64).slice(0, 64),
+    pubkey: ISSUER_PUBKEY,
+    kind: BADGE_KINDS.DEFINITION,
+    tags: [
+      ['d', dTag],
+      ['name', `Badge ${dTag}`],
+      ['description', `Description ${dTag}`],
+      ['image', `https://example.com/${dTag}.png`],
+    ],
+  });
+}
+
+function makeAward(dTag: string, id = `${dTag.length + 1}`.repeat(64).slice(0, 64)): NostrEvent {
+  return makeEvent({
+    id,
+    pubkey: ISSUER_PUBKEY,
+    kind: BADGE_KINDS.AWARD,
+    tags: [
+      ['a', `30009:${ISSUER_PUBKEY}:${dTag}`],
+      ['p', TEST_PUBKEY],
+    ],
+  });
+}
+
+function makeProfileBadges(kind: number, dTag: string, awardId: string, createdAt = 1_700_000_000): NostrEvent {
+  return makeEvent({
+    id: `${kind}`.repeat(64).slice(0, 64),
+    pubkey: TEST_PUBKEY,
+    kind,
+    created_at: createdAt,
+    tags: [
+      ...(kind === 30008 ? [['d', 'profile_badges']] : []),
+      ['a', `30009:${ISSUER_PUBKEY}:${dTag}`],
+      ['e', awardId],
+    ],
+  });
+}
 
 function createWrapper() {
   const queryClient = new QueryClient({
@@ -38,6 +96,114 @@ describe('useBadges', () => {
 
   afterEach(() => {
     vi.useRealTimers();
+  });
+
+  it('fetches and validates badges from kind 10008 profile badges', async () => {
+    const award = makeAward('current', '1'.repeat(64));
+    const definition = makeDefinition('current');
+    const profileBadges = makeProfileBadges(10008, 'current', award.id);
+
+    mockNostrQuery
+      .mockResolvedValueOnce([profileBadges])
+      .mockResolvedValueOnce([definition])
+      .mockResolvedValueOnce([award]);
+
+    const { result } = renderHook(
+      () => useBadges(TEST_PUBKEY),
+      { wrapper: createWrapper() },
+    );
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data).toHaveLength(1);
+    expect(result.current.data?.[0].definition.dTag).toBe('current');
+    const profileFilters = mockNostrQuery.mock.calls[0][0] as NostrFilter[];
+    expect(profileFilters).toEqual([
+      { kinds: [10008], authors: [TEST_PUBKEY], limit: 10 },
+      {
+        kinds: [30008],
+        authors: [TEST_PUBKEY],
+        '#d': ['profile_badges'],
+        limit: 10,
+      },
+    ]);
+  });
+
+  it('keeps legacy kind 30008 profile_badges rendering', async () => {
+    const award = makeAward('legacy', '2'.repeat(64));
+    const definition = makeDefinition('legacy');
+    const profileBadges = makeProfileBadges(30008, 'legacy', award.id);
+
+    mockNostrQuery
+      .mockResolvedValueOnce([profileBadges])
+      .mockResolvedValueOnce([definition])
+      .mockResolvedValueOnce([award]);
+
+    const { result } = renderHook(
+      () => useBadges(TEST_PUBKEY),
+      { wrapper: createWrapper() },
+    );
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data?.[0].definition.dTag).toBe('legacy');
+  });
+
+  it('uses a newer legacy profile badges event over an older kind 10008 event', async () => {
+    const award = makeAward('newer-legacy', '3'.repeat(64));
+    const definition = makeDefinition('newer-legacy');
+    const current = makeProfileBadges(10008, 'current-old', '4'.repeat(64), 10);
+    const legacy = makeProfileBadges(30008, 'newer-legacy', award.id, 20);
+
+    mockNostrQuery
+      .mockResolvedValueOnce([current, legacy])
+      .mockResolvedValueOnce([definition])
+      .mockResolvedValueOnce([award]);
+
+    const { result } = renderHook(
+      () => useBadges(TEST_PUBKEY),
+      { wrapper: createWrapper() },
+    );
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data?.[0].definition.dTag).toBe('newer-legacy');
+  });
+
+  it('falls back to awards only when no profile badges event exists', async () => {
+    const award = makeAward('fallback', '5'.repeat(64));
+    const definition = makeDefinition('fallback');
+
+    mockNostrQuery
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([award])
+      .mockResolvedValueOnce([definition]);
+
+    const { result } = renderHook(
+      () => useBadges(TEST_PUBKEY),
+      { wrapper: createWrapper() },
+    );
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data?.[0].definition.dTag).toBe('fallback');
+  });
+
+  it('returns an empty list without awards fallback when profile badges has no refs', async () => {
+    mockNostrQuery.mockResolvedValueOnce([
+      makeEvent({
+        id: '6'.repeat(64),
+        pubkey: TEST_PUBKEY,
+        kind: 10008,
+        tags: [],
+      }),
+    ]);
+
+    const { result } = renderHook(
+      () => useBadges(TEST_PUBKEY),
+      { wrapper: createWrapper() },
+    );
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual([]);
+    expect(mockNostrQuery).toHaveBeenCalledTimes(1);
   });
 
   it('settles with an empty list when the timed-out relay query throws on abort', async () => {

--- a/src/hooks/useBadges.ts
+++ b/src/hooks/useBadges.ts
@@ -1,5 +1,5 @@
 // ABOUTME: Hook to fetch and validate NIP-58 badges for a user profile
-// ABOUTME: Subscribes to kinds 30008, 30009, and 8 to build the full badge chain
+// ABOUTME: Subscribes to kinds 10008, 30008, 30009, and 8 to build the full badge chain
 
 import { useNostr } from '@nostrify/react';
 import { useQuery } from '@tanstack/react-query';
@@ -8,6 +8,7 @@ import {
   BADGE_KINDS,
   parseBadgeDefinition,
   parseProfileBadges,
+  selectProfileBadgesEvent,
   validateBadgeAward,
   getCachedDefinition,
   cacheDefinition,
@@ -18,13 +19,13 @@ import {
  * Fetch and validate all displayable badges for a given pubkey.
  *
  * Flow:
- * 1. Fetch kind 30008 (profile_badges) for the user
+ * 1. Fetch kind 10008 and legacy kind 30008 (profile_badges) for the user
  * 2. For each badge reference, fetch the kind 30009 definition and kind 8 award
  * 3. Validate the chain: definition → award → user
  * 4. Return only validated badges in display order
  */
 /**
- * Shared time budget for the whole badge fan-out (kinds 30008/30009 are
+ * Shared time budget for the whole badge fan-out (kinds 10008/30008/30009 are
  * addressable, so NPool waits for every relay to EOSE — one hung relay would
  * otherwise block the query forever; same failure mode as issue #415).
  */
@@ -47,18 +48,24 @@ export function useBadges(pubkey: string | undefined) {
 
       const signal = AbortSignal.any([querySignal, AbortSignal.timeout(BADGES_QUERY_TIMEOUT_MS)]);
 
-      // Step 1: Fetch profile badges (kind 30008)
-      const profileBadgeFilter: NostrFilter = {
-        kinds: [BADGE_KINDS.PROFILE_BADGES],
-        authors: [pubkey],
-        '#d': ['profile_badges'],
-        limit: 1,
-      };
+      const profileBadgeFilters: NostrFilter[] = [
+        {
+          kinds: [BADGE_KINDS.PROFILE_BADGES],
+          authors: [pubkey],
+          limit: 10,
+        },
+        {
+          kinds: [BADGE_KINDS.PROFILE_BADGES_LEGACY],
+          authors: [pubkey],
+          '#d': ['profile_badges'],
+          limit: 10,
+        },
+      ];
 
       let profileBadgeEvents: NostrEvent[] = [];
       try {
         profileBadgeEvents = await nostr.query(
-          [profileBadgeFilter],
+          profileBadgeFilters,
           { signal }
         );
       } catch (error) {
@@ -66,8 +73,10 @@ export function useBadges(pubkey: string | undefined) {
         return [];
       }
 
-      // Fallback: if no profile_badges event, show all awarded badges
-      if (!profileBadgeEvents.length) {
+      const profileBadgeEvent = selectProfileBadgesEvent(profileBadgeEvents);
+
+      // Fallback: if no profile badges event exists in either encoding, show all awarded badges
+      if (!profileBadgeEvent) {
         // Fetch all badge awards for this user
         const awardFilter: NostrFilter = {
           kinds: [BADGE_KINDS.AWARD],
@@ -120,11 +129,6 @@ export function useBadges(pubkey: string | undefined) {
         }
         return fallbackValidated;
       }
-
-      // Use the most recent one (addressable event, should be only one)
-      const profileBadgeEvent = profileBadgeEvents.sort(
-        (a, b) => b.created_at - a.created_at
-      )[0];
 
       const badgeRefs = parseProfileBadges(profileBadgeEvent);
       if (!badgeRefs.length) return [];

--- a/src/lib/badges.test.ts
+++ b/src/lib/badges.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it } from 'vitest';
+import type { NostrEvent } from '@nostrify/nostrify';
+
+import {
+  BADGE_KINDS,
+  isProfileBadgesEvent,
+  parseProfileBadges,
+  selectProfileBadgesEvent,
+} from './badges';
+
+const USER_PUBKEY = 'a'.repeat(64);
+
+function makeEvent(opts: Partial<NostrEvent> = {}): NostrEvent {
+  return {
+    id: 'f'.repeat(64),
+    pubkey: USER_PUBKEY,
+    created_at: 1_700_000_000,
+    kind: BADGE_KINDS.PROFILE_BADGES,
+    tags: [],
+    content: '',
+    sig: '0'.repeat(128),
+    ...opts,
+  };
+}
+
+describe('profile badge parsing', () => {
+  it('parses adjacent a/e pairs from kind 10008 profile badges', () => {
+    const event = makeEvent({
+      kind: 10008,
+      tags: [
+        ['a', `30009:${USER_PUBKEY}:one`],
+        ['e', '1'.repeat(64)],
+        ['a', `30009:${USER_PUBKEY}:two`],
+        ['e', '2'.repeat(64)],
+      ],
+    });
+
+    expect(parseProfileBadges(event)).toEqual([
+      { naddr: `30009:${USER_PUBKEY}:one`, awardId: '1'.repeat(64) },
+      { naddr: `30009:${USER_PUBKEY}:two`, awardId: '2'.repeat(64) },
+    ]);
+  });
+
+  it('parses legacy kind 30008 profile_badges events', () => {
+    const event = makeEvent({
+      kind: 30008,
+      tags: [
+        ['d', 'profile_badges'],
+        ['a', `30009:${USER_PUBKEY}:legacy`],
+        ['e', '3'.repeat(64)],
+      ],
+    });
+
+    expect(isProfileBadgesEvent(event)).toBe(true);
+    expect(parseProfileBadges(event)).toEqual([
+      { naddr: `30009:${USER_PUBKEY}:legacy`, awardId: '3'.repeat(64) },
+    ]);
+  });
+
+  it('rejects legacy kind 30008 events without d=profile_badges', () => {
+    const event = makeEvent({
+      kind: 30008,
+      tags: [
+        ['d', 'other_badge_set'],
+        ['a', `30009:${USER_PUBKEY}:other`],
+        ['e', '4'.repeat(64)],
+      ],
+    });
+
+    expect(isProfileBadgesEvent(event)).toBe(false);
+    expect(parseProfileBadges(event)).toEqual([]);
+  });
+
+  it('pairs only adjacent a/e tags', () => {
+    const event = makeEvent({
+      kind: 10008,
+      tags: [
+        ['a', `30009:${USER_PUBKEY}:orphaned`],
+        ['a', `30009:${USER_PUBKEY}:paired`],
+        ['e', '5'.repeat(64)],
+      ],
+    });
+
+    expect(parseProfileBadges(event)).toEqual([
+      { naddr: `30009:${USER_PUBKEY}:paired`, awardId: '5'.repeat(64) },
+    ]);
+  });
+});
+
+describe('selectProfileBadgesEvent', () => {
+  it('selects the newest profile badges event', () => {
+    const older = makeEvent({ id: '2'.repeat(64), kind: 10008, created_at: 10 });
+    const newer = makeEvent({
+      id: '1'.repeat(64),
+      kind: 30008,
+      created_at: 20,
+      tags: [['d', 'profile_badges']],
+    });
+
+    expect(selectProfileBadgesEvent([older, newer])).toBe(newer);
+  });
+
+  it('prefers kind 10008 when timestamps tie', () => {
+    const legacy = makeEvent({
+      id: '1'.repeat(64),
+      kind: 30008,
+      created_at: 10,
+      tags: [['d', 'profile_badges']],
+    });
+    const current = makeEvent({ id: '2'.repeat(64), kind: 10008, created_at: 10 });
+
+    expect(selectProfileBadgesEvent([legacy, current])).toBe(current);
+  });
+
+  it('uses lowest event id as the final tie-break', () => {
+    const higher = makeEvent({ id: 'f'.repeat(64), kind: 10008, created_at: 10 });
+    const lower = makeEvent({ id: '0'.repeat(64), kind: 10008, created_at: 10 });
+
+    expect(selectProfileBadgesEvent([higher, lower])).toBe(lower);
+  });
+
+  it('returns null when no profile badges event exists', () => {
+    const otherSet = makeEvent({
+      kind: 30008,
+      tags: [['d', 'other_badge_set']],
+    });
+
+    expect(selectProfileBadgesEvent([otherSet])).toBeNull();
+  });
+});

--- a/src/lib/badges.ts
+++ b/src/lib/badges.ts
@@ -1,5 +1,5 @@
 // ABOUTME: NIP-58 badge utilities - validation, parsing, and caching
-// ABOUTME: Handles badge definitions (kind 30009), awards (kind 8), and profile badges (kind 30008)
+// ABOUTME: Handles badge definitions (kind 30009), awards (kind 8), and profile badges (kind 10008/30008)
 
 import type { NostrEvent } from '@nostrify/nostrify';
 
@@ -13,8 +13,11 @@ export const DIVINE_BADGE_PUBKEY = 'b3a706bcceb39f193da553ce76255dd6ba5b097001c8
 export const BADGE_KINDS = {
   DEFINITION: 30009,
   AWARD: 8,
-  PROFILE_BADGES: 30008,
+  PROFILE_BADGES: 10008,
+  PROFILE_BADGES_LEGACY: 30008,
 } as const;
+
+export const BADGE_READ_KINDS = Object.values(BADGE_KINDS) as number[];
 
 /** Parsed badge definition from a kind 30009 event */
 export interface BadgeDefinition {
@@ -111,27 +114,44 @@ export function getBadgeImageUrl(def: BadgeDefinition, targetSize: number): stri
   return def.image;
 }
 
+export function isProfileBadgesEvent(event: NostrEvent): boolean {
+  if (event.kind === BADGE_KINDS.PROFILE_BADGES) return true;
+  if (event.kind !== BADGE_KINDS.PROFILE_BADGES_LEGACY) return false;
+  return event.tags.some(t => t[0] === 'd' && t[1] === 'profile_badges');
+}
+
+export function selectProfileBadgesEvent(events: NostrEvent[]): NostrEvent | null {
+  const profileBadgeEvents = events.filter(isProfileBadgesEvent);
+  if (!profileBadgeEvents.length) return null;
+
+  return [...profileBadgeEvents].sort((a, b) => {
+    if (a.created_at !== b.created_at) return b.created_at - a.created_at;
+    if (a.kind !== b.kind) {
+      if (a.kind === BADGE_KINDS.PROFILE_BADGES) return -1;
+      if (b.kind === BADGE_KINDS.PROFILE_BADGES) return 1;
+    }
+    return a.id.localeCompare(b.id);
+  })[0];
+}
+
 /**
- * Parse `a` tags from a kind 30008 profile badges event.
+ * Parse `a`/`e` tag pairs from a kind 10008 or legacy 30008 profile badges event.
  * Returns pairs of [naddr, awardEventId] in display order.
  */
 export function parseProfileBadges(event: NostrEvent): Array<{ naddr: string; awardId: string }> {
-  if (event.kind !== BADGE_KINDS.PROFILE_BADGES) return [];
+  if (!isProfileBadgesEvent(event)) return [];
 
   const results: Array<{ naddr: string; awardId: string }> = [];
   const tags = event.tags;
 
-  // Profile badges use alternating a/e tag pairs after the d tag
-  for (let i = 0; i < tags.length; i++) {
-    if (tags[i][0] === 'a' && tags[i][1]) {
-      // Look for the next e tag
-      const nextE = tags.find((t, j) => j > i && t[0] === 'e');
-      if (nextE?.[1]) {
-        results.push({
-          naddr: tags[i][1],
-          awardId: nextE[1],
-        });
-      }
+  for (let i = 0; i < tags.length - 1; i++) {
+    const aTag = tags[i];
+    const eTag = tags[i + 1];
+    if (aTag[0] === 'a' && aTag[1] && eTag[0] === 'e' && eTag[1]) {
+      results.push({
+        naddr: aTag[1],
+        awardId: eTag[1],
+      });
     }
   }
 

--- a/src/lib/badges.ts
+++ b/src/lib/badges.ts
@@ -130,7 +130,11 @@ export function selectProfileBadgesEvent(events: NostrEvent[]): NostrEvent | nul
       if (a.kind === BADGE_KINDS.PROFILE_BADGES) return -1;
       if (b.kind === BADGE_KINDS.PROFILE_BADGES) return 1;
     }
-    return a.id.localeCompare(b.id);
+    // NIP-01 tie-break: retain the lowest event id in lexical (code-point)
+    // order. Event ids are lowercase hex, so a direct string compare is the
+    // spec's byte order; localeCompare could reorder under some locales.
+    if (a.id !== b.id) return a.id < b.id ? -1 : 1;
+    return 0;
   })[0];
 }
 

--- a/src/lib/relayRouting.test.ts
+++ b/src/lib/relayRouting.test.ts
@@ -116,12 +116,14 @@ describe('buildReqRouter — kind-based routing', () => {
     expect(result.size).toBeGreaterThan(0);
   });
 
-  it('routes BADGE_KINDS to BADGE_RELAYS', () => {
-    const filter: NostrFilter = { kinds: [30009] };
-    const result = buildReqRouter(ctx)([filter]);
+  it.each([30009, 8, 30008, 10008])('routes badge kind %i to BADGE_RELAYS', (kind) => {
+    const pickTopN = vi.fn((urls: string[]) => urls.slice(0, 3));
+    const filter: NostrFilter = { kinds: [kind] };
+    const result = buildReqRouter({ ...ctx, pickTopN })([filter]);
     for (const url of result.keys()) {
       expect(BADGE_RELAYS.some((r) => r.url === url)).toBe(true);
     }
+    expect(pickTopN).toHaveBeenCalledWith(getRelayUrls(BADGE_RELAYS), 3, undefined);
   });
 
   it('routes video filters through health-ranked relays and marks sticky', () => {

--- a/src/lib/relayRouting.ts
+++ b/src/lib/relayRouting.ts
@@ -5,9 +5,9 @@
 import type { NostrEvent, NostrFilter } from '@nostrify/nostrify';
 import { MUTE_LIST_KIND } from '@/hooks/useModeration';
 import { BADGE_RELAYS, PROFILE_RELAYS, getRelayUrls } from '@/config/relays';
+import { BADGE_READ_KINDS } from '@/lib/badges';
 import { VIDEO_KINDS } from '@/types/video';
 
-const BADGE_KINDS = [30009, 8, 30008];
 const LIST_KINDS = [30000, 30001, 30005];
 
 export interface RoutingContext {
@@ -52,7 +52,7 @@ export function buildReqRouter(ctx: RoutingContext): ReqRouter {
     for (const filter of filters) {
       if (filter.kinds?.includes(0) || filter.kinds?.includes(3) || filter.kinds?.includes(10011)) {
         profileRelayFilters.push(filter);
-      } else if (filter.kinds?.some((k) => BADGE_KINDS.includes(k))) {
+      } else if (filter.kinds?.some((k) => BADGE_READ_KINDS.includes(k))) {
         badgeRelayFilters.push(filter);
       } else if (filter.kinds?.some((k) => VIDEO_KINDS.includes(k))) {
         videoFilters.push(filter);


### PR DESCRIPTION
## Summary

- Read accepted profile badge lists from current NIP-58 kind `10008` and legacy `30008`/`d=profile_badges`.
- Select the active profile-badges event by newest `created_at`, then prefer kind `10008`, then lowest event id.
- Route all badge read kinds through `BADGE_RELAYS` from the shared badge kind constants.

> Avoid naming corporate partners, customers, or other sensitive external brands in this PR title or body. Use generic descriptors unless a maintainer explicitly approves the public reference.

## Motivation

- Mobile now writes accepted profile badges as kind `10008`; web only read legacy `30008`, so mobile badge accepts/removals were not reflected on web profiles.
- Keeping the fallback-to-awards path only when neither profile-badges encoding exists preserves explicit empty badge lists.

## Related Issue

- Closes #521

## Testing

- [x] `npm run test`
- [x] Manual verification completed: focused red/green regression run with `npx vitest run src/lib/badges.test.ts src/hooks/useBadges.test.ts src/lib/relayRouting.test.ts`

## Visuals

- [ ] UI change with screenshots/video attached
- [x] No visual change
- [x] Visuals and text avoid sensitive external brand or partner names unless explicitly approved
