### PR TITLE
fix(dm): bound remote relay admission

### DIFF
--- a/src/config/relays.test.ts
+++ b/src/config/relays.test.ts
@@ -1,6 +1,17 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import { getFunnelcakeUrl, hasFunnelcake, PROFILE_RELAYS, PRESET_RELAYS, EVENT_LOOKUP_RELAYS } from './relays';
+import {
+  EVENT_LOOKUP_RELAYS,
+  getEventLookupRelayUrls,
+  getFunnelcakeUrl,
+  hasFunnelcake,
+  PRESET_RELAYS,
+  PROFILE_RELAYS,
+} from './relays';
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
 
 describe('hasFunnelcake', () => {
   it('recognizes the production Divine relay', () => {
@@ -48,5 +59,42 @@ describe('PRESET_RELAYS', () => {
   it('does not contain duplicate URLs', () => {
     const urls = PRESET_RELAYS.map((r) => r.url);
     expect(new Set(urls).size).toBe(urls.length);
+  });
+});
+
+describe('getEventLookupRelayUrls', () => {
+  it('rejects remote relay hints with private hosts or non-wss schemes', () => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const relays = getEventLookupRelayUrls({
+      configuredRelayUrls: ['wss://configured.example'],
+      relayHints: [
+        'ws://relay.example',
+        'wss://192.168.1.10',
+        'wss://hint.example',
+      ],
+    });
+
+    expect(relays).toContain('wss://configured.example');
+    expect(relays).toContain('wss://hint.example');
+    expect(relays).not.toContain('ws://relay.example');
+    expect(relays).not.toContain('wss://192.168.1.10');
+  });
+
+  it('caps remote relay hints before adding configured and default lookup relays', () => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const relayHints = Array.from(
+      { length: 12 },
+      (_, index) => `wss://hint-${index}.example`,
+    );
+
+    const relays = getEventLookupRelayUrls({
+      configuredRelayUrls: ['wss://configured.example'],
+      relayHints,
+    });
+
+    expect(relays.filter((relay) => relay.startsWith('wss://hint-'))).toEqual(relayHints.slice(0, 8));
+    expect(relays).toContain('wss://configured.example');
+    expect(relays).toContain(EVENT_LOOKUP_RELAYS[0].url);
   });
 });

--- a/src/config/relays.ts
+++ b/src/config/relays.ts
@@ -1,6 +1,12 @@
 // ABOUTME: Centralized relay configuration for the entire application
 // ABOUTME: Single source of truth for all relay URLs and their purposes
 
+import {
+  REMOTE_RELAY_HINT_CAP,
+  admitRelayUrls,
+  admitRemoteSuppliedRelays,
+} from '@/lib/relayUrlPolicy';
+
 /**
  * Relay configuration with metadata
  */
@@ -183,11 +189,15 @@ export const getRelayUrls = (relays: RelayConfig[]): string[] =>
   relays.map(r => r.url);
 
 function dedupeRelayUrls(urls: Array<string | null | undefined>): string[] {
-  return [...new Set(
-    urls
-      .map(url => url?.trim())
-      .filter((url): url is string => Boolean(url))
-  )];
+  return admitRelayUrls(urls.filter((url): url is string => Boolean(url)));
+}
+
+function warnRejectedRelayHint(relayUrl: string, reason: string): void {
+  console.warn(`[Relay] Rejected remote relay hint "${relayUrl}": ${reason}`);
+}
+
+function warnTruncatedRelayHints(droppedCount: number): void {
+  console.warn(`[Relay] Truncated remote relay hints by ${droppedCount} entries`);
 }
 
 export function getEventLookupRelayUrls(options?: {
@@ -196,7 +206,11 @@ export function getEventLookupRelayUrls(options?: {
 }): string[] {
   return dedupeRelayUrls([
     ...(options?.configuredRelayUrls ?? []),
-    ...(options?.relayHints ?? []),
+    ...admitRemoteSuppliedRelays(options?.relayHints ?? [], {
+      cap: REMOTE_RELAY_HINT_CAP,
+      onRejected: warnRejectedRelayHint,
+      onTruncated: warnTruncatedRelayHints,
+    }),
     ...getRelayUrls(EVENT_LOOKUP_RELAYS),
   ]);
 }

--- a/src/lib/dm.ts
+++ b/src/lib/dm.ts
@@ -5,6 +5,11 @@ import { finalizeEvent, generateSecretKey, nip44, verifyEvent } from 'nostr-tool
 
 import { PRESET_RELAYS, PROFILE_RELAYS, getRelayUrls } from '@/config/relays';
 import { DIVINE_MODERATION_PUBKEY } from '@/lib/officialAccounts';
+import {
+  REMOTE_RELAY_HINT_CAP,
+  admitRelayUrls,
+  admitRemoteSuppliedRelays,
+} from '@/lib/relayUrlPolicy';
 import { getApexShareUrl } from '@/lib/subdomainLinks';
 import { SHORT_VIDEO_KIND } from '@/types/video';
 
@@ -131,12 +136,15 @@ function randomNow(): number {
 }
 
 function normalizeRelayUrls(relayUrls: string[]): string[] {
-  return [...new Set(
-    relayUrls
-      .map((relayUrl) => relayUrl.trim())
-      .filter(Boolean)
-      .filter((relayUrl) => relayUrl.startsWith('ws://') || relayUrl.startsWith('wss://')),
-  )];
+  return admitRelayUrls(relayUrls);
+}
+
+function warnRejectedDmRelay(relayUrl: string, reason: string): void {
+  console.warn(`[DM] Rejected remote relay URL "${relayUrl}": ${reason}`);
+}
+
+function warnTruncatedDmRelayList(droppedCount: number): void {
+  console.warn(`[DM] Truncated remote relay list by ${droppedCount} entries`);
 }
 
 function isPubkey(value: string): boolean {
@@ -274,6 +282,7 @@ async function publishEventToAllRelays(
 async function queryPreferredRelayMap(
   relayUrls: string[],
   authors: string[],
+  relayTrust: 'self' | 'remote',
   signal?: AbortSignal,
 ): Promise<Record<string, string[]>> {
   if (!authors.length || !relayUrls.length) {
@@ -302,11 +311,16 @@ async function queryPreferredRelayMap(
 
     return Object.fromEntries(
       [...newestEvents.entries()].map(([pubkey, event]) => {
-        const urls = normalizeRelayUrls(
-          event.tags
-            .filter((tag) => (tag[0] === 'r' || tag[0] === 'relay') && typeof tag[1] === 'string')
-            .map((tag) => tag[1]),
-        );
+        const relayTags = event.tags
+          .filter((tag) => (tag[0] === 'r' || tag[0] === 'relay') && typeof tag[1] === 'string')
+          .map((tag) => tag[1]);
+        const urls = relayTrust === 'remote'
+          ? admitRemoteSuppliedRelays(relayTags, {
+              cap: REMOTE_RELAY_HINT_CAP,
+              onRejected: warnRejectedDmRelay,
+              onTruncated: warnTruncatedDmRelayList,
+            })
+          : normalizeRelayUrls(relayTags);
         return [pubkey, urls];
       }),
     );
@@ -636,7 +650,7 @@ export async function resolveDmReadRelays(input: ResolveDmRelaysInput): Promise<
     : [];
 
   const preferredRelayMap = currentUserPubkey
-    ? await queryPreferredRelayMap(fallbackRelays, [currentUserPubkey], signal).catch(() => ({}))
+    ? await queryPreferredRelayMap(fallbackRelays, [currentUserPubkey], 'self', signal).catch(() => ({}))
     : {};
 
   return normalizeRelayUrls([
@@ -661,7 +675,7 @@ export async function resolveDmWriteRelays(input: ResolveDmRelaysInput): Promise
       )
     : [];
 
-  const preferredRelayMap = await queryPreferredRelayMap(fallbackRelays, recipientPubkeys, signal).catch(() => ({}));
+  const preferredRelayMap = await queryPreferredRelayMap(fallbackRelays, recipientPubkeys, 'remote', signal).catch(() => ({}));
 
   return normalizeRelayUrls([
     ...fallbackRelays,

--- a/src/lib/dmRelayAdmission.test.ts
+++ b/src/lib/dmRelayAdmission.test.ts
@@ -1,0 +1,124 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { NostrEvent } from '@nostrify/nostrify';
+
+const mockQuery = vi.fn();
+const mockClose = vi.fn();
+let warnSpy: ReturnType<typeof vi.spyOn> | undefined;
+
+vi.mock('@nostrify/nostrify', () => ({
+  NPool: vi.fn().mockImplementation(() => ({
+    query: mockQuery,
+    close: mockClose,
+  })),
+  NRelay1: vi.fn(),
+}));
+
+function relayListEvent(pubkey: string, relays: string[]): NostrEvent {
+  return {
+    id: `${pubkey.slice(0, 8)}${'0'.repeat(56)}`,
+    pubkey,
+    created_at: 1_700_000_000,
+    kind: 10050,
+    tags: relays.map((relay) => ['r', relay]),
+    content: '',
+    sig: '0'.repeat(128),
+  };
+}
+
+describe('DM relay admission', () => {
+  let resolveDmReadRelays: typeof import('@/lib/dm').resolveDmReadRelays;
+  let resolveDmWriteRelays: typeof import('@/lib/dm').resolveDmWriteRelays;
+
+  beforeEach(async () => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const dm = await import('@/lib/dm');
+    resolveDmReadRelays = dm.resolveDmReadRelays;
+    resolveDmWriteRelays = dm.resolveDmWriteRelays;
+  });
+
+  afterEach(() => {
+    warnSpy?.mockRestore();
+    warnSpy = undefined;
+  });
+
+  it('rejects private and non-wss recipient relays from DM write routing', async () => {
+    const recipient = 'a'.repeat(64);
+    mockQuery.mockResolvedValue([
+      relayListEvent(recipient, [
+        'ws://192.168.1.10',
+        'wss://127.0.0.1',
+        'wss://recipient.example',
+      ]),
+    ]);
+
+    const relays = await resolveDmWriteRelays({
+      appRelayUrls: ['wss://app.example'],
+      recipientPubkeys: [recipient],
+    });
+
+    expect(relays).toContain('wss://recipient.example');
+    expect(relays).not.toContain('ws://192.168.1.10');
+    expect(relays).not.toContain('wss://127.0.0.1');
+  });
+
+  it('caps each recipient relay list at eight entries', async () => {
+    const recipient = 'b'.repeat(64);
+    const remoteRelays = Array.from(
+      { length: 40 },
+      (_, index) => `wss://recipient-${index}.example`,
+    );
+    mockQuery.mockResolvedValue([relayListEvent(recipient, remoteRelays)]);
+
+    const relays = await resolveDmWriteRelays({
+      appRelayUrls: ['wss://app.example'],
+      recipientPubkeys: [recipient],
+    });
+
+    expect(relays.filter((relay) => relay.startsWith('wss://recipient-'))).toEqual(remoteRelays.slice(0, 8));
+  });
+
+  it('applies the cap per recipient rather than across the group', async () => {
+    const recipients = ['c'.repeat(64), 'd'.repeat(64), 'e'.repeat(64)];
+    mockQuery.mockResolvedValue(
+      recipients.map((recipient, recipientIndex) => relayListEvent(
+        recipient,
+        Array.from(
+          { length: 10 },
+          (_, relayIndex) => `wss://recipient-${recipientIndex}-${relayIndex}.example`,
+        ),
+      )),
+    );
+
+    const relays = await resolveDmWriteRelays({
+      appRelayUrls: ['wss://app.example'],
+      recipientPubkeys: recipients,
+    });
+
+    expect(relays.filter((relay) => relay.startsWith('wss://recipient-'))).toHaveLength(24);
+    for (const recipientIndex of [0, 1, 2]) {
+      expect(relays.filter((relay) => relay.startsWith(`wss://recipient-${recipientIndex}-`))).toHaveLength(8);
+    }
+  });
+
+  it('keeps loopback relays from the signed-in user relay list for DM reads', async () => {
+    const currentUser = 'f'.repeat(64);
+    mockQuery.mockResolvedValue([
+      relayListEvent(currentUser, [
+        'ws://localhost:7777',
+        'wss://reader.example',
+      ]),
+    ]);
+
+    const relays = await resolveDmReadRelays({
+      appRelayUrls: ['wss://app.example'],
+      currentUserPubkey: currentUser,
+    });
+
+    expect(relays).toContain('ws://localhost:7777');
+    expect(relays).toContain('wss://reader.example');
+  });
+});

--- a/src/lib/relayCapabilities.test.ts
+++ b/src/lib/relayCapabilities.test.ts
@@ -19,6 +19,44 @@ describe('getOptimisticRelayCapabilities (after #415 ditto.pub removal)', () => 
   });
 });
 
+describe('NIP-11 metadata URL', () => {
+  beforeEach(() => {
+    clearCapabilitiesCache();
+    relayHealth.reset();
+    vi.stubGlobal(
+      'WebSocket',
+      class {
+        constructor() {
+          throw new Error('probe not under test');
+        }
+      },
+    );
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  // The websocket->http mapping is a scheme concern, not an admission concern.
+  // Gating it on the relay admission policy left `ws://` on a public host
+  // unmapped, so `fetch` rejected the URL and NIP-11 silently never resolved.
+  it.each([
+    ['wss://relay.nostr.wine', 'https://relay.nostr.wine/'],
+    ['ws://localhost:7777', 'http://localhost:7777/'],
+    ['ws://relay.example', 'http://relay.example/'],
+  ])('fetches %s metadata over http(s)', async (relayUrl, expectedUrl) => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ supported_nips: [50] }),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await detectRelayCapabilities(relayUrl);
+
+    expect(fetchMock).toHaveBeenCalledWith(expectedUrl, expect.anything());
+  });
+});
+
 describe('detectRelayCapabilities failure path', () => {
   // Optimistic caps: NIP-50 yes, video sorts no — so a live probe is attempted.
   const URL = 'wss://relay.nostr.wine';

--- a/src/lib/relayCapabilities.ts
+++ b/src/lib/relayCapabilities.ts
@@ -3,6 +3,7 @@
 
 import type { SortMode } from '@/types/nostr';
 import { VIDEO_KINDS } from '@/types/video';
+import { isRelayUrlAllowed } from '@/lib/relayUrlPolicy';
 import { recordProbe } from './relayHealth';
 
 type CapabilitySource = 'optimistic' | 'nip11' | 'probe' | 'fallback';
@@ -32,7 +33,7 @@ const capabilitiesCache = new Map<string, RelayCapabilities>();
 
 function normalizeRelayUrl(relayUrl: string): URL | null {
   try {
-    if (relayUrl.startsWith('ws://') || relayUrl.startsWith('wss://')) {
+    if (isRelayUrlAllowed(relayUrl)) {
       return new URL(relayUrl.replace(/^ws/, 'http'));
     }
     return new URL(relayUrl);

--- a/src/lib/relayCapabilities.ts
+++ b/src/lib/relayCapabilities.ts
@@ -3,7 +3,6 @@
 
 import type { SortMode } from '@/types/nostr';
 import { VIDEO_KINDS } from '@/types/video';
-import { isRelayUrlAllowed } from '@/lib/relayUrlPolicy';
 import { recordProbe } from './relayHealth';
 
 type CapabilitySource = 'optimistic' | 'nip11' | 'probe' | 'fallback';
@@ -31,12 +30,17 @@ const VIDEO_SORT_MODES: SortMode[] = ['hot', 'top', 'rising', 'controversial'];
 const CACHE_DURATION = 5 * 60 * 1000;
 const capabilitiesCache = new Map<string, RelayCapabilities>();
 
+// Maps a relay URL onto the origin its NIP-11 document is served from. This is
+// a scheme question, not an admission question: admission is enforced where
+// relay lists are built, and reusing that predicate here would leave a `ws://`
+// URL that `fetch` rejects.
 function normalizeRelayUrl(relayUrl: string): URL | null {
   try {
-    if (isRelayUrlAllowed(relayUrl)) {
-      return new URL(relayUrl.replace(/^ws/, 'http'));
+    const url = new URL(relayUrl);
+    if (url.protocol === 'ws:' || url.protocol === 'wss:') {
+      url.protocol = url.protocol === 'ws:' ? 'http:' : 'https:';
     }
-    return new URL(relayUrl);
+    return url;
   } catch {
     return null;
   }

--- a/src/lib/relayUrl.ts
+++ b/src/lib/relayUrl.ts
@@ -1,11 +1,8 @@
 // ABOUTME: Helpers for validating relay URLs by scheme
 // ABOUTME: Uses the URL constructor instead of regex for correctness
 
+import { isRelayUrlAllowed } from '@/lib/relayUrlPolicy';
+
 export function isWssUrl(value: string): boolean {
-  if (!value) return false;
-  try {
-    return new URL(value).protocol === 'wss:';
-  } catch {
-    return false;
-  }
+  return isRelayUrlAllowed(value) && new URL(value.trim()).protocol === 'wss:';
 }

--- a/src/lib/relayUrlPolicy.test.ts
+++ b/src/lib/relayUrlPolicy.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  REMOTE_RELAY_HINT_CAP,
+  admitRemoteSuppliedRelays,
+  isPrivateOrLinkLocalHost,
+  isRelayUrlAllowed,
+  isRemoteSuppliedRelayUrlAllowed,
+} from '@/lib/relayUrlPolicy';
+
+describe('relayUrlPolicy', () => {
+  it('detects private and link-local IPv4 hosts after URL normalization', () => {
+    expect(isPrivateOrLinkLocalHost('0x7f.0.0.1')).toBe(true);
+    expect(isPrivateOrLinkLocalHost('2130706433')).toBe(true);
+    expect(isPrivateOrLinkLocalHost('127.1')).toBe(true);
+
+    for (const host of [
+      '0.1.2.3',
+      '10.0.0.1',
+      '100.64.0.1',
+      '127.0.0.1',
+      '169.254.1.1',
+      '172.16.0.1',
+      '172.31.255.255',
+      '192.168.0.1',
+      '224.0.0.1',
+    ]) {
+      expect(isPrivateOrLinkLocalHost(host)).toBe(true);
+    }
+  });
+
+  it('detects private IPv6, IPv4-mapped IPv6, and local hostnames', () => {
+    expect(isPrivateOrLinkLocalHost(new URL('wss://[::1]').hostname)).toBe(true);
+    expect(isPrivateOrLinkLocalHost(new URL('wss://[::ffff:10.0.0.1]').hostname)).toBe(true);
+    expect(isPrivateOrLinkLocalHost(new URL('wss://[fe80::1]').hostname)).toBe(true);
+    expect(isPrivateOrLinkLocalHost(new URL('wss://[fc00::1]').hostname)).toBe(true);
+    expect(isPrivateOrLinkLocalHost('localhost')).toBe(true);
+    expect(isPrivateOrLinkLocalHost('relay.local')).toBe(true);
+    expect(isPrivateOrLinkLocalHost('relay.internal')).toBe(true);
+    expect(isPrivateOrLinkLocalHost('relay.home.arpa')).toBe(true);
+  });
+
+  it('allows self/app wss relays and loopback ws relays only', () => {
+    expect(isRelayUrlAllowed('wss://relay.example')).toBe(true);
+    expect(isRelayUrlAllowed('ws://localhost:7777')).toBe(true);
+    expect(isRelayUrlAllowed('ws://127.0.0.1:7777')).toBe(true);
+    expect(isRelayUrlAllowed('ws://relay.example')).toBe(false);
+  });
+
+  it('requires remote-supplied relays to use wss and public hosts', () => {
+    expect(isRemoteSuppliedRelayUrlAllowed('wss://relay.example')).toBe(true);
+    expect(isRemoteSuppliedRelayUrlAllowed('ws://localhost:7777')).toBe(false);
+    expect(isRemoteSuppliedRelayUrlAllowed('wss://127.0.0.1')).toBe(false);
+    expect(isRemoteSuppliedRelayUrlAllowed('wss://[::ffff:192.168.0.1]')).toBe(false);
+    expect(isRemoteSuppliedRelayUrlAllowed('wss://http://evil.example')).toBe(false);
+  });
+
+  it('dedupes remote relays by parsed key while preserving first admitted values', () => {
+    expect(admitRemoteSuppliedRelays([
+      ' wss://relay.example ',
+      'wss://relay.example/',
+      'wss://second.example',
+    ])).toEqual([
+      'wss://relay.example',
+      'wss://second.example',
+    ]);
+  });
+
+  it('caps remote relay lists preserving order and reports truncation', () => {
+    const onTruncated = vi.fn();
+    const relays = Array.from(
+      { length: REMOTE_RELAY_HINT_CAP + 2 },
+      (_, index) => `wss://relay-${index}.example`,
+    );
+
+    expect(admitRemoteSuppliedRelays(relays, {
+      cap: REMOTE_RELAY_HINT_CAP,
+      onTruncated,
+    })).toEqual(relays.slice(0, REMOTE_RELAY_HINT_CAP));
+    expect(onTruncated).toHaveBeenCalledWith(2);
+  });
+
+  it('reports rejected remote relays', () => {
+    const onRejected = vi.fn();
+
+    expect(admitRemoteSuppliedRelays([
+      'not a url',
+      'wss://192.168.1.10',
+      'wss://relay.example',
+    ], { onRejected })).toEqual(['wss://relay.example']);
+    expect(onRejected).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/lib/relayUrlPolicy.ts
+++ b/src/lib/relayUrlPolicy.ts
@@ -1,3 +1,6 @@
+// ABOUTME: Shared admission policy for relay URLs, split by who supplied them
+// ABOUTME: Self/app lists may use loopback ws://; remote lists require public wss:// and are capped
+
 export const REMOTE_RELAY_HINT_CAP = 8;
 
 export interface RelayAdmissionOptions {
@@ -20,6 +23,9 @@ function parseRelayUrl(value: string): ParsedRelayUrl | null {
   try {
     const url = new URL(trimmed);
     if (url.protocol !== 'ws:' && url.protocol !== 'wss:') return null;
+    // Load-bearing: `wss://http://evil.example` parses to the single-label host
+    // `http` with pathname `//evil.example`. That host is not private, so the
+    // host filter alone would admit it. Do not remove without a replacement.
     if (url.pathname.startsWith('//')) return null;
     const protocol = url.protocol === 'ws:' ? 'ws:' : 'wss:';
 
@@ -154,17 +160,23 @@ export function isPrivateOrLinkLocalHost(hostname: string): boolean {
   return false;
 }
 
-export function isRelayUrlAllowed(value: string): boolean {
-  const parsed = parseRelayUrl(value);
-  if (!parsed) return false;
+function isParsedRelayAllowed(parsed: ParsedRelayUrl): boolean {
   if (parsed.protocol === 'wss:') return true;
   return isPrivateOrLinkLocalHost(parsed.hostname);
 }
 
+function isParsedRemoteSuppliedRelayAllowed(parsed: ParsedRelayUrl): boolean {
+  return parsed.protocol === 'wss:' && !isPrivateOrLinkLocalHost(parsed.hostname);
+}
+
+export function isRelayUrlAllowed(value: string): boolean {
+  const parsed = parseRelayUrl(value);
+  return parsed ? isParsedRelayAllowed(parsed) : false;
+}
+
 export function isRemoteSuppliedRelayUrlAllowed(value: string): boolean {
   const parsed = parseRelayUrl(value);
-  if (!parsed) return false;
-  return parsed.protocol === 'wss:' && !isPrivateOrLinkLocalHost(parsed.hostname);
+  return parsed ? isParsedRemoteSuppliedRelayAllowed(parsed) : false;
 }
 
 export function admitRelayUrls(relayUrls: string[]): string[] {
@@ -173,7 +185,7 @@ export function admitRelayUrls(relayUrls: string[]): string[] {
 
   for (const relayUrl of relayUrls) {
     const parsed = parseRelayUrl(relayUrl);
-    if (!parsed || !isRelayUrlAllowed(parsed.value) || seen.has(parsed.key)) continue;
+    if (!parsed || !isParsedRelayAllowed(parsed) || seen.has(parsed.key)) continue;
     seen.add(parsed.key);
     admitted.push(parsed.value);
   }
@@ -195,7 +207,7 @@ export function admitRemoteSuppliedRelays(
       continue;
     }
 
-    if (!isRemoteSuppliedRelayUrlAllowed(parsed.value)) {
+    if (!isParsedRemoteSuppliedRelayAllowed(parsed)) {
       options.onRejected?.(parsed.value, 'remote relay URL must use wss:// and a public host');
       continue;
     }

--- a/src/lib/relayUrlPolicy.ts
+++ b/src/lib/relayUrlPolicy.ts
@@ -1,0 +1,215 @@
+export const REMOTE_RELAY_HINT_CAP = 8;
+
+export interface RelayAdmissionOptions {
+  cap?: number;
+  onRejected?: (relayUrl: string, reason: string) => void;
+  onTruncated?: (droppedCount: number) => void;
+}
+
+interface ParsedRelayUrl {
+  value: string;
+  key: string;
+  protocol: 'ws:' | 'wss:';
+  hostname: string;
+}
+
+function parseRelayUrl(value: string): ParsedRelayUrl | null {
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+
+  try {
+    const url = new URL(trimmed);
+    if (url.protocol !== 'ws:' && url.protocol !== 'wss:') return null;
+    if (url.pathname.startsWith('//')) return null;
+    const protocol = url.protocol === 'ws:' ? 'ws:' : 'wss:';
+
+    url.hash = '';
+    url.protocol = url.protocol.toLowerCase();
+    url.hostname = url.hostname.toLowerCase();
+
+    return {
+      value: trimmed,
+      key: url.toString(),
+      protocol,
+      hostname: url.hostname.toLowerCase(),
+    };
+  } catch {
+    return null;
+  }
+}
+
+function parseIpv4(hostname: string): number | null {
+  const parts = hostname.split('.');
+  if (parts.length !== 4) return null;
+
+  let value = 0;
+  for (const part of parts) {
+    if (!/^\d+$/.test(part)) return null;
+    const octet = Number(part);
+    if (!Number.isInteger(octet) || octet < 0 || octet > 255) return null;
+    value = (value << 8) + octet;
+  }
+
+  return value >>> 0;
+}
+
+function parseIpv6(hostname: string): Uint8Array | null {
+  const unwrapped = hostname.startsWith('[') && hostname.endsWith(']')
+    ? hostname.slice(1, -1)
+    : hostname;
+  const zoneIndex = unwrapped.indexOf('%');
+  const host = (zoneIndex === -1 ? unwrapped : unwrapped.slice(0, zoneIndex)).toLowerCase();
+
+  if (!host.includes(':')) return null;
+
+  const sides = host.split('::');
+  if (sides.length > 2) return null;
+
+  const parseGroup = (group: string): number[] | null => {
+    if (!group) return [];
+    const values: number[] = [];
+    for (const part of group.split(':')) {
+      if (!/^[0-9a-f]{1,4}$/.test(part)) return null;
+      values.push(parseInt(part, 16));
+    }
+    return values;
+  };
+
+  const left = parseGroup(sides[0]);
+  const right = parseGroup(sides[1] ?? '');
+  if (!left || !right) return null;
+
+  const missing = sides.length === 2 ? 8 - left.length - right.length : 0;
+  if (missing < 0) return null;
+
+  const groups = sides.length === 2
+    ? [...left, ...Array(missing).fill(0), ...right]
+    : left;
+  if (groups.length !== 8) return null;
+
+  const bytes = new Uint8Array(16);
+  groups.forEach((group, index) => {
+    bytes[index * 2] = group >> 8;
+    bytes[index * 2 + 1] = group & 0xff;
+  });
+  return bytes;
+}
+
+function isPrivateIpv4(value: number): boolean {
+  const first = value >>> 24;
+  const second = (value >>> 16) & 0xff;
+
+  return (
+    first === 0 ||
+    first === 10 ||
+    first === 127 ||
+    (first === 100 && second >= 64 && second <= 127) ||
+    (first === 169 && second === 254) ||
+    (first === 172 && second >= 16 && second <= 31) ||
+    (first === 192 && second === 168) ||
+    first >= 224
+  );
+}
+
+function isPrivateIpv6(bytes: Uint8Array): boolean {
+  const isUnspecified = bytes.every((byte) => byte === 0);
+  const isLoopback = bytes.slice(0, 15).every((byte) => byte === 0) && bytes[15] === 1;
+  const isUniqueLocal = (bytes[0] & 0xfe) === 0xfc;
+  const isLinkLocal = bytes[0] === 0xfe && (bytes[1] & 0xc0) === 0x80;
+  const isMulticast = bytes[0] === 0xff;
+  const isIpv4Mapped = bytes.slice(0, 10).every((byte) => byte === 0) && bytes[10] === 0xff && bytes[11] === 0xff;
+
+  if (isIpv4Mapped) {
+    const ipv4 = ((bytes[12] << 24) | (bytes[13] << 16) | (bytes[14] << 8) | bytes[15]) >>> 0;
+    return isPrivateIpv4(ipv4);
+  }
+
+  return isUnspecified || isLoopback || isUniqueLocal || isLinkLocal || isMulticast;
+}
+
+export function isPrivateOrLinkLocalHost(hostname: string): boolean {
+  let host = hostname.toLowerCase();
+  try {
+    host = new URL(`wss://${host}`).hostname.toLowerCase();
+  } catch {
+    // Fall back to direct parsing for IPv6 strings that are already unwrapped.
+  }
+
+  if (
+    host === 'localhost' ||
+    host.endsWith('.localhost') ||
+    host.endsWith('.local') ||
+    host.endsWith('.internal') ||
+    host.endsWith('.home.arpa')
+  ) {
+    return true;
+  }
+
+  const ipv4 = parseIpv4(host);
+  if (ipv4 !== null) return isPrivateIpv4(ipv4);
+
+  const ipv6 = parseIpv6(host);
+  if (ipv6) return isPrivateIpv6(ipv6);
+
+  return false;
+}
+
+export function isRelayUrlAllowed(value: string): boolean {
+  const parsed = parseRelayUrl(value);
+  if (!parsed) return false;
+  if (parsed.protocol === 'wss:') return true;
+  return isPrivateOrLinkLocalHost(parsed.hostname);
+}
+
+export function isRemoteSuppliedRelayUrlAllowed(value: string): boolean {
+  const parsed = parseRelayUrl(value);
+  if (!parsed) return false;
+  return parsed.protocol === 'wss:' && !isPrivateOrLinkLocalHost(parsed.hostname);
+}
+
+export function admitRelayUrls(relayUrls: string[]): string[] {
+  const admitted: string[] = [];
+  const seen = new Set<string>();
+
+  for (const relayUrl of relayUrls) {
+    const parsed = parseRelayUrl(relayUrl);
+    if (!parsed || !isRelayUrlAllowed(parsed.value) || seen.has(parsed.key)) continue;
+    seen.add(parsed.key);
+    admitted.push(parsed.value);
+  }
+
+  return admitted;
+}
+
+export function admitRemoteSuppliedRelays(
+  relayUrls: string[],
+  options: RelayAdmissionOptions = {},
+): string[] {
+  const admitted: string[] = [];
+  const seen = new Set<string>();
+
+  for (const relayUrl of relayUrls) {
+    const parsed = parseRelayUrl(relayUrl);
+    if (!parsed) {
+      options.onRejected?.(relayUrl, 'invalid relay URL');
+      continue;
+    }
+
+    if (!isRemoteSuppliedRelayUrlAllowed(parsed.value)) {
+      options.onRejected?.(parsed.value, 'remote relay URL must use wss:// and a public host');
+      continue;
+    }
+
+    if (seen.has(parsed.key)) continue;
+    seen.add(parsed.key);
+    admitted.push(parsed.value);
+  }
+
+  if (options.cap !== undefined && admitted.length > options.cap) {
+    const droppedCount = admitted.length - options.cap;
+    options.onTruncated?.(droppedCount);
+    return admitted.slice(0, options.cap);
+  }
+
+  return admitted;
+}


### PR DESCRIPTION
## Summary

- Add a shared relay URL admission policy with URL parsing, private/link-local host detection, trust-tiered ws/wss handling, dedupe, and an 8-relay remote cap.
- Apply remote-supplied relay filtering to DM recipient kind-10050 lists and event lookup relay hints, with warnings on rejection/truncation.
- Consolidate older relay URL predicates through the shared policy and add regression coverage for encoded private hosts, caps, and DM routing.

## Motivation

- Recipient-supplied DM relay URLs could previously make the browser dial unbounded ws/wss relay lists, including private or link-local hosts.

## Related Issue

- Closes #542

## Testing

- [x] `npm run test`
- [x] Mutation check: temporarily weakened the remote host guard and confirmed the new policy, DM admission, and event lookup tests failed; restored the guard and reran the focused tests.

## Visuals

- [ ] UI change with screenshots/video attached
- [x] No visual change
- [x] Visuals and text avoid sensitive external brand or partner names unless explicitly approved