### PR TITLE
fix(compilation): stop replaceState loop

### DIFF
--- a/src/components/AppLayout.test.tsx
+++ b/src/components/AppLayout.test.tsx
@@ -1,0 +1,128 @@
+import { useEffect } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { BrowserRouter, Route, Routes } from 'react-router-dom';
+import { AppLayout } from './AppLayout';
+import type { ParsedVideoData } from '@/types/video';
+
+const mockExitFullscreen = vi.fn();
+const mockOnLoadMore = vi.fn();
+
+const mockVideos = [
+  { id: 'video-1' },
+  { id: 'video-2' },
+] as ParsedVideoData[];
+
+vi.mock('@/components/AppHeader', () => ({
+  AppHeader: () => <header>header</header>,
+}));
+
+vi.mock('@/components/BottomNav', () => ({
+  BottomNav: () => <nav>bottom nav</nav>,
+}));
+
+vi.mock('@/components/PWAInstallPrompt', () => ({
+  PWAInstallPrompt: () => null,
+}));
+
+vi.mock('@/components/AppSidebar', () => ({
+  AppSidebar: () => <aside>sidebar</aside>,
+}));
+
+vi.mock('@/hooks/useAppContext', () => ({
+  useAppContext: () => ({ isRecording: false }),
+}));
+
+vi.mock('@/hooks/useCurrentUser', () => ({
+  useCurrentUser: () => ({ user: null }),
+}));
+
+vi.mock('@/hooks/useSubdomainUser', () => ({
+  getSubdomainUser: () => null,
+}));
+
+vi.mock('@/contexts/FullscreenFeedContext', () => ({
+  useFullscreenFeed: () => ({
+    state: {
+      isOpen: true,
+      videos: mockVideos,
+      startIndex: 0,
+    },
+    exitFullscreen: mockExitFullscreen,
+    onLoadMore: mockOnLoadMore,
+    hasMore: false,
+  }),
+}));
+
+vi.mock('@/components/FullscreenFeed', () => ({
+  FullscreenFeed: ({
+    videos,
+    onVideoChange,
+  }: {
+    videos: ParsedVideoData[];
+    onVideoChange?: (videoId: string) => void;
+  }) => {
+    useEffect(() => {
+      onVideoChange?.(videos[0]?.id);
+    }, [onVideoChange, videos]);
+
+    return (
+      <div>
+        <button type="button" onClick={() => onVideoChange?.('video-2')}>
+          report video 2
+        </button>
+      </div>
+    );
+  },
+}));
+
+function renderLayout(path: string) {
+  window.history.pushState(null, '', path);
+
+  return render(
+    <BrowserRouter>
+      <Routes>
+        <Route element={<AppLayout />}>
+          <Route path="/search" element={<main>search page</main>} />
+        </Route>
+      </Routes>
+    </BrowserRouter>
+  );
+}
+
+describe('AppLayout', () => {
+  const originalReplaceState = window.history.replaceState;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    window.history.replaceState = originalReplaceState;
+  });
+
+  it('does not rewrite the url when the compilation active video is already current', () => {
+    const replaceStateSpy = vi.fn();
+    window.history.replaceState = replaceStateSpy;
+
+    renderLayout('/search?q=x&play=compilation&video=video-1');
+    replaceStateSpy.mockClear();
+
+    expect(replaceStateSpy).not.toHaveBeenCalled();
+  });
+
+  it('rewrites the compilation video param once when the active video changes', async () => {
+    const user = userEvent.setup();
+    const replaceStateSpy = vi.fn(originalReplaceState.bind(window.history));
+    window.history.replaceState = replaceStateSpy;
+
+    renderLayout('/search?q=x&play=compilation&video=video-1');
+    replaceStateSpy.mockClear();
+
+    await user.click(screen.getByRole('button', { name: 'report video 2' }));
+
+    expect(replaceStateSpy).toHaveBeenCalledTimes(1);
+    expect(window.location.search).toBe('?q=x&play=compilation&video=video-2');
+  });
+});

--- a/src/components/AppLayout.test.tsx
+++ b/src/components/AppLayout.test.tsx
@@ -69,6 +69,9 @@ vi.mock('@/components/FullscreenFeed', () => ({
 
     return (
       <div>
+        <button type="button" onClick={() => onVideoChange?.('video-1')}>
+          report video 1
+        </button>
         <button type="button" onClick={() => onVideoChange?.('video-2')}>
           report video 2
         </button>
@@ -102,12 +105,17 @@ describe('AppLayout', () => {
     window.history.replaceState = originalReplaceState;
   });
 
-  it('does not rewrite the url when the compilation active video is already current', () => {
-    const replaceStateSpy = vi.fn();
+  it('does not rewrite the url when the compilation active video is already current', async () => {
+    const user = userEvent.setup();
+    const replaceStateSpy = vi.fn(originalReplaceState.bind(window.history));
     window.history.replaceState = replaceStateSpy;
 
     renderLayout('/search?q=x&play=compilation&video=video-1');
     replaceStateSpy.mockClear();
+
+    // Re-report the already-current video: the handler must no-op rather than
+    // rewrite the identical URL (the replaceState loop this fix prevents).
+    await user.click(screen.getByRole('button', { name: 'report video 1' }));
 
     expect(replaceStateSpy).not.toHaveBeenCalled();
   });

--- a/src/components/AppLayout.test.tsx
+++ b/src/components/AppLayout.test.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
@@ -58,17 +58,30 @@ vi.mock('@/contexts/FullscreenFeedContext', () => ({
 vi.mock('@/components/FullscreenFeed', () => ({
   FullscreenFeed: ({
     videos,
+    onClose,
     onVideoChange,
   }: {
     videos: ParsedVideoData[];
+    onClose: () => void;
     onVideoChange?: (videoId: string) => void;
   }) => {
+    const lastReportedVideoIdRef = useRef<string>();
+
     useEffect(() => {
-      onVideoChange?.(videos[0]?.id);
+      const activeVideoId = videos[0]?.id;
+      if (!activeVideoId || lastReportedVideoIdRef.current === activeVideoId) {
+        return;
+      }
+
+      lastReportedVideoIdRef.current = activeVideoId;
+      onVideoChange?.(activeVideoId);
     }, [onVideoChange, videos]);
 
     return (
       <div>
+        <button type="button" onClick={onClose}>
+          close fullscreen
+        </button>
         <button type="button" onClick={() => onVideoChange?.('video-1')}>
           report video 1
         </button>
@@ -103,6 +116,7 @@ describe('AppLayout', () => {
 
   afterEach(() => {
     window.history.replaceState = originalReplaceState;
+    window.history.pushState(null, '', '/');
   });
 
   it('does not rewrite the url when the compilation active video is already current', async () => {
@@ -132,5 +146,20 @@ describe('AppLayout', () => {
 
     expect(replaceStateSpy).toHaveBeenCalledTimes(1);
     expect(window.location.search).toBe('?q=x&play=compilation&video=video-2');
+  });
+
+  it('clears compilation playback params when fullscreen closes', async () => {
+    const user = userEvent.setup();
+    const replaceStateSpy = vi.fn(originalReplaceState.bind(window.history));
+    window.history.replaceState = replaceStateSpy;
+
+    renderLayout('/search?q=x&play=compilation&video=video-1');
+    replaceStateSpy.mockClear();
+
+    await user.click(screen.getByRole('button', { name: 'close fullscreen' }));
+
+    expect(mockExitFullscreen).toHaveBeenCalledTimes(1);
+    expect(replaceStateSpy).toHaveBeenCalledTimes(1);
+    expect(window.location.search).toBe('?q=x');
   });
 });

--- a/src/components/AppLayout.tsx
+++ b/src/components/AppLayout.tsx
@@ -1,3 +1,4 @@
+import { useCallback, useEffect, useRef } from 'react';
 import { Outlet, useLocation, useSearchParams } from 'react-router-dom';
 import { AppHeader } from '@/components/AppHeader';
 import { BottomNav } from '@/components/BottomNav';
@@ -20,34 +21,61 @@ export function AppLayout() {
   const { isRecording } = useAppContext();
   const { state: fullscreenState, exitFullscreen, onLoadMore, hasMore } = useFullscreenFeed();
   const compilationRequest = parseCompilationPlaybackParams(searchParams);
+  const searchParamsRef = useRef(searchParams);
+  const setSearchParamsRef = useRef(setSearchParams);
+  const exitFullscreenRef = useRef(exitFullscreen);
+
+  useEffect(() => {
+    searchParamsRef.current = searchParams;
+    setSearchParamsRef.current = setSearchParams;
+    exitFullscreenRef.current = exitFullscreen;
+  }, [exitFullscreen, searchParams, setSearchParams]);
 
   const isLoggedIn = Boolean(user);
 
   // Hide header/sidebar on landing page (when logged out on root path), but NOT on subdomain profiles
   const isLandingPage = location.pathname === '/' && !isLoggedIn && !getSubdomainUser();
 
-  const handleCloseFullscreen = () => {
-    exitFullscreen();
+  const handleCloseFullscreen = useCallback(() => {
+    exitFullscreenRef.current();
 
-    if (!compilationRequest.play) {
+    const currentParams = searchParamsRef.current;
+    const currentRequest = parseCompilationPlaybackParams(currentParams);
+    if (!currentRequest.play) {
       return;
     }
 
-    const nextParams = new URLSearchParams(searchParams);
+    const nextParams = new URLSearchParams(currentParams);
     clearCompilationPlaybackParams(nextParams);
-    setSearchParams(nextParams, { replace: true });
-  };
-
-  const handleCompilationVideoChange = (videoId: string) => {
-    if (!compilationRequest.play) {
+    if (nextParams.toString() === currentParams.toString()) {
       return;
     }
 
-    const nextParams = new URLSearchParams(searchParams);
+    searchParamsRef.current = nextParams;
+    setSearchParamsRef.current(nextParams, { replace: true });
+  }, []);
+
+  const handleCompilationVideoChange = useCallback((videoId: string) => {
+    const currentParams = searchParamsRef.current;
+    const currentRequest = parseCompilationPlaybackParams(currentParams);
+    if (!currentRequest.play) {
+      return;
+    }
+
+    if (currentRequest.videoId === videoId && currentRequest.start === undefined) {
+      return;
+    }
+
+    const nextParams = new URLSearchParams(currentParams);
     nextParams.set('video', videoId);
     nextParams.delete('start');
-    setSearchParams(nextParams, { replace: true });
-  };
+    if (nextParams.toString() === currentParams.toString()) {
+      return;
+    }
+
+    searchParamsRef.current = nextParams;
+    setSearchParamsRef.current(nextParams, { replace: true });
+  }, []);
 
   return (
     <>

--- a/src/components/AppLayout.tsx
+++ b/src/components/AppLayout.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef } from 'react';
+import { useCallback } from 'react';
 import { Outlet, useLocation, useSearchParams } from 'react-router-dom';
 import { AppHeader } from '@/components/AppHeader';
 import { BottomNav } from '@/components/BottomNav';
@@ -21,15 +21,6 @@ export function AppLayout() {
   const { isRecording } = useAppContext();
   const { state: fullscreenState, exitFullscreen, onLoadMore, hasMore } = useFullscreenFeed();
   const compilationRequest = parseCompilationPlaybackParams(searchParams);
-  const searchParamsRef = useRef(searchParams);
-  const setSearchParamsRef = useRef(setSearchParams);
-  const exitFullscreenRef = useRef(exitFullscreen);
-
-  useEffect(() => {
-    searchParamsRef.current = searchParams;
-    setSearchParamsRef.current = setSearchParams;
-    exitFullscreenRef.current = exitFullscreen;
-  }, [exitFullscreen, searchParams, setSearchParams]);
 
   const isLoggedIn = Boolean(user);
 
@@ -37,45 +28,33 @@ export function AppLayout() {
   const isLandingPage = location.pathname === '/' && !isLoggedIn && !getSubdomainUser();
 
   const handleCloseFullscreen = useCallback(() => {
-    exitFullscreenRef.current();
+    exitFullscreen();
 
-    const currentParams = searchParamsRef.current;
-    const currentRequest = parseCompilationPlaybackParams(currentParams);
+    const currentRequest = parseCompilationPlaybackParams(searchParams);
     if (!currentRequest.play) {
       return;
     }
 
-    const nextParams = new URLSearchParams(currentParams);
+    const nextParams = new URLSearchParams(searchParams);
     clearCompilationPlaybackParams(nextParams);
-    if (nextParams.toString() === currentParams.toString()) {
-      return;
-    }
-
-    searchParamsRef.current = nextParams;
-    setSearchParamsRef.current(nextParams, { replace: true });
-  }, []);
+    setSearchParams(nextParams, { replace: true });
+  }, [exitFullscreen, searchParams, setSearchParams]);
 
   const handleCompilationVideoChange = useCallback((videoId: string) => {
-    const currentParams = searchParamsRef.current;
-    const currentRequest = parseCompilationPlaybackParams(currentParams);
+    const currentRequest = parseCompilationPlaybackParams(searchParams);
     if (!currentRequest.play) {
       return;
     }
 
-    if (currentRequest.videoId === videoId && currentRequest.start === undefined) {
-      return;
-    }
-
-    const nextParams = new URLSearchParams(currentParams);
+    const nextParams = new URLSearchParams(searchParams);
     nextParams.set('video', videoId);
     nextParams.delete('start');
-    if (nextParams.toString() === currentParams.toString()) {
+    if (nextParams.toString() === searchParams.toString()) {
       return;
     }
 
-    searchParamsRef.current = nextParams;
-    setSearchParamsRef.current(nextParams, { replace: true });
-  }, []);
+    setSearchParams(nextParams, { replace: true });
+  }, [searchParams, setSearchParams]);
 
   return (
     <>

--- a/src/components/FullscreenFeed.test.tsx
+++ b/src/components/FullscreenFeed.test.tsx
@@ -128,6 +128,42 @@ describe('FullscreenFeed', () => {
     expect(screen.getByTestId('fullscreen-item-video-b')).toHaveAttribute('data-active', 'true');
   });
 
+  it('reports video changes only once per active video id', () => {
+    const onVideoChange = vi.fn();
+    const firstCallback = vi.fn(onVideoChange);
+    const secondCallback = vi.fn(onVideoChange);
+    const videos = [makeVideo('video-a'), makeVideo('video-b')];
+    const { rerender } = render(
+      <FullscreenFeed
+        videos={videos}
+        startIndex={0}
+        onClose={vi.fn()}
+        autoAdvance
+        onVideoChange={firstCallback}
+      />
+    );
+
+    expect(onVideoChange).toHaveBeenCalledTimes(1);
+    expect(onVideoChange).toHaveBeenLastCalledWith('video-a');
+
+    rerender(
+      <FullscreenFeed
+        videos={videos}
+        startIndex={0}
+        onClose={vi.fn()}
+        autoAdvance
+        onVideoChange={secondCallback}
+      />
+    );
+
+    expect(onVideoChange).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(screen.getByRole('button', { name: 'end-video-a' }));
+
+    expect(onVideoChange).toHaveBeenCalledTimes(2);
+    expect(onVideoChange).toHaveBeenLastCalledWith('video-b');
+  });
+
   it('requests only one additional page while waiting at the loaded tail', () => {
     const onLoadMore = vi.fn();
 

--- a/src/components/FullscreenFeed.tsx
+++ b/src/components/FullscreenFeed.tsx
@@ -191,10 +191,16 @@ export function FullscreenFeed({
   const [awaitingNextPage, setAwaitingNextPage] = useState(false);
   const { setGlobalMuted, globalMuted } = useVideoPlayback();
   const previousMutedState = useRef(globalMuted);
+  const onVideoChangeRef = useRef(onVideoChange);
+  const lastReportedVideoIdRef = useRef<string>();
   const scrollToIndex = useCallback((index: number, behavior: ScrollBehavior = 'smooth') => {
     const targetElement = containerRef.current?.children[index] as HTMLElement | undefined;
     targetElement?.scrollIntoView({ behavior });
   }, []);
+
+  useEffect(() => {
+    onVideoChangeRef.current = onVideoChange;
+  }, [onVideoChange]);
 
   // Unmute when entering fullscreen, restore on exit
   useEffect(() => {
@@ -231,8 +237,13 @@ export function FullscreenFeed({
       return;
     }
 
-    onVideoChange?.(activeVideo.id);
-  }, [currentIndex, onVideoChange, videos]);
+    if (lastReportedVideoIdRef.current === activeVideo.id) {
+      return;
+    }
+
+    lastReportedVideoIdRef.current = activeVideo.id;
+    onVideoChangeRef.current?.(activeVideo.id);
+  }, [currentIndex, videos]);
 
   // Handle scroll to detect current video
   const handleScroll = useCallback(() => {

--- a/src/pages/SearchPage.test.tsx
+++ b/src/pages/SearchPage.test.tsx
@@ -186,10 +186,14 @@ vi.mock('@/lib/eventLookup', () => ({
   fetchEventById: mockFetchEventById,
 }));
 
-function renderPage(initialEntries: string[] = ['/search']) {
-  const queryClient = new QueryClient({
+function createTestQueryClient() {
+  return new QueryClient({
     defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
   });
+}
+
+function renderPage(initialEntries: string[] = ['/search']) {
+  const queryClient = createTestQueryClient();
   return render(
     <QueryClientProvider client={queryClient}>
       <MemoryRouter initialEntries={initialEntries}>
@@ -202,10 +206,14 @@ function renderPage(initialEntries: string[] = ['/search']) {
 
 function renderPageInBrowser(path: string) {
   window.history.pushState(null, '', path);
-  const queryClient = new QueryClient({
-    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
-  });
+  const queryClient = createTestQueryClient();
   return render(
+    renderPageWithBrowserRouter(queryClient)
+  );
+}
+
+function renderPageWithBrowserRouter(queryClient = createTestQueryClient()) {
+  return (
     <QueryClientProvider client={queryClient}>
       <BrowserRouter>
         <SearchPage />
@@ -269,6 +277,7 @@ describe('SearchPage', () => {
 
   afterEach(() => {
     vi.useRealTimers();
+    window.history.pushState(null, '', '/');
   });
 
   it('clears the blur suggestion timeout on unmount', async () => {
@@ -599,15 +608,7 @@ describe('SearchPage', () => {
       });
 
       rerender(
-        <QueryClientProvider client={new QueryClient({
-          defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
-        })}
-        >
-          <BrowserRouter>
-            <SearchPage />
-            <LocationDisplay />
-          </BrowserRouter>
-        </QueryClientProvider>
+        renderPageWithBrowserRouter()
       );
 
       await act(async () => {
@@ -619,6 +620,56 @@ describe('SearchPage', () => {
     } finally {
       window.history.replaceState = originalReplaceState;
     }
+  });
+
+  it('tracks a slow search once after results settle', async () => {
+    vi.useFakeTimers();
+    mockUseInfiniteSearchVideos.mockReturnValue({
+      data: { pages: [{ videos: [] }] },
+      fetchNextPage: vi.fn(),
+      hasNextPage: false,
+      isLoading: true,
+      error: null,
+      fetchedCount: 0,
+    });
+
+    const { rerender } = renderPage(['/search?q=twerking&filter=videos']);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(600);
+    });
+
+    expect(trackSearch).not.toHaveBeenCalled();
+
+    mockUseInfiniteSearchVideos.mockReturnValue({
+      data: {
+        pages: [
+          { videos: [{ id: 'video-1', pubkey: 'a'.repeat(64) }] },
+          { videos: [{ id: 'video-2', pubkey: 'b'.repeat(64) }] },
+        ],
+      },
+      fetchNextPage: vi.fn(),
+      hasNextPage: false,
+      isLoading: false,
+      error: null,
+      fetchedCount: 2,
+    });
+
+    rerender(
+      <QueryClientProvider client={createTestQueryClient()}>
+        <MemoryRouter initialEntries={['/search?q=twerking&filter=videos']}>
+          <SearchPage />
+          <LocationDisplay />
+        </MemoryRouter>
+      </QueryClientProvider>
+    );
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(600);
+    });
+
+    expect(trackSearch).toHaveBeenCalledTimes(1);
+    expect(trackSearch).toHaveBeenLastCalledWith('twerking', 'videos', 2);
   });
 
   it('does not retrack a settled search when result counts change', async () => {
@@ -656,10 +707,7 @@ describe('SearchPage', () => {
     });
 
     rerender(
-      <QueryClientProvider client={new QueryClient({
-        defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
-      })}
-      >
+      <QueryClientProvider client={createTestQueryClient()}>
         <MemoryRouter initialEntries={['/search?q=twerking&filter=videos']}>
           <SearchPage />
           <LocationDisplay />

--- a/src/pages/SearchPage.test.tsx
+++ b/src/pages/SearchPage.test.tsx
@@ -1,7 +1,7 @@
 import { describe, expect, it, beforeEach, afterEach, vi } from 'vitest';
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { MemoryRouter, useLocation } from 'react-router-dom';
+import { BrowserRouter, MemoryRouter, useLocation } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import type {
   ButtonHTMLAttributes,
@@ -12,6 +12,7 @@ import type {
 } from 'react';
 import { nip19 } from 'nostr-tools';
 import { initializeI18n } from '@/lib/i18n';
+import { trackSearch } from '@/lib/analytics';
 import SearchPage from './SearchPage';
 
 const {
@@ -195,6 +196,21 @@ function renderPage(initialEntries: string[] = ['/search']) {
         <SearchPage />
         <LocationDisplay />
       </MemoryRouter>
+    </QueryClientProvider>
+  );
+}
+
+function renderPageInBrowser(path: string) {
+  window.history.pushState(null, '', path);
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <BrowserRouter>
+        <SearchPage />
+        <LocationDisplay />
+      </BrowserRouter>
     </QueryClientProvider>
   );
 }
@@ -541,6 +557,121 @@ describe('SearchPage', () => {
     expect(screen.getByTestId('location-display').textContent).toBe(
       '/search?q=twerking&filter=videos&play=compilation&video=video-1'
     );
+  });
+
+  it('does not rewrite the same search url when only result counts change', async () => {
+    vi.useFakeTimers();
+    const originalReplaceState = window.history.replaceState;
+    const replaceStateSpy = vi.fn(originalReplaceState.bind(window.history));
+    window.history.replaceState = replaceStateSpy;
+
+    try {
+      mockUseInfiniteSearchVideos.mockReturnValue({
+        data: { pages: [{ videos: [{ id: 'video-1', pubkey: 'a'.repeat(64) }] }] },
+        fetchNextPage: vi.fn(),
+        hasNextPage: false,
+        isLoading: false,
+        error: null,
+        fetchedCount: 1,
+      });
+
+      const { rerender } = renderPageInBrowser('/search?q=twerking&filter=videos');
+      replaceStateSpy.mockClear();
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(600);
+      });
+
+      expect(replaceStateSpy).not.toHaveBeenCalled();
+
+      mockUseInfiniteSearchVideos.mockReturnValue({
+        data: {
+          pages: [
+            { videos: [{ id: 'video-1', pubkey: 'a'.repeat(64) }] },
+            { videos: [{ id: 'video-2', pubkey: 'b'.repeat(64) }] },
+          ],
+        },
+        fetchNextPage: vi.fn(),
+        hasNextPage: false,
+        isLoading: false,
+        error: null,
+        fetchedCount: 2,
+      });
+
+      rerender(
+        <QueryClientProvider client={new QueryClient({
+          defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+        })}
+        >
+          <BrowserRouter>
+            <SearchPage />
+            <LocationDisplay />
+          </BrowserRouter>
+        </QueryClientProvider>
+      );
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(600);
+      });
+
+      expect(replaceStateSpy).not.toHaveBeenCalled();
+      expect(screen.getByTestId('location-display').textContent).toBe('/search?q=twerking&filter=videos');
+    } finally {
+      window.history.replaceState = originalReplaceState;
+    }
+  });
+
+  it('does not retrack a settled search when result counts change', async () => {
+    vi.useFakeTimers();
+    mockUseInfiniteSearchVideos.mockReturnValue({
+      data: { pages: [{ videos: [{ id: 'video-1', pubkey: 'a'.repeat(64) }] }] },
+      fetchNextPage: vi.fn(),
+      hasNextPage: false,
+      isLoading: false,
+      error: null,
+      fetchedCount: 1,
+    });
+
+    const { rerender } = renderPage(['/search?q=twerking&filter=videos']);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(600);
+    });
+
+    expect(trackSearch).toHaveBeenCalledTimes(1);
+    expect(trackSearch).toHaveBeenLastCalledWith('twerking', 'videos', 1);
+
+    mockUseInfiniteSearchVideos.mockReturnValue({
+      data: {
+        pages: [
+          { videos: [{ id: 'video-1', pubkey: 'a'.repeat(64) }] },
+          { videos: [{ id: 'video-2', pubkey: 'b'.repeat(64) }] },
+        ],
+      },
+      fetchNextPage: vi.fn(),
+      hasNextPage: false,
+      isLoading: false,
+      error: null,
+      fetchedCount: 2,
+    });
+
+    rerender(
+      <QueryClientProvider client={new QueryClient({
+        defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+      })}
+      >
+        <MemoryRouter initialEntries={['/search?q=twerking&filter=videos']}>
+          <SearchPage />
+          <LocationDisplay />
+        </MemoryRouter>
+      </QueryClientProvider>
+    );
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(600);
+    });
+
+    expect(trackSearch).toHaveBeenCalledTimes(1);
   });
 
   // Regression: bare VideoCard hides view counts because it has no metrics

--- a/src/pages/SearchPage.tsx
+++ b/src/pages/SearchPage.tsx
@@ -146,20 +146,7 @@ export function SearchPage() {
   // This prevents analytics from firing on every keystroke
   const debounceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const analyticsTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const resultCountsRef = useRef({
-    videos: videoResults.length,
-    users: userResults.length,
-    hashtags: hashtagResults.length,
-  });
   const lastTrackedSearchRef = useRef<string | null>(null);
-
-  useEffect(() => {
-    resultCountsRef.current = {
-      videos: videoResults.length,
-      users: userResults.length,
-      hashtags: hashtagResults.length,
-    };
-  }, [hashtagResults.length, userResults.length, videoResults.length]);
 
   useEffect(() => {
     // Clear any existing timer
@@ -208,20 +195,24 @@ export function SearchPage() {
       clearTimeout(analyticsTimerRef.current);
     }
 
+    const trimmedQuery = searchQuery.trim();
+    if (!trimmedQuery) {
+      lastTrackedSearchRef.current = null;
+      return;
+    }
+
+    if (isLoadingVideos || isLoadingUsers || isLoadingHashtags) {
+      return;
+    }
+
+    const trackingKey = JSON.stringify([trimmedQuery, activeFilter]);
+    if (lastTrackedSearchRef.current === trackingKey) {
+      return;
+    }
+
     analyticsTimerRef.current = setTimeout(() => {
-      const trimmedQuery = searchQuery.trim();
-      if (!trimmedQuery) {
-        lastTrackedSearchRef.current = null;
-        return;
-      }
-
-      const trackingKey = JSON.stringify([trimmedQuery, activeFilter]);
-      if (lastTrackedSearchRef.current === trackingKey) {
-        return;
-      }
-
-      const counts = resultCountsRef.current;
-      trackSearch(searchQuery, activeFilter, counts.videos + counts.users + counts.hashtags);
+      const totalResults = videoResults.length + userResults.length + hashtagResults.length;
+      trackSearch(searchQuery, activeFilter, totalResults);
       lastTrackedSearchRef.current = trackingKey;
     }, 500);
 
@@ -230,7 +221,16 @@ export function SearchPage() {
         clearTimeout(analyticsTimerRef.current);
       }
     };
-  }, [activeFilter, searchQuery]);
+  }, [
+    activeFilter,
+    hashtagResults.length,
+    isLoadingHashtags,
+    isLoadingUsers,
+    isLoadingVideos,
+    searchQuery,
+    userResults.length,
+    videoResults.length,
+  ]);
 
   useEffect(() => {
     return () => {

--- a/src/pages/SearchPage.tsx
+++ b/src/pages/SearchPage.tsx
@@ -142,10 +142,24 @@ export function SearchPage() {
     description: 'Search for videos, users, and hashtags on Divine Web',
   });
 
-  // Debounced URL update - only update URL after user stops typing for 300ms
+  // Debounced URL update - only update URL after user stops typing for 500ms
   // This prevents analytics from firing on every keystroke
-  const debouncedSearchQuery = useRef(searchQuery);
-  const debounceTimerRef = useRef<NodeJS.Timeout | null>(null);
+  const debounceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const analyticsTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const resultCountsRef = useRef({
+    videos: videoResults.length,
+    users: userResults.length,
+    hashtags: hashtagResults.length,
+  });
+  const lastTrackedSearchRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    resultCountsRef.current = {
+      videos: videoResults.length,
+      users: userResults.length,
+      hashtags: hashtagResults.length,
+    };
+  }, [hashtagResults.length, userResults.length, videoResults.length]);
 
   useEffect(() => {
     // Clear any existing timer
@@ -153,9 +167,8 @@ export function SearchPage() {
       clearTimeout(debounceTimerRef.current);
     }
 
-    // Set new timer to update URL after 300ms of no typing
+    // Set new timer to update URL after 500ms of no typing
     debounceTimerRef.current = setTimeout(() => {
-      debouncedSearchQuery.current = searchQuery;
       const params = new URLSearchParams();
       if (searchQuery) params.set('q', searchQuery);
       if (sortMode !== 'hot') params.set('sort', sortMode);
@@ -168,12 +181,9 @@ export function SearchPage() {
           params.set('start', String(compilationRequest.start));
         }
       }
-      setSearchParams(params, { replace: true });
 
-      // Track search analytics when user stops typing
-      if (searchQuery.trim()) {
-        const totalResults = videoResults.length + userResults.length + hashtagResults.length;
-        trackSearch(searchQuery, activeFilter, totalResults);
+      if (params.toString() !== searchParams.toString()) {
+        setSearchParams(params, { replace: true });
       }
     }, 500);
 
@@ -187,13 +197,40 @@ export function SearchPage() {
     compilationRequest.play,
     compilationRequest.start,
     compilationRequest.videoId,
-    hashtagResults.length,
+    searchParams,
     searchQuery,
     setSearchParams,
     sortMode,
-    userResults.length,
-    videoResults.length,
   ]);
+
+  useEffect(() => {
+    if (analyticsTimerRef.current) {
+      clearTimeout(analyticsTimerRef.current);
+    }
+
+    analyticsTimerRef.current = setTimeout(() => {
+      const trimmedQuery = searchQuery.trim();
+      if (!trimmedQuery) {
+        lastTrackedSearchRef.current = null;
+        return;
+      }
+
+      const trackingKey = JSON.stringify([trimmedQuery, activeFilter]);
+      if (lastTrackedSearchRef.current === trackingKey) {
+        return;
+      }
+
+      const counts = resultCountsRef.current;
+      trackSearch(searchQuery, activeFilter, counts.videos + counts.users + counts.hashtags);
+      lastTrackedSearchRef.current = trackingKey;
+    }, 500);
+
+    return () => {
+      if (analyticsTimerRef.current) {
+        clearTimeout(analyticsTimerRef.current);
+      }
+    };
+  }, [activeFilter, searchQuery]);
 
   useEffect(() => {
     return () => {


### PR DESCRIPTION
## Summary

- Stop compilation fullscreen playback from repeatedly replacing the same search params when the active video is already reflected in the URL.
- Report fullscreen video changes only when the active video id actually changes.
- Guard SearchPage's debounced URL sync against identical writes and track search analytics once after result hooks settle.
- Confirmed the adjacent URL normalization paths in PopularPage, UniversalUserPage, and LeaderboardPage are already guarded or safe by construction for #509.

> Avoid naming corporate partners, customers, or other sensitive external brands in this PR title or body. Use generic descriptors unless a maintainer explicitly approves the public reference.

## Motivation

- Safari hard-throws when a page calls history.replaceState too frequently. Compilation playback could trigger a replace loop through the fullscreen feed callback path.

## Related Issue

- Closes #509

## Testing

- [x] npm run test
- [ ] Manual verification completed

## Visuals

- [ ] UI change with screenshots/video attached
- [x] No visual change
- [x] Visuals and text avoid sensitive external brand or partner names unless explicitly approved