### PR TITLE
fix(search): keep relay fallback pagination advancing

### DIFF
--- a/src/hooks/useInfiniteSearchVideos.test.ts
+++ b/src/hooks/useInfiniteSearchVideos.test.ts
@@ -74,22 +74,26 @@ function createWrapper() {
   };
 }
 
+function makeHex(index: number, length: number): string {
+  return index.toString(16).padStart(length, '0');
+}
+
 function makeEvent(index: number, createdAt = 1700000000 - index): NostrEvent {
   return {
-    id: `event-${String(index).padStart(2, '0')}`,
-    pubkey: `pubkey-${String(index).padStart(2, '0')}`,
+    id: makeHex(index, 64),
+    pubkey: makeHex(1000 + index, 64),
     created_at: createdAt,
     kind: 34236,
     tags: [['d', `vine-${index}`]],
     content: '',
-    sig: 'sig',
+    sig: makeHex(2000 + index, 128),
   };
 }
 
 function makeVideo(index: number, overrides: Partial<ParsedVideoData> = {}): ParsedVideoData {
   return {
-    id: `event-${String(index).padStart(2, '0')}`,
-    pubkey: `pubkey-${String(index).padStart(2, '0')}`,
+    id: makeEvent(index).id,
+    pubkey: makeEvent(index).pubkey,
     kind: 34236,
     createdAt: 1700000000 - index,
     content: '',
@@ -110,7 +114,7 @@ describe('useInfiniteSearchVideos', () => {
 
   it('uses Funnelcake search results without falling back to relay search', async () => {
     const expectedVideos = [
-      { id: 'video-1', pubkey: 'pubkey-1', createdAt: 123 } as const,
+      makeVideo(101, { createdAt: 123 }),
     ];
 
     mockSearchVideos.mockResolvedValue({
@@ -178,20 +182,12 @@ describe('useInfiniteSearchVideos', () => {
 
   it('falls back to relay search when Funnelcake search throws', async () => {
     const relayVideos = [
-      { id: 'video-2', pubkey: 'pubkey-2', createdAt: 456 } as const,
+      makeVideo(102, { createdAt: 456 }),
     ];
 
     mockSearchVideos.mockRejectedValue(new Error('boom'));
     mockNostrQuery.mockResolvedValue([
-      {
-        id: 'event-1',
-        pubkey: 'pubkey-2',
-        kind: 34236,
-        created_at: 456,
-        tags: [['d', 'vine-1']],
-        content: 'jack video',
-        sig: 'sig',
-      },
+      makeEvent(102, 456),
     ]);
     mockParseVideoEvents.mockReturnValue(relayVideos);
 
@@ -409,8 +405,8 @@ describe('useInfiniteSearchVideos', () => {
     expect(mockNostrQuery.mock.calls[0]?.[0][0]).not.toHaveProperty('until');
     expect(mockNostrQuery.mock.calls[1]?.[0][0]).not.toHaveProperty('until');
     expect(mockParseVideoEvents.mock.calls[1]?.[0].map((event: NostrEvent) => event.id)).toEqual([
-      'event-03',
-      'event-04',
+      makeEvent(3).id,
+      makeEvent(4).id,
     ]);
   });
 
@@ -462,7 +458,7 @@ describe('useInfiniteSearchVideos', () => {
     expect(result.current.hasNextPage).toBe(false);
   });
 
-  it('does not interpret a Funnelcake offset as a relay timestamp when falling back', async () => {
+  it('does not carry a Funnelcake offset into ranked relay fallback', async () => {
     mockSearchVideos
       .mockResolvedValueOnce({ videos: [], has_more: true })
       .mockRejectedValueOnce(new Error('boom'));
@@ -474,20 +470,8 @@ describe('useInfiniteSearchVideos', () => {
     mockNostrQuery.mockResolvedValueOnce([
       makeEvent(1),
       makeEvent(2),
-      makeEvent(3),
-      makeEvent(4),
-      makeEvent(5),
-      makeEvent(6),
-      makeEvent(7),
-      makeEvent(8),
-      makeEvent(9),
-      makeEvent(10),
-      makeEvent(11),
-      makeEvent(12),
-      makeEvent(13),
-      makeEvent(14),
     ]);
-    mockParseVideoEvents.mockReturnValueOnce([makeVideo(13), makeVideo(14)]);
+    mockParseVideoEvents.mockReturnValueOnce([makeVideo(1), makeVideo(2)]);
 
     const { result } = renderHook(
       () => useInfiniteSearchVideos({ query: 'jack', sortMode: 'relevance', pageSize: 2 }),
@@ -507,9 +491,70 @@ describe('useInfiniteSearchVideos', () => {
     });
 
     expect(mockNostrQuery.mock.calls[0]?.[0][0]).toEqual(
-      expect.objectContaining({ search: 'jack', limit: 14 })
+      expect.objectContaining({ search: 'jack', limit: 2 })
     );
     expect(mockNostrQuery.mock.calls[0]?.[0][0]).not.toHaveProperty('until');
+  });
+
+  it('does not pass an author timestamp cursor into ranked relay fallback', async () => {
+    mockSearchProfiles
+      .mockResolvedValueOnce([{ pubkey: 'a'.repeat(64) }])
+      .mockRejectedValueOnce(new Error('boom'));
+    mockNostrQuery
+      .mockResolvedValueOnce([
+        makeEvent(1, 100),
+        makeEvent(2, 90),
+      ])
+      .mockResolvedValueOnce([
+        makeEvent(3, 80),
+        makeEvent(4, 70),
+      ]);
+    mockParseVideoEvents
+      .mockReturnValueOnce([makeVideo(1, { createdAt: 100 })])
+      .mockReturnValueOnce([makeVideo(3, { createdAt: 80 }), makeVideo(4, { createdAt: 70 })]);
+
+    const { result } = renderHook(
+      () => useInfiniteSearchVideos({ query: 'alice', searchType: 'author', sortMode: 'relevance', pageSize: 2 }),
+      { wrapper: createWrapper() }
+    );
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    await waitFor(() => {
+      expect(result.current.hasNextPage).toBe(true);
+    });
+
+    await act(async () => {
+      await result.current.fetchNextPage();
+    });
+
+    expect(mockNostrQuery.mock.calls[1]?.[0][0]).toEqual(
+      expect.objectContaining({ search: 'alice', limit: 2 })
+    );
+    expect(mockNostrQuery.mock.calls[1]?.[0][0]).not.toHaveProperty('until');
+  });
+
+  it('stops pagination when Funnelcake returns a non-numeric offset cursor', async () => {
+    mockSearchVideos.mockResolvedValueOnce({ videos: [], has_more: true });
+    mockTransformToVideoPage.mockReturnValueOnce({
+      videos: [makeVideo(1)],
+      offset: NaN,
+      hasMore: true,
+    });
+
+    const { result } = renderHook(
+      () => useInfiniteSearchVideos({ query: 'jack', sortMode: 'relevance', pageSize: 2 }),
+      { wrapper: createWrapper() }
+    );
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(result.current.hasNextPage).toBe(false);
+    expect(mockNostrQuery).not.toHaveBeenCalled();
   });
 });
 

--- a/src/hooks/useInfiniteSearchVideos.test.ts
+++ b/src/hooks/useInfiniteSearchVideos.test.ts
@@ -536,6 +536,69 @@ describe('useInfiniteSearchVideos', () => {
     expect(mockNostrQuery.mock.calls[1]?.[0][0]).not.toHaveProperty('until');
   });
 
+  it('keeps paging the ranked window after author fallback instead of rewinding', async () => {
+    mockSearchProfiles
+      .mockResolvedValueOnce([{ pubkey: 'a'.repeat(64) }])
+      .mockRejectedValueOnce(new Error('boom'))
+      .mockResolvedValue([{ pubkey: 'a'.repeat(64) }]);
+    mockNostrQuery
+      .mockResolvedValueOnce([
+        makeEvent(1, 100),
+        makeEvent(2, 90),
+      ])
+      .mockResolvedValueOnce([
+        makeEvent(3, 80),
+        makeEvent(4, 70),
+      ])
+      .mockResolvedValueOnce([
+        makeEvent(3, 80),
+        makeEvent(4, 70),
+        makeEvent(5, 60),
+        makeEvent(6, 50),
+      ]);
+    mockParseVideoEvents
+      .mockReturnValueOnce([makeVideo(1, { createdAt: 100 })])
+      .mockReturnValueOnce([makeVideo(3, { createdAt: 80 }), makeVideo(4, { createdAt: 70 })])
+      .mockReturnValueOnce([makeVideo(5, { createdAt: 60 }), makeVideo(6, { createdAt: 50 })]);
+
+    const { result } = renderHook(
+      () => useInfiniteSearchVideos({ query: 'alice', searchType: 'author', sortMode: 'relevance', pageSize: 2 }),
+      { wrapper: createWrapper() }
+    );
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    await waitFor(() => {
+      expect(result.current.hasNextPage).toBe(true);
+    });
+
+    await act(async () => {
+      await result.current.fetchNextPage();
+    });
+
+    await waitFor(() => {
+      expect(result.current.hasNextPage).toBe(true);
+    });
+
+    await act(async () => {
+      await result.current.fetchNextPage();
+    });
+
+    // Once author search falls over to the ranked window it stays there: no third
+    // profile lookup, and the window grows instead of restarting the author feed.
+    expect(mockSearchProfiles).toHaveBeenCalledTimes(2);
+    expect(mockNostrQuery.mock.calls[2]?.[0][0]).toEqual(
+      expect.objectContaining({ search: 'alice', limit: 4 })
+    );
+    expect(mockNostrQuery.mock.calls[2]?.[0][0]).not.toHaveProperty('until');
+    expect(mockParseVideoEvents.mock.calls[2]?.[0].map((event: NostrEvent) => event.id)).toEqual([
+      makeEvent(5).id,
+      makeEvent(6).id,
+    ]);
+  });
+
   it('stops pagination when Funnelcake returns a non-numeric offset cursor', async () => {
     mockSearchVideos.mockResolvedValueOnce({ videos: [], has_more: true });
     mockTransformToVideoPage.mockReturnValueOnce({

--- a/src/hooks/useInfiniteSearchVideos.test.ts
+++ b/src/hooks/useInfiniteSearchVideos.test.ts
@@ -1,13 +1,18 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { renderHook, waitFor } from '@testing-library/react';
+import { act, renderHook, waitFor } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import React from 'react';
 
+import type { NostrEvent } from '@nostrify/nostrify';
+import type { ParsedVideoData } from '@/types/video';
+
 const mockNostrQuery = vi.fn();
 const mockSearchVideos = vi.fn();
+const mockSearchProfiles = vi.fn();
 const mockTransformToVideoPage = vi.fn();
 const mockParseVideoEvents = vi.fn();
 const mockReportFunnelcakeFallback = vi.fn();
+const mockIsFunnelcakeAvailable = vi.fn();
 
 vi.mock('@/lib/funnelcakeFallbackReporting', async (importOriginal) => ({
   ...(await importOriginal<typeof import('@/lib/funnelcakeFallbackReporting')>()),
@@ -36,10 +41,15 @@ vi.mock('@/hooks/useAppContext', () => ({
 
 vi.mock('@/lib/funnelcakeClient', () => ({
   searchVideos: mockSearchVideos,
+  searchProfiles: mockSearchProfiles,
 }));
 
 vi.mock('@/lib/funnelcakeTransform', () => ({
   transformToVideoPage: mockTransformToVideoPage,
+}));
+
+vi.mock('@/lib/funnelcakeHealth', () => ({
+  isFunnelcakeAvailable: mockIsFunnelcakeAvailable,
 }));
 
 vi.mock('@/lib/videoParser', () => ({
@@ -64,9 +74,38 @@ function createWrapper() {
   };
 }
 
+function makeEvent(index: number, createdAt = 1700000000 - index): NostrEvent {
+  return {
+    id: `event-${String(index).padStart(2, '0')}`,
+    pubkey: `pubkey-${String(index).padStart(2, '0')}`,
+    created_at: createdAt,
+    kind: 34236,
+    tags: [['d', `vine-${index}`]],
+    content: '',
+    sig: 'sig',
+  };
+}
+
+function makeVideo(index: number, overrides: Partial<ParsedVideoData> = {}): ParsedVideoData {
+  return {
+    id: `event-${String(index).padStart(2, '0')}`,
+    pubkey: `pubkey-${String(index).padStart(2, '0')}`,
+    kind: 34236,
+    createdAt: 1700000000 - index,
+    content: '',
+    videoUrl: `https://example.com/video-${index}.mp4`,
+    hashtags: [],
+    vineId: `vine-${index}`,
+    isVineMigrated: false,
+    reposts: [],
+    ...overrides,
+  };
+}
+
 describe('useInfiniteSearchVideos', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockIsFunnelcakeAvailable.mockReturnValue(true);
   });
 
   it('uses Funnelcake search results without falling back to relay search', async () => {
@@ -198,6 +237,279 @@ describe('useInfiniteSearchVideos', () => {
 
     expect(mockReportFunnelcakeFallback).not.toHaveBeenCalled();
     expect(mockNostrQuery).not.toHaveBeenCalled();
+  });
+
+  it('backfills hashtag fallback when a full raw page parses to zero videos', async () => {
+    mockIsFunnelcakeAvailable.mockReturnValue(false);
+    mockNostrQuery
+      .mockResolvedValueOnce([
+        makeEvent(1, 100),
+        makeEvent(2, 99),
+      ])
+      .mockResolvedValueOnce([makeEvent(3, 80)]);
+    mockParseVideoEvents
+      .mockReturnValueOnce([])
+      .mockReturnValueOnce([makeVideo(3)]);
+
+    const { result } = renderHook(
+      () => useInfiniteSearchVideos({ query: '#vine', sortMode: 'relevance', pageSize: 2 }),
+      { wrapper: createWrapper() }
+    );
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(mockNostrQuery).toHaveBeenCalledTimes(2);
+    expect(mockNostrQuery.mock.calls[0]?.[0]).toEqual([
+      expect.objectContaining({ '#t': ['vine'], limit: 2 }),
+    ]);
+    expect(mockNostrQuery.mock.calls[1]?.[0]).toEqual([
+      expect.objectContaining({ '#t': ['vine'], limit: 2, until: 98 }),
+    ]);
+    expect(result.current.data?.pages[0].videos).toEqual([makeVideo(3)]);
+  });
+
+  it('advances hashtag fallback from the raw tail when a page parses short', async () => {
+    mockIsFunnelcakeAvailable.mockReturnValue(false);
+    mockNostrQuery
+      .mockResolvedValueOnce([
+        makeEvent(1, 100),
+        makeEvent(2, 90),
+      ])
+      .mockResolvedValueOnce([makeEvent(3, 70)]);
+    mockParseVideoEvents
+      .mockReturnValueOnce([makeVideo(1, { createdAt: 100 })])
+      .mockReturnValueOnce([makeVideo(3, { createdAt: 70 })]);
+
+    const { result } = renderHook(
+      () => useInfiniteSearchVideos({ query: '#vine', sortMode: 'relevance', pageSize: 2 }),
+      { wrapper: createWrapper() }
+    );
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    await waitFor(() => {
+      expect(result.current.hasNextPage).toBe(true);
+    });
+
+    await act(async () => {
+      await result.current.fetchNextPage();
+    });
+
+    expect(mockNostrQuery.mock.calls[1]?.[0]).toEqual([
+      expect.objectContaining({ '#t': ['vine'], limit: 2, until: 89 }),
+    ]);
+  });
+
+  it('backfills author fallback when a full raw page parses to zero videos', async () => {
+    mockSearchProfiles.mockResolvedValue([{ pubkey: 'a'.repeat(64) }]);
+    mockNostrQuery
+      .mockResolvedValueOnce([
+        makeEvent(1, 100),
+        makeEvent(2, 99),
+      ])
+      .mockResolvedValueOnce([makeEvent(3, 80)]);
+    mockParseVideoEvents
+      .mockReturnValueOnce([])
+      .mockReturnValueOnce([makeVideo(3)]);
+
+    const { result } = renderHook(
+      () => useInfiniteSearchVideos({ query: 'alice', searchType: 'author', sortMode: 'relevance', pageSize: 2 }),
+      { wrapper: createWrapper() }
+    );
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(mockNostrQuery).toHaveBeenCalledTimes(2);
+    expect(mockNostrQuery.mock.calls[0]?.[0]).toEqual([
+      expect.objectContaining({ authors: ['a'.repeat(64)], limit: 2 }),
+    ]);
+    expect(mockNostrQuery.mock.calls[1]?.[0]).toEqual([
+      expect.objectContaining({ authors: ['a'.repeat(64)], limit: 2, until: 98 }),
+    ]);
+    expect(result.current.data?.pages[0].videos).toEqual([makeVideo(3)]);
+  });
+
+  it('advances author fallback from the raw tail when a page parses short', async () => {
+    mockSearchProfiles.mockResolvedValue([{ pubkey: 'a'.repeat(64) }]);
+    mockNostrQuery
+      .mockResolvedValueOnce([
+        makeEvent(1, 100),
+        makeEvent(2, 90),
+      ])
+      .mockResolvedValueOnce([makeEvent(3, 70)]);
+    mockParseVideoEvents
+      .mockReturnValueOnce([makeVideo(1, { createdAt: 100 })])
+      .mockReturnValueOnce([makeVideo(3, { createdAt: 70 })]);
+
+    const { result } = renderHook(
+      () => useInfiniteSearchVideos({ query: 'alice', searchType: 'author', sortMode: 'relevance', pageSize: 2 }),
+      { wrapper: createWrapper() }
+    );
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    await waitFor(() => {
+      expect(result.current.hasNextPage).toBe(true);
+    });
+
+    await act(async () => {
+      await result.current.fetchNextPage();
+    });
+
+    expect(mockNostrQuery.mock.calls[1]?.[0]).toEqual([
+      expect.objectContaining({ authors: ['a'.repeat(64)], limit: 2, until: 89 }),
+    ]);
+  });
+
+  it('paginates content fallback with a ranked raw window instead of until', async () => {
+    mockSearchVideos.mockRejectedValue(new Error('boom'));
+    const firstPageEvents = [makeEvent(1, 100), makeEvent(2, 90)];
+    const secondPrefixEvents = [
+      makeEvent(1, 100),
+      makeEvent(2, 90),
+      makeEvent(3, 80),
+      makeEvent(4, 70),
+    ];
+    mockNostrQuery
+      .mockResolvedValueOnce(firstPageEvents)
+      .mockResolvedValueOnce(secondPrefixEvents);
+    mockParseVideoEvents
+      .mockReturnValueOnce([makeVideo(1), makeVideo(2)])
+      .mockReturnValueOnce([makeVideo(3), makeVideo(4)]);
+
+    const { result } = renderHook(
+      () => useInfiniteSearchVideos({ query: 'jack', sortMode: 'relevance', pageSize: 2 }),
+      { wrapper: createWrapper() }
+    );
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    await waitFor(() => {
+      expect(result.current.hasNextPage).toBe(true);
+    });
+
+    await act(async () => {
+      await result.current.fetchNextPage();
+    });
+
+    expect(mockNostrQuery.mock.calls.map(call => call[0][0])).toEqual([
+      expect.objectContaining({ search: 'jack', limit: 2 }),
+      expect.objectContaining({ search: 'jack', limit: 4 }),
+    ]);
+    expect(mockNostrQuery.mock.calls[0]?.[0][0]).not.toHaveProperty('until');
+    expect(mockNostrQuery.mock.calls[1]?.[0][0]).not.toHaveProperty('until');
+    expect(mockParseVideoEvents.mock.calls[1]?.[0].map((event: NostrEvent) => event.id)).toEqual([
+      'event-03',
+      'event-04',
+    ]);
+  });
+
+  it('expands ranked content fallback before stopping after backfill exhaustion', async () => {
+    mockSearchVideos.mockRejectedValue(new Error('boom'));
+    mockNostrQuery
+      .mockResolvedValueOnce([makeEvent(1), makeEvent(2)])
+      .mockResolvedValueOnce([makeEvent(1), makeEvent(2), makeEvent(3), makeEvent(4)])
+      .mockResolvedValueOnce([makeEvent(1), makeEvent(2), makeEvent(3), makeEvent(4), makeEvent(5), makeEvent(6)]);
+    mockParseVideoEvents
+      .mockReturnValueOnce([])
+      .mockReturnValueOnce([])
+      .mockReturnValueOnce([]);
+
+    const { result } = renderHook(
+      () => useInfiniteSearchVideos({ query: 'jack', sortMode: 'hot', pageSize: 2 }),
+      { wrapper: createWrapper() }
+    );
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(mockNostrQuery).toHaveBeenCalledTimes(3);
+    expect(mockNostrQuery.mock.calls.map(call => call[0][0].limit)).toEqual([2, 4, 6]);
+    expect(result.current.data?.pages[0].videos).toEqual([]);
+    expect(result.current.hasNextPage).toBe(false);
+  });
+
+  it('stops ranked content fallback when the relay returns fewer raw events than requested', async () => {
+    mockSearchVideos.mockRejectedValue(new Error('boom'));
+    mockNostrQuery.mockResolvedValueOnce([makeEvent(1)]);
+    mockParseVideoEvents.mockReturnValueOnce([]);
+
+    const { result } = renderHook(
+      () => useInfiniteSearchVideos({ query: 'jack', sortMode: 'relevance', pageSize: 2 }),
+      { wrapper: createWrapper() }
+    );
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(mockNostrQuery).toHaveBeenCalledTimes(1);
+    expect(mockNostrQuery.mock.calls[0]?.[0][0]).toEqual(
+      expect.objectContaining({ search: 'jack', limit: 2 })
+    );
+    expect(result.current.data?.pages[0].videos).toEqual([]);
+    expect(result.current.hasNextPage).toBe(false);
+  });
+
+  it('does not interpret a Funnelcake offset as a relay timestamp when falling back', async () => {
+    mockSearchVideos
+      .mockResolvedValueOnce({ videos: [], has_more: true })
+      .mockRejectedValueOnce(new Error('boom'));
+    mockTransformToVideoPage.mockReturnValueOnce({
+      videos: [makeVideo(1)],
+      offset: 12,
+      hasMore: true,
+    });
+    mockNostrQuery.mockResolvedValueOnce([
+      makeEvent(1),
+      makeEvent(2),
+      makeEvent(3),
+      makeEvent(4),
+      makeEvent(5),
+      makeEvent(6),
+      makeEvent(7),
+      makeEvent(8),
+      makeEvent(9),
+      makeEvent(10),
+      makeEvent(11),
+      makeEvent(12),
+      makeEvent(13),
+      makeEvent(14),
+    ]);
+    mockParseVideoEvents.mockReturnValueOnce([makeVideo(13), makeVideo(14)]);
+
+    const { result } = renderHook(
+      () => useInfiniteSearchVideos({ query: 'jack', sortMode: 'relevance', pageSize: 2 }),
+      { wrapper: createWrapper() }
+    );
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    await waitFor(() => {
+      expect(result.current.hasNextPage).toBe(true);
+    });
+
+    await act(async () => {
+      await result.current.fetchNextPage();
+    });
+
+    expect(mockNostrQuery.mock.calls[0]?.[0][0]).toEqual(
+      expect.objectContaining({ search: 'jack', limit: 14 })
+    );
+    expect(mockNostrQuery.mock.calls[0]?.[0][0]).not.toHaveProperty('until');
   });
 });
 

--- a/src/hooks/useInfiniteSearchVideos.ts
+++ b/src/hooks/useInfiniteSearchVideos.ts
@@ -226,11 +226,16 @@ export function useInfiniteSearchVideos({
       const relayOffset = getRelayOffset(pageParam);
       const searchParams = parseSearchQuery(debouncedQuery, searchType);
       const funnelcakeAvailable = isFunnelcakeAvailable(apiUrl);
+      // Author search resolves pubkeys through Funnelcake and then pages the relay
+      // chronologically, so it may re-enter Funnelcake on a relay-timestamp param.
+      // A relay-offset param means we already fell over to the ranked window, which
+      // has no timestamp cursor to resume from — re-entering there would rewind the
+      // author feed to its newest page (#560).
       const canUseFunnelcake = funnelcakeAvailable
         && (
           !isSearchPageParam(pageParam)
           || pageParam.type === 'funnelcake-offset'
-          || searchParams.type === 'author'
+          || (searchParams.type === 'author' && pageParam.type === 'relay-timestamp')
         );
       const requestContext = {
         query: debouncedQuery,

--- a/src/hooks/useInfiniteSearchVideos.ts
+++ b/src/hooks/useInfiniteSearchVideos.ts
@@ -39,6 +39,10 @@ type SearchPageParam =
   | { type: 'relay-timestamp'; until: number }
   | { type: 'relay-offset'; offset: number };
 
+function isPageParamNumber(value: unknown): value is number {
+  return typeof value === 'number' && Number.isInteger(value) && value >= 0;
+}
+
 function useDebouncedValue(value: string, delay: number): string {
   const [debounced, setDebounced] = useState(value);
 
@@ -109,7 +113,7 @@ function getRelayOffset(pageParam: unknown): number {
     return 0;
   }
 
-  return pageParam.type === 'relay-offset' || pageParam.type === 'funnelcake-offset'
+  return pageParam.type === 'relay-offset'
     ? pageParam.offset
     : 0;
 }
@@ -120,11 +124,11 @@ function isSearchPageParam(pageParam: unknown): pageParam is SearchPageParam {
     && 'type' in pageParam
     && (
       ((pageParam as { type?: unknown; offset?: unknown }).type === 'funnelcake-offset'
-        && typeof (pageParam as { offset?: unknown }).offset === 'number')
+        && isPageParamNumber((pageParam as { offset?: unknown }).offset))
       || ((pageParam as { type?: unknown; until?: unknown }).type === 'relay-timestamp'
-        && typeof (pageParam as { until?: unknown }).until === 'number')
+        && isPageParamNumber((pageParam as { until?: unknown }).until))
       || ((pageParam as { type?: unknown; offset?: unknown }).type === 'relay-offset'
-        && typeof (pageParam as { offset?: unknown }).offset === 'number')
+        && isPageParamNumber((pageParam as { offset?: unknown }).offset))
     );
 }
 
@@ -267,7 +271,7 @@ export function useInfiniteSearchVideos({
             const page = transformToVideoPage(result, 'offset');
             const apiCompletedAt = performance.now();
             const nextCursor = page.offset ?? page.nextCursor;
-            const nextPageParam = nextCursor === undefined
+            const nextPageParam = !isPageParamNumber(nextCursor)
               ? undefined
               : { type: 'funnelcake-offset' as const, offset: nextCursor };
 
@@ -389,12 +393,11 @@ export function useInfiniteSearchVideos({
         limit: pageSize,
       };
 
-      if (relayTimestamp) {
-        filter.until = relayTimestamp;
-      }
-
       if (searchParams.type === 'hashtag') {
         filter['#t'] = [searchParams.value];
+        if (relayTimestamp) {
+          filter.until = relayTimestamp;
+        }
 
         const relayStartedAt = performance.now();
         const { events, videos } = await fetchChronologicalRelayPage({

--- a/src/hooks/useInfiniteSearchVideos.ts
+++ b/src/hooks/useInfiniteSearchVideos.ts
@@ -3,6 +3,7 @@
 
 import { useInfiniteQuery } from '@tanstack/react-query';
 import { useNostr } from '@nostrify/react';
+import type { NostrEvent } from '@nostrify/nostrify';
 import { useState, useEffect } from 'react';
 import { VIDEO_KINDS, type ParsedVideoData } from '@/types/video';
 import type { NIP50Filter, SortMode } from '@/types/nostr';
@@ -14,6 +15,12 @@ import { debugLog } from '@/lib/debug';
 import { transformToVideoPage } from '@/lib/funnelcakeTransform';
 import { isAbortError, reportFunnelcakeFallback } from '@/lib/funnelcakeFallbackReporting';
 import { isUrlLikeQuery } from '@/lib/searchUtils';
+import {
+  nextSortedOffset,
+  RAW_FEED_BACKFILL_ATTEMPTS,
+  sortedFeedHasMore,
+  sortedFeedWindowSize,
+} from '@/lib/sortedFeedWindow';
 
 interface UseInfiniteSearchVideosOptions {
   query: string;
@@ -24,8 +31,13 @@ interface UseInfiniteSearchVideosOptions {
 
 interface VideoPage {
   videos: ParsedVideoData[];
-  nextCursor: number | undefined;
+  nextPageParam?: SearchPageParam;
 }
+
+type SearchPageParam =
+  | { type: 'funnelcake-offset'; offset: number }
+  | { type: 'relay-timestamp'; until: number }
+  | { type: 'relay-offset'; offset: number };
 
 function useDebouncedValue(value: string, delay: number): string {
   const [debounced, setDebounced] = useState(value);
@@ -80,6 +92,105 @@ function parseSearchQuery(query: string, searchType: 'content' | 'author' | 'aut
   return { type: 'content', value: trimmedQuery };
 }
 
+function getFunnelcakeOffset(pageParam: unknown): number | undefined {
+  return isSearchPageParam(pageParam) && pageParam.type === 'funnelcake-offset'
+    ? pageParam.offset
+    : undefined;
+}
+
+function getRelayTimestamp(pageParam: unknown): number | undefined {
+  return isSearchPageParam(pageParam) && pageParam.type === 'relay-timestamp'
+    ? pageParam.until
+    : undefined;
+}
+
+function getRelayOffset(pageParam: unknown): number {
+  if (!isSearchPageParam(pageParam)) {
+    return 0;
+  }
+
+  return pageParam.type === 'relay-offset' || pageParam.type === 'funnelcake-offset'
+    ? pageParam.offset
+    : 0;
+}
+
+function isSearchPageParam(pageParam: unknown): pageParam is SearchPageParam {
+  return typeof pageParam === 'object'
+    && pageParam !== null
+    && 'type' in pageParam
+    && (
+      ((pageParam as { type?: unknown; offset?: unknown }).type === 'funnelcake-offset'
+        && typeof (pageParam as { offset?: unknown }).offset === 'number')
+      || ((pageParam as { type?: unknown; until?: unknown }).type === 'relay-timestamp'
+        && typeof (pageParam as { until?: unknown }).until === 'number')
+      || ((pageParam as { type?: unknown; offset?: unknown }).type === 'relay-offset'
+        && typeof (pageParam as { offset?: unknown }).offset === 'number')
+    );
+}
+
+async function fetchChronologicalRelayPage({
+  nostr,
+  filter,
+  pageSize,
+  signal,
+}: {
+  nostr: { query: (filters: NIP50Filter[], opts: { signal: AbortSignal }) => Promise<NostrEvent[]> };
+  filter: NIP50Filter;
+  pageSize: number;
+  signal: AbortSignal;
+}): Promise<{ events: NostrEvent[]; videos: ParsedVideoData[] }> {
+  let events: NostrEvent[] = [];
+  let videos: ParsedVideoData[] = [];
+  const queryFilter = { ...filter, limit: pageSize };
+
+  for (let attempt = 0; attempt < RAW_FEED_BACKFILL_ATTEMPTS; attempt++) {
+    events = await nostr.query([{ ...queryFilter }], { signal });
+    videos = parseVideoEvents(events);
+
+    if (videos.length > 0 || events.length < pageSize) {
+      break;
+    }
+
+    const lastEvent = events[events.length - 1];
+    if (!lastEvent) {
+      break;
+    }
+    queryFilter.until = lastEvent.created_at - 1;
+  }
+
+  return { events, videos };
+}
+
+async function fetchRankedRelayPage({
+  nostr,
+  filter,
+  pageSize,
+  offset,
+  signal,
+}: {
+  nostr: { query: (filters: NIP50Filter[], opts: { signal: AbortSignal }) => Promise<NostrEvent[]> };
+  filter: NIP50Filter;
+  pageSize: number;
+  offset: number;
+  signal: AbortSignal;
+}): Promise<{ events: NostrEvent[]; videos: ParsedVideoData[]; requestedLimit: number }> {
+  let events: NostrEvent[] = [];
+  let videos: ParsedVideoData[] = [];
+  let requestedLimit = pageSize;
+
+  for (let attempt = 0; attempt < RAW_FEED_BACKFILL_ATTEMPTS; attempt++) {
+    requestedLimit = offset + sortedFeedWindowSize(pageSize, attempt);
+    events = await nostr.query([{ ...filter, limit: requestedLimit }], { signal });
+    videos = parseVideoEvents(events.slice(offset));
+
+    if (videos.length > 0 || events.length < requestedLimit) {
+      break;
+    }
+  }
+
+  return { events, videos, requestedLimit };
+}
+
 export function useInfiniteSearchVideos({
   query,
   searchType = 'auto',
@@ -97,24 +208,33 @@ export function useInfiniteSearchVideos({
     queryKey: ['infinite-search-videos', debouncedQuery, searchType, sortMode, pageSize],
     queryFn: async ({ pageParam, signal }) => {
       if (!debouncedQuery.trim()) {
-        return { videos: [], nextCursor: undefined };
+        return { videos: [] };
       }
 
       // Skip URL-like queries that cause Funnelcake 500 errors (#166)
       if (isUrlLikeQuery(debouncedQuery)) {
-        return { videos: [], nextCursor: undefined };
+        return { videos: [] };
       }
 
       const requestStartedAt = performance.now();
-      const cursor = pageParam as number | undefined;
+      const funnelcakeOffset = getFunnelcakeOffset(pageParam);
+      const relayTimestamp = getRelayTimestamp(pageParam);
+      const relayOffset = getRelayOffset(pageParam);
       const searchParams = parseSearchQuery(debouncedQuery, searchType);
+      const funnelcakeAvailable = isFunnelcakeAvailable(apiUrl);
+      const canUseFunnelcake = funnelcakeAvailable
+        && (
+          !isSearchPageParam(pageParam)
+          || pageParam.type === 'funnelcake-offset'
+          || searchParams.type === 'author'
+        );
       const requestContext = {
         query: debouncedQuery,
         parsedType: searchParams.type,
         parsedValue: searchParams.value,
         searchType,
         sortMode,
-        cursor: cursor ?? null,
+        pageParam: isSearchPageParam(pageParam) ? pageParam : null,
         pageSize,
       };
 
@@ -128,7 +248,7 @@ export function useInfiniteSearchVideos({
         AbortSignal.timeout(8000),
       ]);
 
-      if (isFunnelcakeAvailable(apiUrl)) {
+      if (canUseFunnelcake) {
         try {
           const funnelcakeSort = mapSearchSortModeToFunnelcakeSort(sortMode);
 
@@ -139,7 +259,7 @@ export function useInfiniteSearchVideos({
               tag: searchParams.type === 'hashtag' ? searchParams.value : undefined,
               sort: funnelcakeSort,
               limit: pageSize,
-              offset: cursor,
+              offset: funnelcakeOffset,
               classic: sortMode === 'classic' ? true : undefined,
               platform: sortMode === 'classic' ? 'vine' : undefined,
               signal: abortSignal,
@@ -147,6 +267,9 @@ export function useInfiniteSearchVideos({
             const page = transformToVideoPage(result, 'offset');
             const apiCompletedAt = performance.now();
             const nextCursor = page.offset ?? page.nextCursor;
+            const nextPageParam = nextCursor === undefined
+              ? undefined
+              : { type: 'funnelcake-offset' as const, offset: nextCursor };
 
             console.info('[search/videos] funnelcake query complete', {
               ...requestContext,
@@ -160,7 +283,7 @@ export function useInfiniteSearchVideos({
 
             return {
               videos: page.videos,
-              nextCursor,
+              nextPageParam,
             };
           }
 
@@ -176,7 +299,7 @@ export function useInfiniteSearchVideos({
             const pubkeys = profiles.map(profile => profile.pubkey);
 
             if (pubkeys.length === 0) {
-              return { videos: [], nextCursor: undefined };
+              return { videos: [] };
             }
 
             const filter: NIP50Filter = {
@@ -184,14 +307,21 @@ export function useInfiniteSearchVideos({
               authors: pubkeys,
               limit: pageSize,
             };
-            if (cursor) {
-              filter.until = cursor;
+            if (relayTimestamp) {
+              filter.until = relayTimestamp;
             }
 
             const relayStartedAt = performance.now();
-            const events = await nostr.query([filter], { signal: abortSignal });
-            const videos = parseVideoEvents(events);
+            const { events, videos } = await fetchChronologicalRelayPage({
+              nostr,
+              filter,
+              pageSize,
+              signal: abortSignal,
+            });
             const relayCompletedAt = performance.now();
+            const rawCursor = events.length > 0
+              ? events[events.length - 1].created_at - 1
+              : undefined;
 
             console.info('[search/videos] author query complete', {
               ...requestContext,
@@ -204,7 +334,9 @@ export function useInfiniteSearchVideos({
 
             return {
               videos,
-              nextCursor: videos.length > 0 ? videos[videos.length - 1].createdAt - 1 : undefined,
+              nextPageParam: videos.length > 0 && rawCursor !== undefined
+                ? { type: 'relay-timestamp', until: rawCursor }
+                : undefined,
             };
           }
         } catch (error) {
@@ -233,7 +365,7 @@ export function useInfiniteSearchVideos({
             },
           });
         }
-      } else {
+      } else if (!funnelcakeAvailable) {
         console.info('[search/videos] funnelcake unavailable, falling back to relay search', {
           ...requestContext,
           totalMs: Math.round(performance.now() - requestStartedAt),
@@ -248,6 +380,8 @@ export function useInfiniteSearchVideos({
             searchType: searchParams.type,
           },
         });
+      } else {
+        debugLog('[useInfiniteSearchVideos] Continuing relay pagination for search fallback', pageParam);
       }
 
       const filter: NIP50Filter = {
@@ -255,17 +389,24 @@ export function useInfiniteSearchVideos({
         limit: pageSize,
       };
 
-      if (cursor) {
-        filter.until = cursor;
+      if (relayTimestamp) {
+        filter.until = relayTimestamp;
       }
 
       if (searchParams.type === 'hashtag') {
         filter['#t'] = [searchParams.value];
 
         const relayStartedAt = performance.now();
-        const events = await nostr.query([filter], { signal: abortSignal });
-        const videos = parseVideoEvents(events);
+        const { events, videos } = await fetchChronologicalRelayPage({
+          nostr,
+          filter,
+          pageSize,
+          signal: abortSignal,
+        });
         const relayCompletedAt = performance.now();
+        const rawCursor = events.length > 0
+          ? events[events.length - 1].created_at - 1
+          : undefined;
 
         console.info('[search/videos] hashtag query complete', {
           ...requestContext,
@@ -278,7 +419,9 @@ export function useInfiniteSearchVideos({
 
         return {
           videos,
-          nextCursor: videos.length > 0 ? videos[videos.length - 1].createdAt - 1 : undefined,
+          nextPageParam: videos.length > 0 && rawCursor !== undefined
+            ? { type: 'relay-timestamp', until: rawCursor }
+            : undefined,
         };
       }
 
@@ -287,25 +430,34 @@ export function useInfiniteSearchVideos({
         : `sort:${sortMode} ${searchParams.value}`;
 
       const relayStartedAt = performance.now();
-      const events = await nostr.query([filter], { signal: abortSignal });
-      const videos = parseVideoEvents(events);
+      const { events, videos, requestedLimit } = await fetchRankedRelayPage({
+        nostr,
+        filter,
+        pageSize,
+        offset: relayOffset,
+        signal: abortSignal,
+      });
       const relayCompletedAt = performance.now();
+      const nextOffset = nextSortedOffset(events.length, relayOffset);
+      const hasMore = videos.length > 0 && sortedFeedHasMore(events.length, requestedLimit);
 
       console.info('[search/videos] relay query complete', {
         ...requestContext,
         mode: 'nip50',
         relayMs: Math.round(relayCompletedAt - relayStartedAt),
         totalMs: Math.round(relayCompletedAt - requestStartedAt),
+        offset: relayOffset,
+        requestedLimit,
         eventCount: events.length,
         videoCount: videos.length,
       });
 
       return {
         videos,
-        nextCursor: videos.length > 0 ? videos[videos.length - 1].createdAt - 1 : undefined,
+        nextPageParam: hasMore ? { type: 'relay-offset', offset: nextOffset } : undefined,
       };
     },
-    getNextPageParam: lastPage => lastPage.nextCursor,
+    getNextPageParam: lastPage => lastPage.nextPageParam,
     initialPageParam: undefined,
     enabled: !!debouncedQuery.trim() && !!nostr,
     staleTime: 60_000,


### PR DESCRIPTION
## Summary

- Add typed pagination state for search video pages so Funnelcake offsets, chronological relay timestamps, and ranked relay offsets are not mixed.
- Backfill parsed-empty relay fallback pages and advance chronological search fallback from the raw event tail.
- Page ranked NIP-50 content fallback with growing raw windows instead of timestamp `until` cursors.

> Avoid naming corporate partners, customers, or other sensitive external brands in this PR title or body. Use generic descriptors unless a maintainer explicitly approves the public reference.

## Motivation

- Relay fallback pagination could stop on parsed-short pages because the cursor came from parsed videos instead of raw events.
- Ranked NIP-50 search results are not chronologically sorted, so timestamp cursors could silently skip valid results.

## Related Issue

- Closes #560

## Testing

- [x] `npm run test`
- [x] Manual verification completed: focused hook regressions with `npx vitest run src/hooks/useInfiniteSearchVideos.test.ts src/hooks/useInfiniteVideos.test.ts src/lib/sortedFeedWindow.test.ts`

## Visuals

- [ ] UI change with screenshots/video attached
- [x] No visual change
- [x] Visuals and text avoid sensitive external brand or partner names unless explicitly approved