### PR TITLE
chore(github): enforce semantic issue titles

### DIFF
--- a/.agents/skills/pr-conventions/SKILL.md
+++ b/.agents/skills/pr-conventions/SKILL.md
@@ -22,11 +22,27 @@ type(scope): summary
 type: summary
 ```
 
-Allowed types: `feat`, `fix`, `docs`, `style`, `refactor`, `test`, `chore`,
-`perf`.
+Allowed types: `build`, `chore`, `ci`, `docs`, `feat`, `fix`, `perf`,
+`refactor`, `revert`, `style`, `test`.
 
 Set the correct title when opening the PR. Editing the title afterward may not
 retrigger `semantic_pr.yml`, leaving the check stale or failed.
+
+## Issue Titles
+
+Use scoped Conventional Commit format:
+
+```
+type(scope): summary
+```
+
+Issue titles require a scope. Allowed types match PR titles: `build`, `chore`,
+`ci`, `docs`, `feat`, `fix`, `perf`, `refactor`, `revert`, `style`, `test`.
+
+Examples:
+
+- `fix(search): avoid duplicate fallback requests`
+- `docs(readme): clarify deploy commands`
 
 ## PR Description
 

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,6 +1,6 @@
 name: Bug Report
 description: Report a bug or regression in divine-web.
-title: "fix: "
+title: "fix(scope): "
 labels:
   - bug
 body:
@@ -8,7 +8,11 @@ body:
     id: summary
     attributes:
       label: Summary
-      description: What is broken? Avoid naming corporate partners, customers, or other sensitive external brands; use generic descriptors unless explicitly approved.
+      description: >-
+        What is broken? Keep the issue title in `type(scope): subject` format,
+        for example `fix(search): avoid duplicate fallback requests`. Avoid
+        naming corporate partners, customers, or other sensitive external
+        brands; use generic descriptors unless explicitly approved.
       placeholder: Briefly describe the bug.
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,18 +1,21 @@
 name: Bug Report
 description: Report a bug or regression in divine-web.
-title: "fix(scope): "
+title: "fix(): "
 labels:
   - bug
+assignees:
+  - NotThatKindOfDrLiz
 body:
   - type: textarea
     id: summary
     attributes:
       label: Summary
       description: >-
-        What is broken? Keep the issue title in `type(scope): subject` format,
-        for example `fix(search): avoid duplicate fallback requests`. Avoid
-        naming corporate partners, customers, or other sensitive external
-        brands; use generic descriptors unless explicitly approved.
+        What is broken? Replace the title placeholder with a specific scope:
+        `fix(scope): subject`, for example `fix(search): avoid duplicate
+        fallback requests`. Avoid naming corporate partners, customers, or other
+        sensitive external brands; use generic descriptors unless explicitly
+        approved.
       placeholder: Briefly describe the bug.
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,1 +1,1 @@
-blank_issues_enabled: true
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,6 +1,6 @@
 name: Feature Request
 description: Propose a new capability or product improvement for divine-web.
-title: "feat: "
+title: "feat(scope): "
 labels:
   - enhancement
 body:
@@ -8,7 +8,12 @@ body:
     id: summary
     attributes:
       label: Summary
-      description: What should be added or changed? Avoid naming corporate partners, customers, or other sensitive external brands; use generic descriptors unless explicitly approved.
+      description: >-
+        What should be added or changed? Keep the issue title in
+        `type(scope): subject` format, for example `feat(profile): show saved
+        collections`. Avoid naming corporate partners, customers, or other
+        sensitive external brands; use generic descriptors unless explicitly
+        approved.
       placeholder: Briefly describe the feature request.
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,17 +1,19 @@
 name: Feature Request
 description: Propose a new capability or product improvement for divine-web.
-title: "feat(scope): "
+title: "feat(): "
 labels:
   - enhancement
+assignees:
+  - NotThatKindOfDrLiz
 body:
   - type: textarea
     id: summary
     attributes:
       label: Summary
       description: >-
-        What should be added or changed? Keep the issue title in
-        `type(scope): subject` format, for example `feat(profile): show saved
-        collections`. Avoid naming corporate partners, customers, or other
+        What should be added or changed? Replace the title placeholder with a
+        specific scope: `feat(scope): subject`, for example `feat(profile): show
+        saved collections`. Avoid naming corporate partners, customers, or other
         sensitive external brands; use generic descriptors unless explicitly
         approved.
       placeholder: Briefly describe the feature request.

--- a/.github/ISSUE_TEMPLATE/general.yml
+++ b/.github/ISSUE_TEMPLATE/general.yml
@@ -1,0 +1,25 @@
+name: General Issue
+description: Track docs, chores, CI, refactors, tests, and other work.
+title: "chore(): "
+labels:
+  - triage
+assignees:
+  - NotThatKindOfDrLiz
+body:
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: >-
+        Replace the title placeholder with `type(scope): subject`. Allowed
+        types are `build`, `chore`, `ci`, `docs`, `feat`, `fix`, `perf`,
+        `refactor`, `revert`, `style`, and `test`.
+      placeholder: Briefly describe the work.
+    validations:
+      required: true
+  - type: textarea
+    id: details
+    attributes:
+      label: Details
+      description: Add context, constraints, links, or acceptance criteria.
+      placeholder: What needs to happen?

--- a/.github/workflows/issue_assignee.yml
+++ b/.github/workflows/issue_assignee.yml
@@ -1,0 +1,30 @@
+name: Issue Assignee
+
+on:
+  issues:
+    types: [opened, reopened, unassigned]
+
+permissions:
+  issues: write
+
+jobs:
+  default-assignee:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Assign unowned issues
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const defaultAssignee = 'NotThatKindOfDrLiz';
+            const issue = context.payload.issue;
+
+            if (issue.assignees.length > 0) {
+              return;
+            }
+
+            await github.rest.issues.addAssignees({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issue.number,
+              assignees: [defaultAssignee],
+            });

--- a/.github/workflows/semantic_issue_title.yml
+++ b/.github/workflows/semantic_issue_title.yml
@@ -1,0 +1,25 @@
+name: Semantic Issue Title
+
+on:
+  issues:
+    types: [opened, edited, reopened]
+
+permissions:
+  issues: read
+
+jobs:
+  semantic-issue-title:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check issue title
+        env:
+          ISSUE_TITLE: ${{ github.event.issue.title }}
+        run: |
+          pattern='^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test|review|ops|epic)\([a-z0-9][a-z0-9-]*\): .+'
+          if [[ ! "$ISSUE_TITLE" =~ $pattern ]]; then
+            echo "Issue title must use: type(scope): subject"
+            echo "Allowed types: build, chore, ci, docs, feat, fix, perf, refactor, revert, style, test, review, ops, epic"
+            echo "Example: fix(search): avoid duplicate fallback requests"
+            echo "Actual: $ISSUE_TITLE"
+            exit 1
+          fi

--- a/.github/workflows/semantic_issue_title.yml
+++ b/.github/workflows/semantic_issue_title.yml
@@ -2,24 +2,103 @@ name: Semantic Issue Title
 
 on:
   issues:
-    types: [opened, edited, reopened]
+    types: [opened, edited]
 
 permissions:
-  issues: read
+  issues: write
 
 jobs:
   semantic-issue-title:
     runs-on: ubuntu-latest
     steps:
       - name: Check issue title
+        id: check-title
         env:
           ISSUE_TITLE: ${{ github.event.issue.title }}
         run: |
-          pattern='^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test|review|ops|epic)\([a-z0-9][a-z0-9-]*\): .+'
-          if [[ ! "$ISSUE_TITLE" =~ $pattern ]]; then
-            echo "Issue title must use: type(scope): subject"
-            echo "Allowed types: build, chore, ci, docs, feat, fix, perf, refactor, revert, style, test, review, ops, epic"
-            echo "Example: fix(search): avoid duplicate fallback requests"
-            echo "Actual: $ISSUE_TITLE"
-            exit 1
+          pattern='^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test)\([[:alnum:]_$./* -]+\)!?: .+'
+          placeholder_scope='^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test)\(scope\)!?: .+'
+          if [[ "$ISSUE_TITLE" =~ $pattern && ! "$ISSUE_TITLE" =~ $placeholder_scope ]]; then
+            echo "valid=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "valid=false" >> "$GITHUB_OUTPUT"
           fi
+
+      - name: Comment on invalid title
+        if: steps.check-title.outputs.valid == 'false'
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const marker = '<!-- semantic-issue-title -->';
+            const body = [
+              marker,
+              'This issue title needs `type(scope): subject`.',
+              '',
+              'Allowed types: `build`, `chore`, `ci`, `docs`, `feat`, `fix`, `perf`, `refactor`, `revert`, `style`, `test`.',
+              '',
+              'Examples:',
+              '- `fix(search): avoid duplicate fallback requests`',
+              '- `docs(readme): clarify deploy commands`',
+            ].join('\n');
+
+            const issue_number = context.payload.issue.number;
+            const { owner, repo } = context.repo;
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner,
+              repo,
+              issue_number,
+              per_page: 100,
+            });
+            const existing = comments.find((comment) =>
+              comment.user.type === 'Bot' && comment.body.includes(marker)
+            );
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner,
+                repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number,
+                body,
+              });
+            }
+
+      - name: Remove resolved title comment
+        if: steps.check-title.outputs.valid == 'true'
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const marker = '<!-- semantic-issue-title -->';
+            const issue_number = context.payload.issue.number;
+            const { owner, repo } = context.repo;
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner,
+              repo,
+              issue_number,
+              per_page: 100,
+            });
+            const existing = comments.find((comment) =>
+              comment.user.type === 'Bot' && comment.body.includes(marker)
+            );
+
+            if (existing) {
+              await github.rest.issues.deleteComment({
+                owner,
+                repo,
+                comment_id: existing.id,
+              });
+            }
+
+      - name: Fail invalid title
+        if: steps.check-title.outputs.valid == 'false'
+        run: |
+          echo "Issue title must use: type(scope): subject"
+          echo "Allowed types: build, chore, ci, docs, feat, fix, perf, refactor, revert, style, test"
+          echo "Example: fix(search): avoid duplicate fallback requests"
+          exit 1

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -230,6 +230,35 @@ Requirements:
 - Rebase on `origin/main` before pushing
 - One PR per issue when possible
 
+## Issues
+
+Issue titles use scoped Conventional Commit format: `type(scope): summary`.
+Unlike PR titles, issue titles require a scope so the backlog stays scannable.
+
+Allowed issue-title types match the default PR-title checker:
+
+- `build`
+- `chore`
+- `ci`
+- `docs`
+- `feat`
+- `fix`
+- `perf`
+- `refactor`
+- `revert`
+- `style`
+- `test`
+
+Use a short, specific scope such as `search`, `profile`, `deploy`, or
+`docs/readme`. Examples:
+
+- `fix(search): avoid duplicate fallback requests`
+- `docs(readme): clarify deploy commands`
+
+Issue templates assign new issues to the default repo owner. The
+`Issue Assignee` workflow also assigns any open issue that is filed without an
+assignee or later loses its last assignee, so backlog items do not sit unowned.
+
 Before opening, make sure you have followed [Scope Discipline](#scope-discipline)
 and `npm run test` passes locally.
 


### PR DESCRIPTION
## Summary

- Update issue forms to prefill titles as type(scope): subject.
- Disable blank issues so new issues go through the guided forms.
- Add an issue-title workflow that checks opened, edited, and reopened issue titles against the semantic format.

> Avoid naming corporate partners, customers, or other sensitive external brands in this PR title or body. Use generic descriptors unless a maintainer explicitly approves the public reference.

## Motivation

- Keep issue titles consistent and scannable across divine-web.

## Related Issue

- N/A

## Testing

- [x] npm run test
- [x] Manual verification completed: live open issue title regex check returned no violations; YAML parse check passed for touched issue templates and workflow; git diff --check passed.

## Visuals

- [ ] UI change with screenshots/video attached
- [x] No visual change
- [x] Visuals and text avoid sensitive external brand or partner names unless explicitly approved