### PR TITLE
fix(notifications): align read marker timing

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -52,6 +52,25 @@ contexts (`AppContext`, `VideoPlaybackContext`, `FullscreenFeedContext`,
 and subscriptions against Nostr relays. Auth uses `@divinevideo/login` with
 `NostrLoginProvider`, hydrated from cross-subdomain cookies.
 
+### Notification Read Marker
+
+Web and mobile both write the same Funnelcake per-pubkey notification read
+marker through `POST /api/users/{pubkey}/notifications/read` with an empty body.
+On web, [`src/pages/NotificationsPage.tsx`](./src/pages/NotificationsPage.tsx)
+marks the All tab read once per page mount after the notifications query
+successfully loads, even when the fetched list is empty or already read. Filtered
+tabs do not mark read.
+
+Web deliberately does not mark read on `refetchOnWindowFocus`. Mobile marks
+after an explicit unfiltered pull-to-refresh, but excludes app resume; the web
+window-focus refetch maps to app resume, not to that deliberate refresh gesture.
+
+Until Funnelcake supports bounded read-marker writes (divine-funnelcake #938),
+the empty-body request advances the marker to server time. That can cover
+notifications whose source events existed before the request but whose inbox
+rows had not materialized yet. Web accepts that tradeoff only for the
+once-per-mount All-tab write.
+
 ## Routing
 
 Client-side SPA routing via react-router-dom v6.

--- a/src/hooks/useHydratedNotifications.test.ts
+++ b/src/hooks/useHydratedNotifications.test.ts
@@ -114,10 +114,14 @@ function makeNotificationsPage(notifications: RawNotification[], unreadCount = 0
   return { notifications, unreadCount, hasMore: false };
 }
 
-function makeInfiniteQueryResult(pages: NotificationsResponse[], opts?: { isLoading?: boolean; isError?: boolean }) {
+function makeInfiniteQueryResult(
+  pages: NotificationsResponse[],
+  opts?: { isLoading?: boolean; isSuccess?: boolean; isError?: boolean },
+) {
   return {
     data: { pages, pageParams: [undefined] },
     isLoading: opts?.isLoading ?? false,
+    isSuccess: opts?.isSuccess ?? true,
     isError: opts?.isError ?? false,
     error: null,
     fetchNextPage: vi.fn(),
@@ -671,6 +675,7 @@ describe('useHydratedNotifications', () => {
     mockUseNotifications.mockReturnValue({
       data: { pages: [makeNotificationsPage([], 5)], pageParams: [undefined] },
       isLoading: false,
+      isSuccess: true,
       isError: false,
       error: null,
       fetchNextPage,
@@ -694,6 +699,33 @@ describe('useHydratedNotifications', () => {
     expect(result.current.isFetchingNextPage).toBe(true);
     expect(result.current.fetchNextPage).toBe(fetchNextPage);
     expect(result.current.unreadCount).toBe(5);
+    expect(result.current.isSuccess).toBe(true);
+  });
+
+  it('exposes disabled notification queries as not successful', async () => {
+    mockUseNotifications.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      isSuccess: false,
+      isError: false,
+      error: null,
+      fetchNextPage: vi.fn(),
+      hasNextPage: false,
+      isFetchingNextPage: false,
+    });
+    mockUseBatchedAuthors.mockReturnValue({ data: {} });
+
+    const { useHydratedNotifications } = await import('./useHydratedNotifications');
+
+    const { result } = renderHook(
+      () => useHydratedNotifications({ category: 'all' }),
+      { wrapper: createWrapper() },
+    );
+
+    expect(result.current.items).toEqual([]);
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.isError).toBe(false);
+    expect(result.current.isSuccess).toBe(false);
   });
 
   it('attaches video title and thumbnail from fetchVideoById when available', async () => {

--- a/src/hooks/useHydratedNotifications.ts
+++ b/src/hooks/useHydratedNotifications.ts
@@ -16,6 +16,7 @@ import type { ActorInfo, NotificationFilters, NotificationItem, RawNotification 
 export interface HydratedNotificationsResult {
   items: NotificationItem[];
   isLoading: boolean;
+  isSuccess: boolean;
   isError: boolean;
   error: Error | null;
   fetchNextPage: () => void;
@@ -225,6 +226,7 @@ export function useHydratedNotifications(
   return {
     items,
     isLoading: notificationsQuery.isLoading,
+    isSuccess: notificationsQuery.isSuccess,
     isError: notificationsQuery.isError,
     error: notificationsQuery.error,
     fetchNextPage: notificationsQuery.fetchNextPage,

--- a/src/pages/NotificationsPage.test.tsx
+++ b/src/pages/NotificationsPage.test.tsx
@@ -68,6 +68,7 @@ function makeHookResult(items: NotificationItem[], overrides = {}) {
   return {
     items,
     isLoading: false,
+    isSuccess: true,
     isError: false,
     error: null,
     fetchNextPage: vi.fn(),
@@ -136,6 +137,74 @@ describe('NotificationsPage', () => {
     });
   });
 
+  it('marks all read on open when the All list is all read', async () => {
+    mockUseHydratedNotifications.mockImplementation(() =>
+      makeHookResult([
+        buildVideoNotification({ id: 'earlier-1', rawIds: ['raw-earlier-1'], isRead: true }),
+      ]),
+    );
+
+    render(<NotificationsPage />);
+
+    expect(await screen.findByText('earlier-1')).toBeInTheDocument();
+    expect(screen.queryByText('New')).not.toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(mockMarkReadMutate).toHaveBeenCalledWith(undefined);
+    });
+  });
+
+  it('marks all read on open when the All list is empty', async () => {
+    mockUseHydratedNotifications.mockImplementation(() => makeHookResult([]));
+
+    render(<NotificationsPage />);
+
+    expect(await screen.findByText('All quiet. Nothing to flag.')).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(mockMarkReadMutate).toHaveBeenCalledWith(undefined);
+    });
+  });
+
+  it('does not mark all read before the All list successfully loads', async () => {
+    mockUseHydratedNotifications.mockImplementation(() =>
+      makeHookResult([], { isLoading: true, isSuccess: false }),
+    );
+
+    render(<NotificationsPage />);
+
+    await waitFor(() => {
+      expect(mockUseHydratedNotifications).toHaveBeenCalled();
+    });
+    expect(mockMarkReadMutate).not.toHaveBeenCalled();
+  });
+
+  it('does not mark all read when the All list errors', async () => {
+    mockUseHydratedNotifications.mockImplementation(() =>
+      makeHookResult([], {
+        isSuccess: false,
+        isError: true,
+        error: new Error('Network error'),
+      }),
+    );
+
+    render(<NotificationsPage />);
+
+    expect(await screen.findByText('Failed to load notifications')).toBeInTheDocument();
+    expect(mockMarkReadMutate).not.toHaveBeenCalled();
+  });
+
+  it('does not mark all read for disabled logged-out notification queries', async () => {
+    mockUseHydratedNotifications.mockImplementation(() =>
+      makeHookResult([], { isSuccess: false }),
+    );
+
+    render(<NotificationsPage />);
+
+    expect(await screen.findByText('All quiet. Nothing to flag.')).toBeInTheDocument();
+    expect(mockMarkReadMutate).not.toHaveBeenCalled();
+  });
+
   it('files unread rows from a later page under New, and still marks read once', async () => {
     const firstPage = [
       buildVideoNotification({ id: 'new-1', rawIds: ['raw-new-1'], isRead: false }),
@@ -165,6 +234,30 @@ describe('NotificationsPage', () => {
     expect(mockMarkReadMutate).toHaveBeenCalledTimes(1);
   });
 
+  it('files unread rows from a later page under New after an all-read first page', async () => {
+    const firstPage = [
+      buildActorNotification({ id: 'earlier-1', rawIds: ['raw-earlier-1'], isRead: true }),
+    ];
+    mockUseHydratedNotifications.mockImplementation(() => makeHookResult(firstPage));
+
+    const { rerender } = render(<NotificationsPage />);
+    expect(await screen.findByText('earlier-1')).toBeInTheDocument();
+
+    mockUseHydratedNotifications.mockImplementation(() =>
+      makeHookResult([
+        ...firstPage,
+        buildVideoNotification({ id: 'new-2', rawIds: ['raw-new-2'], isRead: false }),
+      ]),
+    );
+    rerender(<NotificationsPage />);
+
+    const newSection = (await screen.findByText('New')).parentElement;
+    await waitFor(() => {
+      expect(newSection?.textContent).toContain('new-2');
+    });
+    expect(mockMarkReadMutate).toHaveBeenCalledTimes(1);
+  });
+
   it('renders VideoNotificationRow for video kind and ActorNotificationRow for actor kind', async () => {
     render(<NotificationsPage />);
 
@@ -185,6 +278,25 @@ describe('NotificationsPage', () => {
     expect(screen.queryByText('new-1')).not.toBeInTheDocument();
     expect(screen.queryByText('Earlier')).not.toBeInTheDocument();
     expect(screen.queryByText('New')).not.toBeInTheDocument();
+  });
+
+  it('does not mark all read on a filtered tab', async () => {
+    mockUseHydratedNotifications.mockImplementation((filters?: { category?: string }) => {
+      const category = filters?.category ?? 'all';
+      if (category === 'likes') {
+        return makeHookResult([
+          buildVideoNotification({ id: 'like-1', type: 'like', isRead: true }),
+        ]);
+      }
+      return makeHookResult([], { isLoading: true, isSuccess: false });
+    });
+    const user = userEvent.setup();
+
+    render(<NotificationsPage />);
+    await user.click(screen.getByRole('tab', { name: 'Likes' }));
+
+    expect(await screen.findByText('like-1')).toBeInTheDocument();
+    expect(mockMarkReadMutate).not.toHaveBeenCalled();
   });
 
   it('category unread does NOT use the New/Earlier split', async () => {

--- a/src/pages/NotificationsPage.tsx
+++ b/src/pages/NotificationsPage.tsx
@@ -1,5 +1,5 @@
 // ABOUTME: Notifications page showing social interactions (likes, comments, follows, reposts)
-// ABOUTME: Simple list with infinite scroll, marks all as read on page open
+// ABOUTME: Infinite list that marks All-tab visits read after a successful load
 
 import { useEffect, useRef, useCallback, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -59,6 +59,7 @@ export default function NotificationsPage() {
   const {
     items,
     isLoading,
+    isSuccess,
     isError,
     error,
     fetchNextPage,
@@ -69,27 +70,28 @@ export default function NotificationsPage() {
   // Destructured because useMutation returns a fresh object every render, so
   // depending on the whole result re-ran the effect below on every render.
   const { mutate: markAllRead } = useMarkNotificationsRead();
-  const hasCapturedInitialUnread = useRef(false);
+  const hasMarkedRead = useRef(false);
   const [initialUnreadIds, setInitialUnreadIds] = useState<Set<string>>(() => new Set());
+
+  useEffect(() => {
+    if (category !== 'all') return;
+    if (!isSuccess) return;
+    if (hasMarkedRead.current) return;
+
+    hasMarkedRead.current = true;
+    markAllRead(undefined);
+  }, [category, isSuccess, markAllRead]);
 
   // Keep a snapshot of unread rawIds so the list can still show what was new
   // when the user arrived, even after optimistic updates flip everything to
-  // read in the cache.
-  //
-  // The snapshot accumulates across pages rather than latching on the first
-  // one: under infinite scroll a row that is still unread when page 2 arrives
-  // was also unread when the user landed, so it belongs under "New". The
-  // mark-read call stays one-shot for the visit.
+  // read in the cache. The snapshot accumulates across pages: under infinite
+  // scroll a row that is still unread when page 2 arrives was also unread when
+  // the user landed, so it belongs under "New".
   useEffect(() => {
     if (category !== 'all') return;
-    if (items.length === 0) return;
-
     const unreadIds = items
       .filter((n) => !n.isRead)
       .flatMap((n) => n.rawIds);
-
-    const shouldMarkRead = !hasCapturedInitialUnread.current && unreadIds.length > 0;
-    hasCapturedInitialUnread.current = true;
 
     if (unreadIds.length > 0) {
       setInitialUnreadIds((prev) => {
@@ -104,11 +106,7 @@ export default function NotificationsPage() {
         return added ? next : prev;
       });
     }
-
-    if (shouldMarkRead) {
-      markAllRead(undefined);
-    }
-  }, [category, items, markAllRead]);
+  }, [category, items]);
 
   const newNotifications = useMemo(
     () => items.filter((n) => n.rawIds.some((id) => initialUnreadIds.has(id))),


### PR DESCRIPTION
## Summary

- Mark the All notifications tab read once per page mount after a successful load, even when the fetched list is empty or already read.
- Keep the New/Earlier unread snapshot independent from the marker write so later unread pages still render under New.
- Document the shared notification read-marker contract and the deliberate window-focus difference from mobile.

> Avoid naming corporate partners, customers, or other sensitive external brands in this PR title or body. Use generic descriptors unless a maintainer explicitly approves the public reference.

## Motivation

- Web and mobile write the same per-user read marker, but web skipped empty and all-read lists. That could leave the unread badge stuck when the count endpoint and list endpoint drifted.
- Mobile marks again after explicit unfiltered pull-to-refresh; web does not have that gesture, and window focus maps closer to mobile app resume.

## Related Issue

- Closes #577

## Testing

- [x] `npm run test`
- [ ] Manual verification completed

## Visuals

- [ ] UI change with screenshots/video attached
- [x] No visual change
- [x] Visuals and text avoid sensitive external brand or partner names unless explicitly approved