### PR TITLE
fix(metrics): publish sub-second view events

### DIFF
--- a/src/hooks/useVideoMetricsTracker.test.ts
+++ b/src/hooks/useVideoMetricsTracker.test.ts
@@ -84,7 +84,7 @@ describe('useVideoMetricsTracker', () => {
     expect(mockPublishViewEvent).not.toHaveBeenCalled();
   });
 
-  it('does not publish for less than 1 second of watch time', () => {
+  it('publishes for sub-second watch time', () => {
     const video = makeVideo('v1');
     const { unmount } = renderHook(() =>
       useVideoMetricsTracker({
@@ -95,11 +95,18 @@ describe('useVideoMetricsTracker', () => {
       })
     );
 
-    // Only 500ms — not enough
     act(() => { vi.advanceTimersByTime(500); });
     unmount();
 
-    expect(mockPublishViewEvent).not.toHaveBeenCalled();
+    expect(mockPublishViewEvent).toHaveBeenCalledTimes(1);
+    expect(mockPublishViewEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        video,
+        startSeconds: 0,
+        endSeconds: 0,
+        source: 'unknown',
+      })
+    );
   });
 
   it('publishes remaining time on unmount', () => {
@@ -128,6 +135,74 @@ describe('useVideoMetricsTracker', () => {
     const call = mockPublishViewEvent.mock.calls[0][0];
     expect(call.endSeconds).toBeGreaterThanOrEqual(2);
     expect(call.endSeconds).toBeLessThanOrEqual(4);
+  });
+
+  it('flushes watch time before publishing on unmount', () => {
+    const video = makeVideo('v1');
+    const { unmount } = renderHook(() =>
+      useVideoMetricsTracker({
+        video,
+        isPlaying: true,
+        currentTime: 0,
+        duration: 6,
+      })
+    );
+
+    act(() => { vi.advanceTimersByTime(500); });
+    unmount();
+
+    expect(mockPublishViewEvent).toHaveBeenCalledTimes(1);
+    expect(mockTrackProductEvent).toHaveBeenCalledWith('video_engagement_summary', expect.objectContaining({
+      duration_ms: 0,
+      properties: expect.objectContaining({
+        watched_seconds: 0,
+      }),
+    }));
+  });
+
+  it('publishes sub-second watch time after pausing', () => {
+    const video = makeVideo('v1');
+    const { rerender, unmount } = renderHook(
+      ({ isPlaying }) =>
+        useVideoMetricsTracker({
+          video,
+          isPlaying,
+          currentTime: 0,
+          duration: 6,
+        }),
+      { initialProps: { isPlaying: true } }
+    );
+
+    act(() => { vi.advanceTimersByTime(500); });
+    rerender({ isPlaying: false });
+    act(() => { vi.advanceTimersByTime(5000); });
+    unmount();
+
+    expect(mockPublishViewEvent).toHaveBeenCalledTimes(1);
+    expect(mockPublishViewEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        video,
+        startSeconds: 0,
+        endSeconds: 0,
+      })
+    );
+  });
+
+  it('does not publish when playback never starts', () => {
+    const video = makeVideo('v1');
+    const { unmount } = renderHook(() =>
+      useVideoMetricsTracker({
+        video,
+        isPlaying: false,
+        currentTime: 0,
+        duration: 6,
+      })
+    );
+
+    act(() => { vi.advanceTimersByTime(500); });
+    unmount();
+
+    expect(mockPublishViewEvent).not.toHaveBeenCalled();
   });
 
   it('does NOT publish on every re-render when video object reference changes', () => {

--- a/src/hooks/useVideoMetricsTracker.test.ts
+++ b/src/hooks/useVideoMetricsTracker.test.ts
@@ -303,10 +303,20 @@ describe('useVideoMetricsTracker', () => {
     act(() => { vi.advanceTimersByTime(2000); });
 
     expect(mockPublishViewEvent).toHaveBeenCalledTimes(1);
+    expect(mockPublishViewEvent).toHaveBeenNthCalledWith(1, expect.objectContaining({
+      video: video1,
+      startSeconds: 0,
+      source: 'unknown',
+    }));
 
     unmount();
     // Also publishes for video2
     expect(mockPublishViewEvent).toHaveBeenCalledTimes(2);
+    expect(mockPublishViewEvent).toHaveBeenNthCalledWith(2, expect.objectContaining({
+      video: video2,
+      startSeconds: 0,
+      source: 'unknown',
+    }));
   });
 
   it('does not accumulate time while paused', () => {

--- a/src/hooks/useVideoMetricsTracker.test.ts
+++ b/src/hooks/useVideoMetricsTracker.test.ts
@@ -231,6 +231,26 @@ describe('useVideoMetricsTracker', () => {
     expect(mockPublishViewEvent).toHaveBeenCalledTimes(1);
   });
 
+  it('preserves accumulated watch time when the video object reference changes for the same id', () => {
+    // Regression: async enrichment (e.g. ProofMode) hands VideoPlayer a new video
+    // object with the same id mid-play. That must not reset the watch accumulator.
+    const { rerender, unmount } = renderHook(
+      ({ video }) =>
+        useVideoMetricsTracker({ video, isPlaying: true, currentTime: 3, duration: 6 }),
+      { initialProps: { video: makeVideo('v1') } }
+    );
+
+    act(() => { vi.advanceTimersByTime(3000); }); // ~3s accumulated
+    rerender({ video: makeVideo('v1') });         // same id, new object reference
+    act(() => { vi.advanceTimersByTime(1000); });  // ~1s more
+    unmount();
+
+    expect(mockPublishViewEvent).toHaveBeenCalledTimes(1);
+    const call = mockPublishViewEvent.mock.calls[0][0];
+    // ~4s total watched must survive the reference change (was wiped to ~1s before the fix).
+    expect(call.endSeconds).toBeGreaterThanOrEqual(3);
+  });
+
   it('publishes on each loop, then remaining time on unmount', () => {
     const video = makeVideo('v1');
 

--- a/src/hooks/useVideoMetricsTracker.ts
+++ b/src/hooks/useVideoMetricsTracker.ts
@@ -131,27 +131,34 @@ export function useVideoMetricsTracker({
     });
   }, [trackEngagementSummary]); // Reads playback state from refs
 
-  // Reset metrics when video ID changes and keep the tracked video fresh for same-ID updates.
+  // Reset metrics on a real video id change; keep the tracked object fresh otherwise.
   useEffect(() => {
     const videoId = video?.id ?? null;
     if (!videoId) return;
 
-    // If video changed, publish remaining time for previous video
-    if (currentVideoIdRef.current && currentVideoIdRef.current !== videoId) {
-      const previousVideo = trackedVideoRef.current;
-      flushWatchTime();
-      publishAndReset(previousVideo);
+    const idChanged = currentVideoIdRef.current !== videoId;
+
+    // Only a genuine id change publishes leftovers and resets. A same-id object
+    // change (e.g. async ProofMode enrichment handing us a new object with the
+    // same id) must NOT reset the accumulator, or mid-play watch time is lost.
+    if (idChanged) {
+      if (currentVideoIdRef.current) {
+        const previousVideo = trackedVideoRef.current;
+        flushWatchTime();
+        publishAndReset(previousVideo);
+      }
+
+      metricsRef.current = {
+        lastPosition: 0,
+        loopCount: 0,
+        hasTrackedView: false,
+      };
+      watchTimeAccumulatorRef.current = 0;
+      lastUpdateTimeRef.current = Date.now();
+      currentVideoIdRef.current = videoId;
     }
 
-    // Reset metrics for new video
-    metricsRef.current = {
-      lastPosition: 0,
-      loopCount: 0,
-      hasTrackedView: false,
-    };
-    watchTimeAccumulatorRef.current = 0;
-    lastUpdateTimeRef.current = Date.now();
-    currentVideoIdRef.current = videoId;
+    // Keep the tracked object current for this id (same id/pubkey/vineId).
     trackedVideoRef.current = video;
   }, [video, video?.id, publishAndReset, flushWatchTime]);
 

--- a/src/hooks/useVideoMetricsTracker.ts
+++ b/src/hooks/useVideoMetricsTracker.ts
@@ -44,14 +44,12 @@ export function useVideoMetricsTracker({
   const { publishViewEvent, isAuthenticated } = useViewEventPublisher();
 
   // Store props/callbacks in refs so effects don't re-run on object reference changes.
-  const videoRef = useRef(video);
   const publishViewEventRef = useRef(publishViewEvent);
   const sourceRef = useRef(source);
   const isAuthenticatedRef = useRef(isAuthenticated);
   const enabledRef = useRef(enabled);
   const isPlayingRef = useRef(isPlaying);
 
-  videoRef.current = video;
   publishViewEventRef.current = publishViewEvent;
   sourceRef.current = source;
   isAuthenticatedRef.current = isAuthenticated;
@@ -67,6 +65,7 @@ export function useVideoMetricsTracker({
 
   // Track the current video ID to detect video changes
   const currentVideoIdRef = useRef<string | null>(null);
+  const trackedVideoRef = useRef<ParsedVideoData | null>(video);
 
   // Track accumulated watch time since last publish
   const watchTimeAccumulatorRef = useRef<number>(0);
@@ -99,8 +98,8 @@ export function useVideoMetricsTracker({
   }, []);
 
   // Publish a view event and reset the accumulator (stable, reads from refs)
-  const publishAndReset = useCallback(async () => {
-    const currentVideo = videoRef.current;
+  const publishAndReset = useCallback(async (targetVideo = trackedVideoRef.current) => {
+    const currentVideo = targetVideo;
     if (!currentVideo || !enabledRef.current || !isAuthenticatedRef.current) return;
 
     const rawWatchedSeconds = watchTimeAccumulatorRef.current;
@@ -132,15 +131,16 @@ export function useVideoMetricsTracker({
     });
   }, [trackEngagementSummary]); // Reads playback state from refs
 
-  // Reset metrics when video ID changes (primitive comparison, stable)
+  // Reset metrics when video ID changes and keep the tracked video fresh for same-ID updates.
   useEffect(() => {
     const videoId = video?.id ?? null;
     if (!videoId) return;
 
     // If video changed, publish remaining time for previous video
     if (currentVideoIdRef.current && currentVideoIdRef.current !== videoId) {
+      const previousVideo = trackedVideoRef.current;
       flushWatchTime();
-      publishAndReset();
+      publishAndReset(previousVideo);
     }
 
     // Reset metrics for new video
@@ -152,7 +152,8 @@ export function useVideoMetricsTracker({
     watchTimeAccumulatorRef.current = 0;
     lastUpdateTimeRef.current = Date.now();
     currentVideoIdRef.current = videoId;
-  }, [video?.id, publishAndReset, flushWatchTime]);
+    trackedVideoRef.current = video;
+  }, [video, video?.id, publishAndReset, flushWatchTime]);
 
   // Track playback time — depends only on primitives
   useEffect(() => {
@@ -181,6 +182,7 @@ export function useVideoMetricsTracker({
     }, 1000);
 
     return () => {
+      // On pause, render has already set isPlayingRef.current=false; count the slice that just ended.
       flushWatchTime(true);
       clearInterval(interval);
     };
@@ -213,27 +215,13 @@ export function useVideoMetricsTracker({
     metrics.lastPosition = currentTime;
   }, [video?.id, enabled, currentTime, duration, flushWatchTime, publishAndReset]);
 
-  // Publish remaining time on actual component unmount (empty deps)
+  // Publish remaining time on actual component unmount.
   useEffect(() => {
     return () => {
-      const currentVideo = videoRef.current;
       flushWatchTime();
-      const rawWatchedSeconds = watchTimeAccumulatorRef.current;
-      const watchedSeconds = Math.floor(rawWatchedSeconds);
-
-      if (currentVideo && rawWatchedSeconds > 0 && isAuthenticatedRef.current && enabledRef.current) {
-        trackEngagementSummary(currentVideo, watchedSeconds);
-        publishViewEventRef.current({
-          video: currentVideo,
-          startSeconds: 0,
-          endSeconds: watchedSeconds,
-          source: sourceRef.current,
-        }).catch(() => {
-          // Ignore errors on unmount
-        });
-      }
+      void publishAndReset();
     };
-  }, [flushWatchTime, trackEngagementSummary]); // Fires only on unmount
+  }, [flushWatchTime, publishAndReset]);
 
   // Return current metrics for debugging/display purposes
   return {

--- a/src/hooks/useVideoMetricsTracker.ts
+++ b/src/hooks/useVideoMetricsTracker.ts
@@ -49,12 +49,14 @@ export function useVideoMetricsTracker({
   const sourceRef = useRef(source);
   const isAuthenticatedRef = useRef(isAuthenticated);
   const enabledRef = useRef(enabled);
+  const isPlayingRef = useRef(isPlaying);
 
   videoRef.current = video;
   publishViewEventRef.current = publishViewEvent;
   sourceRef.current = source;
   isAuthenticatedRef.current = isAuthenticated;
   enabledRef.current = enabled;
+  isPlayingRef.current = isPlaying;
 
   // Track metrics state in a ref to avoid re-renders
   const metricsRef = useRef<VideoMetricsState>({
@@ -71,10 +73,10 @@ export function useVideoMetricsTracker({
   const lastUpdateTimeRef = useRef<number>(Date.now());
 
   // Flush accumulated watch time into the accumulator (call before reading it)
-  const flushWatchTime = useCallback(() => {
+  const flushWatchTime = useCallback((countPlayback = isPlayingRef.current) => {
     const now = Date.now();
     const elapsed = (now - lastUpdateTimeRef.current) / 1000;
-    if (elapsed > 0 && elapsed < 10) { // Sanity check: ignore huge gaps (tab was backgrounded)
+    if (countPlayback && elapsed > 0 && elapsed < 10) { // Sanity check: ignore huge gaps (tab was backgrounded)
       watchTimeAccumulatorRef.current += elapsed;
     }
     lastUpdateTimeRef.current = now;
@@ -101,12 +103,13 @@ export function useVideoMetricsTracker({
     const currentVideo = videoRef.current;
     if (!currentVideo || !enabledRef.current || !isAuthenticatedRef.current) return;
 
-    const watchedSeconds = Math.floor(watchTimeAccumulatorRef.current);
-    if (watchedSeconds < 1) {
-      debugLog('[VideoMetricsTracker] Skipping view event: less than 1 second watched');
+    const rawWatchedSeconds = watchTimeAccumulatorRef.current;
+    if (rawWatchedSeconds <= 0) {
+      debugLog('[VideoMetricsTracker] Skipping view event: no playback time watched');
       return;
     }
 
+    const watchedSeconds = Math.floor(rawWatchedSeconds);
     debugLog('[VideoMetricsTracker] Publishing view event', {
       videoId: currentVideo.id,
       watchedSeconds,
@@ -177,8 +180,11 @@ export function useVideoMetricsTracker({
       lastUpdateTimeRef.current = now;
     }, 1000);
 
-    return () => clearInterval(interval);
-  }, [video?.id, enabled, isPlaying]);
+    return () => {
+      flushWatchTime(true);
+      clearInterval(interval);
+    };
+  }, [video?.id, enabled, isPlaying, flushWatchTime]);
 
   // Detect loops and publish once per loop
   useEffect(() => {
@@ -211,9 +217,11 @@ export function useVideoMetricsTracker({
   useEffect(() => {
     return () => {
       const currentVideo = videoRef.current;
-      const watchedSeconds = Math.floor(watchTimeAccumulatorRef.current);
+      flushWatchTime();
+      const rawWatchedSeconds = watchTimeAccumulatorRef.current;
+      const watchedSeconds = Math.floor(rawWatchedSeconds);
 
-      if (currentVideo && watchedSeconds >= 1 && isAuthenticatedRef.current && enabledRef.current) {
+      if (currentVideo && rawWatchedSeconds > 0 && isAuthenticatedRef.current && enabledRef.current) {
         trackEngagementSummary(currentVideo, watchedSeconds);
         publishViewEventRef.current({
           video: currentVideo,
@@ -225,7 +233,7 @@ export function useVideoMetricsTracker({
         });
       }
     };
-  }, [trackEngagementSummary]); // Fires only on unmount
+  }, [flushWatchTime, trackEngagementSummary]); // Fires only on unmount
 
   // Return current metrics for debugging/display purposes
   return {

--- a/src/hooks/useViewEventPublisher.test.ts
+++ b/src/hooks/useViewEventPublisher.test.ts
@@ -85,10 +85,10 @@ describe('useViewEventPublisher', () => {
     ]);
   });
 
-  it('skips publishing when watch time is less than 1 second', async () => {
+  it('publishes zero-length viewed ranges for sub-second playback', async () => {
     const { result } = renderHook(() => useViewEventPublisher());
 
-    let success: boolean = true;
+    let success: boolean = false;
     await act(async () => {
       success = await result.current.publishViewEvent({
         video: makeVideo(),
@@ -97,11 +97,13 @@ describe('useViewEventPublisher', () => {
       });
     });
 
-    expect(success).toBe(false);
-    expect(mockPublishEvent).not.toHaveBeenCalled();
+    expect(success).toBe(true);
+    expect(mockPublishEvent).toHaveBeenCalledTimes(1);
+    const tags = mockPublishEvent.mock.calls[0][0].tags as string[][];
+    expect(tags).toContainEqual(['viewed', '0', '0']);
   });
 
-  it('skips publishing when endSeconds <= startSeconds', async () => {
+  it('skips publishing when endSeconds is before startSeconds', async () => {
     const { result } = renderHook(() => useViewEventPublisher());
 
     let success: boolean = true;

--- a/src/hooks/useViewEventPublisher.ts
+++ b/src/hooks/useViewEventPublisher.ts
@@ -27,6 +27,7 @@ const CLIENT_ID = 'divine-web/1.0';
 
 interface PublishViewEventParams {
   video: ParsedVideoData;
+  /** Elapsed playback seconds in this view event, not positions within the video. */
   startSeconds: number;
   endSeconds: number;
   source?: ViewTrafficSource;
@@ -55,15 +56,8 @@ export function useViewEventPublisher(): UseViewEventPublisherResult {
     endSeconds,
     source = 'unknown',
   }: PublishViewEventParams): Promise<boolean> => {
-    // Skip if no meaningful watch time
-    if (endSeconds <= startSeconds) {
-      debugLog('[ViewEventPublisher] Skipping: no watch time', { startSeconds, endSeconds });
-      return false;
-    }
-
-    // Skip very short views (less than 1 second)
-    if (endSeconds - startSeconds < 1) {
-      debugLog('[ViewEventPublisher] Skipping: less than 1 second watched');
+    if (endSeconds < startSeconds) {
+      debugLog('[ViewEventPublisher] Skipping: invalid watch range', { startSeconds, endSeconds });
       return false;
     }
 


### PR DESCRIPTION
## Summary

- Publish kind-22236 view events for positive sub-second playback instead of dropping them client-side.
- Allow zero-length `["viewed", "0", "0"]` ranges while still rejecting inverted ranges.
- Flush active playback time when tracking stops or unmounts so final sub-second slices are not lost.

## Motivation

- Web was stricter than mobile and Funnelcake by dropping playback sessions under one second before the server could count them.
- Keeping this scoped avoids emitting a `loops` tag before the backend contract is settled.
- Positive playback now emits view events even for sub-second retry/HLS-remount slices and scroll-past starts, matching the intended counting policy while increasing kind-22236 writes versus the previous web gate.

## Related Issue

- Refs #564

## Testing

- [x] `npx vitest run src/hooks/useViewEventPublisher.test.ts src/hooks/useVideoMetricsTracker.test.ts`
- [x] `npm run test`
- [ ] Manual verification completed — not applicable; hook-level metrics behavior covered by regression tests.

## Visuals

- [ ] UI change with screenshots/video attached
- [x] No visual change
- [x] Visuals and text avoid sensitive external brand or partner names unless explicitly approved
