### PR TITLE
fix(lists): preserve people-list relay hints

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -98,6 +98,9 @@ them on the generic event route rather than sending them to a detail page that
 cannot render them. Divine clients no longer author `d=block` kind `30000`
 lists; web reads that list only for legacy compatibility with pre-retirement
 accounts and older or non-Divine clients.
+People-list detail routes preserve `?relays=` hints from NIP-19 addresses and
+generic event redirects so lists published only to non-default relays can still
+be resolved.
 
 ## Styling
 

--- a/src/config/relays.test.ts
+++ b/src/config/relays.test.ts
@@ -97,4 +97,20 @@ describe('getEventLookupRelayUrls', () => {
     expect(relays).toContain('wss://configured.example');
     expect(relays).toContain(EVENT_LOOKUP_RELAYS[0].url);
   });
+
+  it('filters disabled configured and lookup relays without dropping explicit hints', () => {
+    const disabledLookupRelay = EVENT_LOOKUP_RELAYS[1].url;
+    const disabledHintRelay = EVENT_LOOKUP_RELAYS[2].url;
+
+    const relays = getEventLookupRelayUrls({
+      configuredRelayUrls: ['wss://configured.example', disabledLookupRelay],
+      relayHints: [disabledHintRelay],
+      disabledRelayUrls: [disabledLookupRelay, disabledHintRelay],
+    });
+
+    expect(relays).toContain('wss://configured.example');
+    expect(relays).not.toContain(disabledLookupRelay);
+    expect(relays).toContain(disabledHintRelay);
+    expect(relays.indexOf(disabledHintRelay)).toBe(relays.lastIndexOf(disabledHintRelay));
+  });
 });

--- a/src/config/relays.ts
+++ b/src/config/relays.ts
@@ -203,15 +203,23 @@ function warnTruncatedRelayHints(droppedCount: number): void {
 export function getEventLookupRelayUrls(options?: {
   configuredRelayUrls?: string[];
   relayHints?: string[];
+  disabledRelayUrls?: string[];
 }): string[] {
+  const disabledRelays = new Set(options?.disabledRelayUrls ?? []);
+  const configuredRelayUrls = (options?.configuredRelayUrls ?? [])
+    .filter((url) => !disabledRelays.has(url));
+  const relayHints = admitRemoteSuppliedRelays(options?.relayHints ?? [], {
+    cap: REMOTE_RELAY_HINT_CAP,
+    onRejected: warnRejectedRelayHint,
+    onTruncated: warnTruncatedRelayHints,
+  }).sort();
+  const lookupRelayUrls = getRelayUrls(EVENT_LOOKUP_RELAYS)
+    .filter((url) => !disabledRelays.has(url));
+
   return dedupeRelayUrls([
-    ...(options?.configuredRelayUrls ?? []),
-    ...admitRemoteSuppliedRelays(options?.relayHints ?? [], {
-      cap: REMOTE_RELAY_HINT_CAP,
-      onRejected: warnRejectedRelayHint,
-      onTruncated: warnTruncatedRelayHints,
-    }),
-    ...getRelayUrls(EVENT_LOOKUP_RELAYS),
+    ...configuredRelayUrls,
+    ...relayHints,
+    ...lookupRelayUrls,
   ]);
 }
 

--- a/src/hooks/usePeopleLists.test.ts
+++ b/src/hooks/usePeopleLists.test.ts
@@ -140,4 +140,24 @@ describe('people list hooks', () => {
 
     expect(mockNostrQuery).toHaveBeenCalledTimes(2);
   });
+
+  it('shares a cache entry across reordered relay hints', async () => {
+    mockNostrQuery.mockResolvedValue([peopleListEvent()]);
+    const { usePeopleList } = await import('./usePeopleLists');
+    const wrapper = createWrapper();
+    const { result, rerender } = renderHook(
+      ({ relayHints }) => usePeopleList(OWNER, 'friends', { relayHints }),
+      {
+        wrapper,
+        initialProps: { relayHints: ['wss://a.example', 'wss://b.example'] },
+      },
+    );
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    rerender({ relayHints: ['wss://b.example', 'wss://a.example'] });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    // Same hint set in a different order must reuse the cache, not refetch.
+    expect(mockNostrQuery).toHaveBeenCalledTimes(1);
+  });
 });

--- a/src/hooks/usePeopleLists.test.ts
+++ b/src/hooks/usePeopleLists.test.ts
@@ -12,6 +12,15 @@ vi.mock('@nostrify/react', () => ({
   useNostr: () => ({ nostr: { query: mockNostrQuery } }),
 }));
 
+vi.mock('@/hooks/useAppContext', () => ({
+  useAppContext: () => ({
+    config: {
+      relayUrl: 'wss://relay.divine.video',
+      relayUrls: ['wss://relay.divine.video'],
+    },
+  }),
+}));
+
 const OWNER = 'a'.repeat(64);
 const MEMBER = 'b'.repeat(64);
 
@@ -84,8 +93,51 @@ describe('people list hooks', () => {
 
     expect(mockNostrQuery).toHaveBeenCalledWith(
       [{ kinds: [30000], authors: [OWNER], '#d': ['friends'], limit: 10 }],
-      { signal: expect.any(AbortSignal) },
+      {
+        signal: expect.any(AbortSignal),
+        relays: expect.arrayContaining(['wss://relay.divine.video']),
+      },
     );
     expect(result.current.data?.name).toBe('New');
+  });
+
+  it('queries exact people lists through relay hints', async () => {
+    mockNostrQuery.mockResolvedValue([peopleListEvent()]);
+    const { usePeopleList } = await import('./usePeopleLists');
+
+    const { result } = renderHook(
+      () => usePeopleList(OWNER, 'friends', { relayHints: ['wss://relay.example'] }),
+      { wrapper: createWrapper() },
+    );
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(mockNostrQuery).toHaveBeenCalledWith(
+      [{ kinds: [30000], authors: [OWNER], '#d': ['friends'], limit: 10 }],
+      {
+        signal: expect.any(AbortSignal),
+        relays: expect.arrayContaining(['wss://relay.divine.video', 'wss://relay.example']),
+      },
+    );
+  });
+
+  it('keeps relay-hinted people-list lookups in distinct cache entries', async () => {
+    mockNostrQuery
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([peopleListEvent({ tags: [['d', 'friends'], ['title', 'Hinted'], ['p', MEMBER]] })]);
+    const { usePeopleList } = await import('./usePeopleLists');
+    const wrapper = createWrapper();
+    const { result, rerender } = renderHook(
+      ({ relayHints }) => usePeopleList(OWNER, 'friends', { relayHints }),
+      {
+        wrapper,
+        initialProps: { relayHints: [] as string[] },
+      },
+    );
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    rerender({ relayHints: ['wss://relay.example'] });
+    await waitFor(() => expect(result.current.data?.name).toBe('Hinted'));
+
+    expect(mockNostrQuery).toHaveBeenCalledTimes(2);
   });
 });

--- a/src/hooks/usePeopleLists.test.ts
+++ b/src/hooks/usePeopleLists.test.ts
@@ -7,6 +7,12 @@ import type { NostrEvent } from '@nostrify/nostrify';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mockNostrQuery = vi.fn();
+const mockAppConfig = vi.hoisted(() => ({
+  relayUrl: 'wss://relay.divine.video',
+  relayUrls: ['wss://relay.divine.video'],
+  customRelayUrls: [] as string[],
+  disabledPresetUrls: [] as string[],
+}));
 
 vi.mock('@nostrify/react', () => ({
   useNostr: () => ({ nostr: { query: mockNostrQuery } }),
@@ -14,10 +20,7 @@ vi.mock('@nostrify/react', () => ({
 
 vi.mock('@/hooks/useAppContext', () => ({
   useAppContext: () => ({
-    config: {
-      relayUrl: 'wss://relay.divine.video',
-      relayUrls: ['wss://relay.divine.video'],
-    },
+    config: mockAppConfig,
   }),
 }));
 
@@ -49,6 +52,10 @@ function createWrapper() {
 describe('people list hooks', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockAppConfig.relayUrl = 'wss://relay.divine.video';
+    mockAppConfig.relayUrls = ['wss://relay.divine.video'];
+    mockAppConfig.customRelayUrls = [];
+    mockAppConfig.disabledPresetUrls = [];
     mockNostrQuery.mockResolvedValue([]);
   });
 
@@ -120,6 +127,27 @@ describe('people list hooks', () => {
     );
   });
 
+  it('uses custom relays and skips disabled app-chosen relays for exact people-list lookups', async () => {
+    mockAppConfig.relayUrls = ['wss://relay.divine.video', 'wss://relay.damus.io'];
+    mockAppConfig.customRelayUrls = ['wss://custom.example'];
+    mockAppConfig.disabledPresetUrls = ['wss://relay.damus.io'];
+    mockNostrQuery.mockResolvedValue([peopleListEvent()]);
+    const { usePeopleList } = await import('./usePeopleLists');
+
+    const { result } = renderHook(() => usePeopleList(OWNER, 'friends'), { wrapper: createWrapper() });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(mockNostrQuery).toHaveBeenCalledWith(
+      [{ kinds: [30000], authors: [OWNER], '#d': ['friends'], limit: 10 }],
+      {
+        signal: expect.any(AbortSignal),
+        relays: expect.arrayContaining(['wss://relay.divine.video', 'wss://custom.example']),
+      },
+    );
+    const relays = mockNostrQuery.mock.calls[0]?.[1]?.relays;
+    expect(relays).not.toContain('wss://relay.damus.io');
+  });
+
   it('keeps relay-hinted people-list lookups in distinct cache entries', async () => {
     mockNostrQuery
       .mockResolvedValueOnce([])
@@ -158,6 +186,26 @@ describe('people list hooks', () => {
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
     // Same hint set in a different order must reuse the cache, not refetch.
+    expect(mockNostrQuery).toHaveBeenCalledTimes(1);
+  });
+
+  it('shares a cache entry when raw hints resolve to the same relay set', async () => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    mockNostrQuery.mockResolvedValue([peopleListEvent()]);
+    const { usePeopleList } = await import('./usePeopleLists');
+    const wrapper = createWrapper();
+    const { result, rerender } = renderHook(
+      ({ relayHints }) => usePeopleList(OWNER, 'friends', { relayHints }),
+      {
+        wrapper,
+        initialProps: { relayHints: ['wss://relay.example'] },
+      },
+    );
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    rerender({ relayHints: ['wss://relay.example', 'ws://rejected.example'] });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
     expect(mockNostrQuery).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/hooks/usePeopleLists.ts
+++ b/src/hooks/usePeopleLists.ts
@@ -35,11 +35,16 @@ export function usePeopleList(
 ) {
   const { nostr } = useNostr();
   const { config } = useAppContext();
-  const configuredRelayUrls = config.relayUrls || [config.relayUrl];
-  // Canonicalize hints (dedupe + sort) so reordered/duplicate hint sets share a
-  // cache entry instead of refetching the same list. The query itself still
-  // admits/dedupes hints via getEventLookupRelayUrls below.
-  const relayKey = [...configuredRelayUrls, ...[...new Set(options.relayHints ?? [])].sort()].join(',');
+  const configuredRelayUrls = [
+    ...(config.relayUrls || [config.relayUrl]),
+    ...(config.customRelayUrls ?? []),
+  ];
+  const relays = getEventLookupRelayUrls({
+    configuredRelayUrls,
+    relayHints: options.relayHints,
+    disabledRelayUrls: config.disabledPresetUrls,
+  });
+  const relayKey = relays.join(',');
 
   return useQuery({
     queryKey: ['people-list', pubkey, listId, relayKey],
@@ -51,10 +56,7 @@ export function usePeopleList(
         limit: 10,
       }], {
         signal: AbortSignal.any([signal, AbortSignal.timeout(5000)]),
-        relays: getEventLookupRelayUrls({
-          configuredRelayUrls,
-          relayHints: options.relayHints,
-        }),
+        relays,
       });
 
       return deduplicatePeopleLists(events)[0] ?? null;

--- a/src/hooks/usePeopleLists.ts
+++ b/src/hooks/usePeopleLists.ts
@@ -2,6 +2,8 @@
 
 import { useNostr } from '@nostrify/react';
 import { useQuery } from '@tanstack/react-query';
+import { getEventLookupRelayUrls } from '@/config/relays';
+import { useAppContext } from '@/hooks/useAppContext';
 import { deduplicatePeopleLists, PEOPLE_LIST_KIND } from '@/lib/parsePeopleListFromEvent';
 
 export function usePeopleLists(pubkey: string | undefined) {
@@ -26,11 +28,18 @@ export function usePeopleLists(pubkey: string | undefined) {
   });
 }
 
-export function usePeopleList(pubkey: string | undefined, listId: string | undefined) {
+export function usePeopleList(
+  pubkey: string | undefined,
+  listId: string | undefined,
+  options: { relayHints?: string[] } = {},
+) {
   const { nostr } = useNostr();
+  const { config } = useAppContext();
+  const configuredRelayUrls = config.relayUrls || [config.relayUrl];
+  const relayKey = [...configuredRelayUrls, ...(options.relayHints ?? [])].join(',');
 
   return useQuery({
-    queryKey: ['people-list', pubkey, listId],
+    queryKey: ['people-list', pubkey, listId, relayKey],
     queryFn: async ({ signal }) => {
       const events = await nostr.query([{
         kinds: [PEOPLE_LIST_KIND],
@@ -39,6 +48,10 @@ export function usePeopleList(pubkey: string | undefined, listId: string | undef
         limit: 10,
       }], {
         signal: AbortSignal.any([signal, AbortSignal.timeout(5000)]),
+        relays: getEventLookupRelayUrls({
+          configuredRelayUrls,
+          relayHints: options.relayHints,
+        }),
       });
 
       return deduplicatePeopleLists(events)[0] ?? null;

--- a/src/hooks/usePeopleLists.ts
+++ b/src/hooks/usePeopleLists.ts
@@ -36,7 +36,10 @@ export function usePeopleList(
   const { nostr } = useNostr();
   const { config } = useAppContext();
   const configuredRelayUrls = config.relayUrls || [config.relayUrl];
-  const relayKey = [...configuredRelayUrls, ...(options.relayHints ?? [])].join(',');
+  // Canonicalize hints (dedupe + sort) so reordered/duplicate hint sets share a
+  // cache entry instead of refetching the same list. The query itself still
+  // admits/dedupes hints via getEventLookupRelayUrls below.
+  const relayKey = [...configuredRelayUrls, ...[...new Set(options.relayHints ?? [])].sort()].join(',');
 
   return useQuery({
     queryKey: ['people-list', pubkey, listId, relayKey],

--- a/src/lib/directSearch.test.ts
+++ b/src/lib/directSearch.test.ts
@@ -85,6 +85,7 @@ describe('directSearch', () => {
       identifier: 'friends',
       pubkey,
       kind: 30000,
+      relays: ['wss://relay.example'],
     });
     const blockListNaddr = nip19.naddrEncode({
       identifier: 'block',
@@ -104,7 +105,7 @@ describe('directSearch', () => {
       entity: 'event',
     });
     expect(getDirectSearchTarget(peopleListNaddr)).toEqual({
-      path: buildPeopleListPath(pubkey, 'friends'),
+      path: `${buildPeopleListPath(pubkey, 'friends')}?relays=${encodeURIComponent('wss://relay.example')}`,
       entity: 'event',
     });
     expect(getDirectSearchTarget(blockListNaddr)).toEqual({

--- a/src/lib/directSearch.ts
+++ b/src/lib/directSearch.ts
@@ -7,6 +7,7 @@ import {
   buildVideoPath,
   buildResolvedEventRoute,
 } from '@/lib/eventRouting';
+import { appendRelayHints } from '@/lib/relayHints';
 
 const VIDEO_COORDINATE_PATTERN = /^(?:a:)?(?<kind>\d+):(?<pubkey>[0-9a-f]{64}):(?<identifier>.+)$/i;
 const HEX_64_PATTERN = /^[0-9a-f]{64}$/i;
@@ -67,16 +68,6 @@ export function isLikelyOpaqueVideoIdentifier(value: string, allowShortTokens = 
   }
 
   return allowShortTokens || normalized.length >= 16;
-}
-
-function withRelayHints(path: string, relayHints?: string[]): string {
-  if (!path.startsWith('/event') || !relayHints?.length) {
-    return path;
-  }
-
-  const params = new URLSearchParams();
-  params.set('relays', relayHints.join(','));
-  return `${path}?${params.toString()}`;
 }
 
 function parseHttpUrl(value: string): URL | null {
@@ -213,7 +204,7 @@ export function getDirectSearchTarget(value: string): DirectSearchTarget | null 
             : buildEventPath(decoded.data.id);
 
         return {
-          path: withRelayHints(path, decoded.data.relays),
+          path: appendRelayHints(path, decoded.data.relays),
           entity: decoded.data.kind && VIDEO_KINDS.includes(decoded.data.kind as typeof VIDEO_KINDS[number])
             ? 'video'
             : 'event',
@@ -224,7 +215,7 @@ export function getDirectSearchTarget(value: string): DirectSearchTarget | null 
         {
           const path = buildAddressableRoute(decoded.data.kind, decoded.data.pubkey, decoded.data.identifier);
         return {
-          path: withRelayHints(path, decoded.data.relays),
+          path: appendRelayHints(path, decoded.data.relays),
           entity: VIDEO_KINDS.includes(decoded.data.kind as typeof VIDEO_KINDS[number]) ? 'video' : 'event',
         };
         }

--- a/src/lib/eventLookup.ts
+++ b/src/lib/eventLookup.ts
@@ -15,12 +15,14 @@ export interface AddressableEventRef {
 export interface EventLookupOptions {
   relayHints?: string[];
   relayUrls?: string[];
+  disabledRelayUrls?: string[];
 }
 
 function resolveEventLookupRelays(options?: EventLookupOptions): string[] {
   return getEventLookupRelayUrls({
     configuredRelayUrls: options?.relayUrls,
     relayHints: options?.relayHints,
+    disabledRelayUrls: options?.disabledRelayUrls,
   });
 }
 

--- a/src/lib/relayHints.test.ts
+++ b/src/lib/relayHints.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import { appendRelayHints, parseRelayHints } from './relayHints';
+
+describe('relayHints', () => {
+  it('parses comma-separated relay hints from repeated query params', () => {
+    expect(parseRelayHints('?relays=wss://one.example,wss://two.example&relays= wss://three.example ')).toEqual([
+      'wss://one.example',
+      'wss://two.example',
+      'wss://three.example',
+    ]);
+  });
+
+  it('appends relay hints to hint-consuming routes', () => {
+    expect(appendRelayHints('/event/a/30000/pubkey/friends', ['wss://relay.example'])).toBe(
+      `/event/a/30000/pubkey/friends?relays=${encodeURIComponent('wss://relay.example')}`,
+    );
+    expect(appendRelayHints('/people-lists/pubkey/friends', ['wss://relay.example'])).toBe(
+      `/people-lists/pubkey/friends?relays=${encodeURIComponent('wss://relay.example')}`,
+    );
+  });
+
+  it('does not append relay hints to routes that do not consume them', () => {
+    expect(appendRelayHints('/video/friends', ['wss://relay.example'])).toBe('/video/friends');
+    expect(appendRelayHints('/list/pubkey/friends', ['wss://relay.example'])).toBe('/list/pubkey/friends');
+  });
+
+  it('leaves paths unchanged when no hints are available', () => {
+    expect(appendRelayHints('/people-lists/pubkey/friends')).toBe('/people-lists/pubkey/friends');
+    expect(appendRelayHints('/people-lists/pubkey/friends', [])).toBe('/people-lists/pubkey/friends');
+  });
+});

--- a/src/lib/relayHints.ts
+++ b/src/lib/relayHints.ts
@@ -1,0 +1,25 @@
+const RELAY_HINT_ROUTE_PREFIXES = ['/event', '/people-lists'];
+
+function canConsumeRelayHints(path: string): boolean {
+  return RELAY_HINT_ROUTE_PREFIXES.some((prefix) => path === prefix || path.startsWith(`${prefix}/`));
+}
+
+export function parseRelayHints(search: string): string[] {
+  const params = new URLSearchParams(search);
+  return params
+    .getAll('relays')
+    .flatMap((value) => value.split(','))
+    .map((value) => value.trim())
+    .filter(Boolean);
+}
+
+export function appendRelayHints(path: string, relayHints?: string[]): string {
+  if (!canConsumeRelayHints(path) || !relayHints?.length) {
+    return path;
+  }
+
+  const [pathname, search = ''] = path.split('?', 2);
+  const params = new URLSearchParams(search);
+  params.set('relays', relayHints.join(','));
+  return `${pathname}?${params.toString()}`;
+}

--- a/src/pages/EventPage.test.tsx
+++ b/src/pages/EventPage.test.tsx
@@ -1,7 +1,7 @@
 import { describe, expect, it, beforeEach, vi } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { MemoryRouter, Route, Routes, Link } from 'react-router-dom';
+import { MemoryRouter, Route, Routes, Link, useLocation } from 'react-router-dom';
 import type {
   ButtonHTMLAttributes,
   HTMLAttributes,
@@ -98,6 +98,11 @@ vi.mock('@/components/ui/badge', () => ({
   Badge: ({ children, ...props }: HTMLAttributes<HTMLSpanElement>) => <span {...props}>{children}</span>,
 }));
 
+function PeopleListRouteProbe() {
+  const location = useLocation();
+  return <div data-testid="people-list-page">People list page {location.search}</div>;
+}
+
 function renderPage(initialEntries: string[]) {
   const queryClient = new QueryClient({
     defaultOptions: {
@@ -112,7 +117,7 @@ function renderPage(initialEntries: string[]) {
           <Route path="/event/:eventId" element={<EventPage />} />
           <Route path="/event/a/:kind/:pubkey/:identifier" element={<EventPage />} />
           <Route path="/list/:pubkey/:listId" element={<div data-testid="list-page">List page</div>} />
-          <Route path="/people-lists/:pubkey/:listId" element={<div data-testid="people-list-page">People list page</div>} />
+          <Route path="/people-lists/:pubkey/:listId" element={<PeopleListRouteProbe />} />
           <Route path="/video/:id" element={<div data-testid="video-page">Video page</div>} />
           <Route path="/profile/:npub" element={<div data-testid="profile-page">Profile page</div>} />
           <Route path="/t/:tag" element={<div data-testid="tag-page">Tag page</div>} />
@@ -187,6 +192,25 @@ describe('EventPage', () => {
     renderPage([`/event/${'c'.repeat(64)}`]);
 
     expect(await screen.findByTestId('people-list-page')).toBeInTheDocument();
+  });
+
+  it('preserves relay hints when redirecting people lists to the detail page', async () => {
+    const pubkey = 'a'.repeat(64);
+    const relayHint = 'wss://relay.example';
+    mockFetchAddressableEvent.mockResolvedValue({
+      id: 'c'.repeat(64),
+      pubkey,
+      created_at: 1_700_000_000,
+      kind: 30000,
+      tags: [['d', 'friends']],
+      content: '',
+      sig: '1'.repeat(128),
+    });
+
+    renderPage([`/event/a/30000/${pubkey}/friends?relays=${encodeURIComponent(relayHint)}`]);
+
+    expect(await screen.findByTestId('people-list-page')).toBeInTheDocument();
+    expect(screen.getByTestId('people-list-page')).toHaveTextContent(`?relays=${encodeURIComponent(relayHint)}`);
   });
 
   it('keeps legacy block list coordinates on the generic event page', async () => {

--- a/src/pages/EventPage.tsx
+++ b/src/pages/EventPage.tsx
@@ -127,7 +127,9 @@ export function EventPage() {
   const decodedIdentifier = identifier ? decodeURIComponent(identifier) : null;
   const relayHints = parseRelayHints(location.search);
   const configuredRelayUrls = config.relayUrls || [config.relayUrl];
-  const relayKey = [...configuredRelayUrls, ...relayHints].join(',');
+  // Canonicalize hints (dedupe + sort) so reordered/duplicate hint sets share a
+  // cache entry instead of refetching the same event.
+  const relayKey = [...configuredRelayUrls, ...[...new Set(relayHints)].sort()].join(',');
 
   const { data: event, isLoading, error } = useQuery({
     queryKey: ['event-page', eventId, numericKind, pubkey, decodedIdentifier, relayKey],

--- a/src/pages/EventPage.tsx
+++ b/src/pages/EventPage.tsx
@@ -20,6 +20,7 @@ import {
 } from '@/lib/eventRouting';
 import { getDirectSearchTarget } from '@/lib/directSearch';
 import { appendRelayHints, parseRelayHints } from '@/lib/relayHints';
+import { getEventLookupRelayUrls } from '@/config/relays';
 import { genUserName } from '@/lib/genUserName';
 import { getSafeProfileImage } from '@/lib/imageUtils';
 import { NoteContent } from '@/components/NoteContent';
@@ -126,10 +127,16 @@ export function EventPage() {
   const numericKind = kind ? Number(kind) : null;
   const decodedIdentifier = identifier ? decodeURIComponent(identifier) : null;
   const relayHints = parseRelayHints(location.search);
-  const configuredRelayUrls = config.relayUrls || [config.relayUrl];
-  // Canonicalize hints (dedupe + sort) so reordered/duplicate hint sets share a
-  // cache entry instead of refetching the same event.
-  const relayKey = [...configuredRelayUrls, ...[...new Set(relayHints)].sort()].join(',');
+  const configuredRelayUrls = [
+    ...(config.relayUrls || [config.relayUrl]),
+    ...(config.customRelayUrls ?? []),
+  ];
+  const relays = getEventLookupRelayUrls({
+    configuredRelayUrls,
+    relayHints,
+    disabledRelayUrls: config.disabledPresetUrls,
+  });
+  const relayKey = relays.join(',');
 
   const { data: event, isLoading, error } = useQuery({
     queryKey: ['event-page', eventId, numericKind, pubkey, decodedIdentifier, relayKey],
@@ -140,6 +147,7 @@ export function EventPage() {
         return fetchEventById(nostr, eventId, signal, {
           relayHints,
           relayUrls: configuredRelayUrls,
+          disabledRelayUrls: config.disabledPresetUrls,
         });
       }
 
@@ -151,6 +159,7 @@ export function EventPage() {
         }, signal, {
           relayHints,
           relayUrls: configuredRelayUrls,
+          disabledRelayUrls: config.disabledPresetUrls,
         });
       }
 

--- a/src/pages/EventPage.tsx
+++ b/src/pages/EventPage.tsx
@@ -19,6 +19,7 @@ import {
   isNoteEventKind,
 } from '@/lib/eventRouting';
 import { getDirectSearchTarget } from '@/lib/directSearch';
+import { appendRelayHints, parseRelayHints } from '@/lib/relayHints';
 import { genUserName } from '@/lib/genUserName';
 import { getSafeProfileImage } from '@/lib/imageUtils';
 import { NoteContent } from '@/components/NoteContent';
@@ -109,15 +110,6 @@ function EventLoadingState() {
   );
 }
 
-function getRelayHints(search: string): string[] {
-  const params = new URLSearchParams(search);
-  return params
-    .getAll('relays')
-    .flatMap(value => value.split(','))
-    .map(value => value.trim())
-    .filter(Boolean);
-}
-
 export function EventPage() {
   const { eventId, kind, pubkey, identifier } = useParams<{
     eventId?: string;
@@ -133,7 +125,7 @@ export function EventPage() {
 
   const numericKind = kind ? Number(kind) : null;
   const decodedIdentifier = identifier ? decodeURIComponent(identifier) : null;
-  const relayHints = getRelayHints(location.search);
+  const relayHints = parseRelayHints(location.search);
   const configuredRelayUrls = config.relayUrls || [config.relayUrl];
   const relayKey = [...configuredRelayUrls, ...relayHints].join(',');
 
@@ -200,7 +192,7 @@ export function EventPage() {
   }
 
   if (event && redirectPath && redirectPath !== location.pathname) {
-    return <Navigate to={redirectPath} replace />;
+    return <Navigate to={appendRelayHints(redirectPath, relayHints)} replace />;
   }
 
   if (!event) {

--- a/src/pages/ListDetailPage.tsx
+++ b/src/pages/ListDetailPage.tsx
@@ -160,7 +160,14 @@ export default function ListDetailPage() {
   const navigate = useNavigate();
   const { nostr } = useNostr();
   const { config } = useAppContext();
-  const listLookupRelayKey = (config.relayUrls || [config.relayUrl]).join(',');
+  const listLookupRelays = getEventLookupRelayUrls({
+    configuredRelayUrls: [
+      ...(config.relayUrls || [config.relayUrl]),
+      ...(config.customRelayUrls ?? []),
+    ],
+    disabledRelayUrls: config.disabledPresetUrls,
+  });
+  const listLookupRelayKey = listLookupRelays.join(',');
   const { user } = useCurrentUser();
   const { toast } = useToast();
   const { share } = useShare();
@@ -212,9 +219,7 @@ export default function ListDetailPage() {
         limit: 1
       }], {
         signal,
-        relays: getEventLookupRelayUrls({
-          configuredRelayUrls: config.relayUrls || [config.relayUrl],
-        }),
+        relays: listLookupRelays,
       });
 
       if (ownerEvents.length === 0) {
@@ -238,9 +243,7 @@ export default function ListDetailPage() {
         limit: 50,
       }], {
         signal,
-        relays: getEventLookupRelayUrls({
-          configuredRelayUrls: config.relayUrls || [config.relayUrl],
-        }),
+        relays: listLookupRelays,
       });
 
       const participantSet = new Set(participantPubkeys);

--- a/src/pages/PeopleListDetailPage.test.tsx
+++ b/src/pages/PeopleListDetailPage.test.tsx
@@ -107,9 +107,9 @@ vi.mock('@/components/VideoGrid', () => ({
   ),
 }));
 
-function renderPage() {
+function renderPage(initialEntry = `/people-lists/${OWNER}/friends`) {
   return render(
-    <MemoryRouter initialEntries={[`/people-lists/${OWNER}/friends`]}>
+    <MemoryRouter initialEntries={[initialEntry]}>
       <Routes>
         <Route path="/people-lists/:pubkey/:listId" element={<PeopleListDetailPage />} />
         <Route path="/profile/:npub/lists" element={<div>Profile lists</div>} />
@@ -210,8 +210,16 @@ describe('PeopleListDetailPage', () => {
 
     renderUppercaseRoute();
 
-    expect(mockUsePeopleList).toHaveBeenCalledWith(OWNER, 'friends');
+    expect(mockUsePeopleList).toHaveBeenCalledWith(OWNER, 'friends', { relayHints: [] });
     expect(screen.getByRole('button', { name: 'Edit' })).toBeInTheDocument();
+  });
+
+  it('threads relay hints into the exact list lookup', () => {
+    renderPage(`/people-lists/${OWNER}/friends?relays=${encodeURIComponent('wss://relay.example')}`);
+
+    expect(mockUsePeopleList).toHaveBeenCalledWith(OWNER, 'friends', {
+      relayHints: ['wss://relay.example'],
+    });
   });
 
   it('hides owner controls for non-owners', () => {

--- a/src/pages/PeopleListDetailPage.tsx
+++ b/src/pages/PeopleListDetailPage.tsx
@@ -5,7 +5,7 @@ import { formatDistanceToNow } from 'date-fns';
 import { nip19 } from 'nostr-tools';
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Link, useNavigate, useParams } from 'react-router-dom';
+import { Link, useLocation, useNavigate, useParams } from 'react-router-dom';
 import { DeleteListDialog } from '@/components/DeleteListDialog';
 import { EditPeopleListDialog } from '@/components/EditPeopleListDialog';
 import { PeopleListMembers } from '@/components/PeopleListMembers';
@@ -24,6 +24,7 @@ import { useToast } from '@/hooks/useToast';
 import { genUserName } from '@/lib/genUserName';
 import { getSafeProfileImage } from '@/lib/imageUtils';
 import { buildProfileLinkPath } from '@/lib/profileLinks';
+import { parseRelayHints } from '@/lib/relayHints';
 import { getPeopleListShareData } from '@/lib/shareUtils';
 
 function LoadMoreButton({
@@ -47,10 +48,18 @@ function LoadMoreButton({
   );
 }
 
-function PeopleListContent({ pubkey, listId }: { pubkey: string; listId: string }) {
+function PeopleListContent({
+  pubkey,
+  listId,
+  relayHints,
+}: {
+  pubkey: string;
+  listId: string;
+  relayHints: string[];
+}) {
   const { t } = useTranslation();
   const navigate = useNavigate();
-  const listQuery = usePeopleList(pubkey, listId);
+  const listQuery = usePeopleList(pubkey, listId, { relayHints });
   const author = useAuthor(pubkey);
   const { user } = useCurrentUser();
   const { toast } = useToast();
@@ -263,7 +272,9 @@ function PeopleListContent({ pubkey, listId }: { pubkey: string; listId: string 
 
 export default function PeopleListDetailPage() {
   const { pubkey, listId } = useParams<{ pubkey: string; listId: string }>();
+  const location = useLocation();
   const isValidPubkey = Boolean(pubkey && /^[0-9a-fA-F]{64}$/.test(pubkey));
+  const relayHints = parseRelayHints(location.search);
 
   if (!isValidPubkey || !pubkey || !listId) {
     return (
@@ -273,5 +284,5 @@ export default function PeopleListDetailPage() {
     );
   }
 
-  return <PeopleListContent pubkey={pubkey.toLowerCase()} listId={listId} />;
+  return <PeopleListContent pubkey={pubkey.toLowerCase()} listId={listId} relayHints={relayHints} />;
 }


### PR DESCRIPTION
## Summary

- Preserve relay hints when direct-searching people-list naddrs and when generic event routes redirect to people-list detail pages.
- Thread relay hints into exact people-list lookups with distinct React Query cache keys.
- Add regression tests for relay hint parsing/appending, direct search, redirects, detail pages, and hook relay selection.

> Avoid naming corporate partners, customers, or other sensitive external brands in this PR title or body. Use generic descriptors unless a maintainer explicitly approves the public reference.

## Motivation

- People lists published only to non-default relays could resolve through an naddr/event lookup and then dead-end on the detail route because relay hints were dropped before the final query.

## Related Issue

- Closes #553

## Testing

- [x] `npm run test`
- [x] Manual verification completed: reviewed routing/query diff and confirmed no visual surface change

## Visuals

- [ ] UI change with screenshots/video attached
- [x] No visual change
- [x] Visuals and text avoid sensitive external brand or partner names unless explicitly approved