### PR TITLE
chore(safety): reconcile legacy block list handling

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -76,7 +76,9 @@ are rejected by
 [`parsePeopleListFromEvent`](./src/lib/parsePeopleListFromEvent.ts), so the
 route builders in [`src/lib/eventRouting.ts`](./src/lib/eventRouting.ts) leave
 them on the generic event route rather than sending them to a detail page that
-cannot render them.
+cannot render them. Divine clients no longer author `d=block` kind `30000`
+lists; web reads that list only for legacy compatibility with pre-retirement
+accounts and older or non-Divine clients.
 
 ## Styling
 

--- a/src/hooks/useFeedBlocklist.test.ts
+++ b/src/hooks/useFeedBlocklist.test.ts
@@ -1,5 +1,5 @@
 // ABOUTME: Tests for useFeedBlocklist hook — per-viewer feed blocklist assembled from relay queries
-// ABOUTME: Covers muters/blockers-of-viewer, own mutes/blocks, fail-open on relay errors, logged-out no-op
+// ABOUTME: Covers muters/legacy blockers-of-viewer, own mutes/legacy blocks, fail-open, logged-out no-op
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { renderHook, waitFor } from '@testing-library/react';
@@ -166,7 +166,7 @@ describe('useFeedBlocklist', () => {
     await waitFor(() => expect(result.current.has(OWN_MUTED)).toBe(true));
   });
 
-  it("includes the viewer's own blocked pubkeys (own kind 30000 d=block p-tags)", async () => {
+  it("includes the viewer's own legacy blocked pubkeys (own kind 30000 d=block p-tags)", async () => {
     respondWith([
       makeEvent({ pubkey: VIEWER, kind: 30000, tags: [['d', 'block'], ['p', OWN_BLOCKED]] }),
     ]);
@@ -174,7 +174,29 @@ describe('useFeedBlocklist', () => {
     await waitFor(() => expect(result.current.has(OWN_BLOCKED)).toBe(true));
   });
 
-  it('unions all sources into one set', async () => {
+  it('keeps own kind 10000 filtering after an empty legacy replacement retires own kind 30000', async () => {
+    respondWith([
+      makeEvent({
+        pubkey: VIEWER,
+        kind: 30000,
+        created_at: 100,
+        tags: [['d', 'block'], ['p', OWN_BLOCKED]],
+      }),
+      makeEvent({
+        pubkey: VIEWER,
+        kind: 30000,
+        created_at: 200,
+        tags: [['d', 'block']],
+      }),
+    ]);
+    mockMuteList = [{ type: MuteType.USER, value: OWN_MUTED }];
+
+    const { result } = renderHook(() => useFeedBlocklist(), { wrapper: createWrapper() });
+    await waitFor(() => expect(result.current.has(OWN_MUTED)).toBe(true));
+    expect(result.current.has(OWN_BLOCKED)).toBe(false);
+  });
+
+  it('unions mixed-era kind 10000 and legacy kind 30000 sources into one set', async () => {
     respondWith([
       makeEvent({ pubkey: MUTER, kind: 10000, tags: [['p', VIEWER]] }),
       makeEvent({ pubkey: BLOCKER, kind: 30000, tags: [['d', 'block'], ['p', VIEWER]] }),

--- a/src/hooks/useFeedBlocklist.test.ts
+++ b/src/hooks/useFeedBlocklist.test.ts
@@ -188,11 +188,17 @@ describe('useFeedBlocklist', () => {
         created_at: 200,
         tags: [['d', 'block']],
       }),
+      makeEvent({
+        pubkey: BLOCKER,
+        kind: 30000,
+        tags: [['d', 'block'], ['p', VIEWER]],
+      }),
     ]);
     mockMuteList = [{ type: MuteType.USER, value: OWN_MUTED }];
 
     const { result } = renderHook(() => useFeedBlocklist(), { wrapper: createWrapper() });
-    await waitFor(() => expect(result.current.has(OWN_MUTED)).toBe(true));
+    await waitFor(() => expect(result.current.has(BLOCKER)).toBe(true));
+    expect(result.current.has(OWN_MUTED)).toBe(true);
     expect(result.current.has(OWN_BLOCKED)).toBe(false);
   });
 

--- a/src/hooks/useFeedBlocklist.ts
+++ b/src/hooks/useFeedBlocklist.ts
@@ -1,5 +1,5 @@
-// ABOUTME: Hook assembling the per-viewer feed blocklist: own mutes/blocks plus authors who
-// ABOUTME: muted (kind 10000) or blocked (kind 30000 d=block) the viewer. Fails open on relay errors.
+// ABOUTME: Hook assembling the per-viewer feed blocklist: own mutes, compatible legacy blocks,
+// ABOUTME: plus authors who muted (kind 10000) or legacy-blocked the viewer. Fails open on relay errors.
 
 import { useMemo } from 'react';
 import { useNostr } from '@nostrify/react';
@@ -9,24 +9,24 @@ import { useCurrentUser } from '@/hooks/useCurrentUser';
 import { useMuteList, MUTE_LIST_KIND } from '@/hooks/useModeration';
 import { MuteType } from '@/types/moderation';
 import {
-  BLOCK_LIST_KIND,
+  LEGACY_BLOCK_LIST_KIND,
   buildFeedBlocklist,
   parseBlockersOfViewer,
   parseMutersOfViewer,
-  parseOwnBlockedPubkeys,
+  parseOwnLegacyBlockedPubkeys,
 } from '@/lib/blocklistFilter';
 import { debugError } from '@/lib/debug';
 
 interface ViewerTargetedLists {
   mutersOfViewer: string[];
   blockersOfViewer: string[];
-  ownBlockedPubkeys: string[];
+  ownLegacyBlockedPubkeys: string[];
 }
 
 const EMPTY_LISTS: ViewerTargetedLists = {
   mutersOfViewer: [],
   blockersOfViewer: [],
-  ownBlockedPubkeys: [],
+  ownLegacyBlockedPubkeys: [],
 };
 
 // Stable empty set so logged-out consumers never re-render on identity changes
@@ -36,9 +36,13 @@ const EMPTY_BLOCKLIST: ReadonlySet<string> = new Set();
  * The set of pubkeys whose videos must be hidden from feed surfaces for the
  * current viewer (parity with divine-mobile's shouldFilterFromFeeds):
  * - pubkeys the viewer muted (own kind 10000 mute list, via useMuteList)
- * - pubkeys the viewer blocked (own kind 30000 d=block list)
+ * - pubkeys on the viewer's own legacy kind 30000 d=block list, for
+ *   pre-retirement accounts and older clients
  * - authors whose kind 10000 mute list p-tags the viewer
- * - authors whose kind 30000 d=block list p-tags the viewer
+ * - authors whose legacy kind 30000 d=block list p-tags the viewer
+ *
+ * Divine clients no longer author own kind 30000 d=block lists; current-era
+ * own blocks arrive through useMuteList as kind 10000 p-tags.
  *
  * Funnelcake REST feeds apply platform moderation only — per-viewer block/mute
  * filtering is a client responsibility (divine-web#399).
@@ -68,9 +72,9 @@ export function useFeedBlocklist(): ReadonlySet<string> {
       const candidateFilters: NostrFilter[] = [
         // Authors who muted or blocked the viewer. The d=block check happens
         // client-side because not all relays support #d filtering.
-        { kinds: [MUTE_LIST_KIND, BLOCK_LIST_KIND], '#p': [viewerPubkey], limit: 1000 },
-        // The viewer's own kind 30000 d=block list (published by Divine mobile)
-        { kinds: [BLOCK_LIST_KIND], authors: [viewerPubkey], limit: 1000 },
+        { kinds: [MUTE_LIST_KIND, LEGACY_BLOCK_LIST_KIND], '#p': [viewerPubkey], limit: 1000 },
+        // The viewer's own retired kind 30000 d=block list, retained for legacy compatibility.
+        { kinds: [LEGACY_BLOCK_LIST_KIND], authors: [viewerPubkey], limit: 1000 },
       ];
 
       try {
@@ -91,7 +95,7 @@ export function useFeedBlocklist(): ReadonlySet<string> {
                 limit: Math.min(1000, Math.max(10, candidateAuthors.length * 5)),
               },
               {
-                kinds: [BLOCK_LIST_KIND],
+                kinds: [LEGACY_BLOCK_LIST_KIND],
                 authors: candidateAuthors,
                 limit: Math.min(1000, Math.max(10, candidateAuthors.length * 10)),
               },
@@ -101,7 +105,7 @@ export function useFeedBlocklist(): ReadonlySet<string> {
         return {
           mutersOfViewer: parseMutersOfViewer(events, viewerPubkey),
           blockersOfViewer: parseBlockersOfViewer(events, viewerPubkey),
-          ownBlockedPubkeys: parseOwnBlockedPubkeys(events, viewerPubkey),
+          ownLegacyBlockedPubkeys: parseOwnLegacyBlockedPubkeys(events, viewerPubkey),
         };
       } catch (err) {
         // Fail open: an unreachable relay must not blank the feed.
@@ -123,7 +127,7 @@ export function useFeedBlocklist(): ReadonlySet<string> {
     return buildFeedBlocklist({
       viewerPubkey,
       ownMutedPubkeys,
-      ownBlockedPubkeys: targeted.ownBlockedPubkeys,
+      ownLegacyBlockedPubkeys: targeted.ownLegacyBlockedPubkeys,
       mutersOfViewer: targeted.mutersOfViewer,
       blockersOfViewer: targeted.blockersOfViewer,
     });

--- a/src/hooks/useModeration.test.ts
+++ b/src/hooks/useModeration.test.ts
@@ -346,9 +346,6 @@ describe('useMuteItem', () => {
     expect(mockPublishEvent).toHaveBeenCalledOnce();
     const call = mockPublishEvent.mock.calls[0][0];
     expect(call.kind).toBe(MUTE_LIST_KIND);
-    expect(call.kind).not.toBe(3);
-    expect(call.kind).not.toBe(30000);
-    expect(call.kind).not.toBe(10001);
     expect(call.content).toBe('');
     expect(call.tags).toEqual([['p', 'target-pubkey', 'spam']]);
   });
@@ -498,8 +495,6 @@ describe('useUnmuteItem', () => {
 
     const call = mockPublishEvent.mock.calls[0][0];
     expect(call.kind).toBe(MUTE_LIST_KIND);
-    expect(call.kind).not.toBe(3);
-    expect(call.kind).not.toBe(30000);
     expect(call.tags).toEqual([
       ['p', 'keep-me'],
       ['t', 'nsfw'],

--- a/src/hooks/useModeration.test.ts
+++ b/src/hooks/useModeration.test.ts
@@ -346,6 +346,8 @@ describe('useMuteItem', () => {
     expect(mockPublishEvent).toHaveBeenCalledOnce();
     const call = mockPublishEvent.mock.calls[0][0];
     expect(call.kind).toBe(MUTE_LIST_KIND);
+    expect(call.kind).not.toBe(3);
+    expect(call.kind).not.toBe(30000);
     expect(call.kind).not.toBe(10001);
     expect(call.content).toBe('');
     expect(call.tags).toEqual([['p', 'target-pubkey', 'spam']]);
@@ -496,6 +498,8 @@ describe('useUnmuteItem', () => {
 
     const call = mockPublishEvent.mock.calls[0][0];
     expect(call.kind).toBe(MUTE_LIST_KIND);
+    expect(call.kind).not.toBe(3);
+    expect(call.kind).not.toBe(30000);
     expect(call.tags).toEqual([
       ['p', 'keep-me'],
       ['t', 'nsfw'],

--- a/src/lib/blocklistFilter.test.ts
+++ b/src/lib/blocklistFilter.test.ts
@@ -1,14 +1,14 @@
 // ABOUTME: Tests for pure per-viewer feed blocklist helpers
-// ABOUTME: Covers muters-of-viewer, blockers-of-viewer (kind 30000 d=block), own blocks, and video filtering
+// ABOUTME: Covers muters-of-viewer, legacy blockers-of-viewer, own legacy blocks, and video filtering
 
 import { describe, it, expect } from 'vitest';
 import type { NostrEvent } from '@nostrify/nostrify';
 import {
-  BLOCK_LIST_KIND,
-  BLOCK_LIST_D_TAG,
+  LEGACY_BLOCK_LIST_KIND,
+  LEGACY_BLOCK_LIST_D_TAG,
   parseMutersOfViewer,
   parseBlockersOfViewer,
-  parseOwnBlockedPubkeys,
+  parseOwnLegacyBlockedPubkeys,
   buildFeedBlocklist,
   filterBlockedVideos,
   filterBlockedVideoPages,
@@ -49,11 +49,11 @@ function muteListEvent(author: string, mutedPubkeys: string[], createdAt = 17000
 function blockListEvent(
   author: string,
   blockedPubkeys: string[],
-  { dTag = BLOCK_LIST_D_TAG, createdAt = 1700000000 }: { dTag?: string; createdAt?: number } = {}
+  { dTag = LEGACY_BLOCK_LIST_D_TAG, createdAt = 1700000000 }: { dTag?: string; createdAt?: number } = {}
 ): NostrEvent {
   return makeEvent({
     pubkey: author,
-    kind: BLOCK_LIST_KIND,
+    kind: LEGACY_BLOCK_LIST_KIND,
     created_at: createdAt,
     tags: [['d', dTag], ...blockedPubkeys.map(pk => ['p', pk])],
   });
@@ -144,13 +144,21 @@ describe('parseBlockersOfViewer', () => {
   });
 });
 
-describe('parseOwnBlockedPubkeys', () => {
-  it('returns p-tags from the viewer’s latest kind 30000 d=block event', () => {
+describe('parseOwnLegacyBlockedPubkeys', () => {
+  it("returns p-tags from the viewer's latest legacy kind 30000 d=block event", () => {
     const events = [
       blockListEvent(VIEWER, [ALICE, BOB], { createdAt: 100 }),
       blockListEvent(VIEWER, [ALICE], { createdAt: 200 }),
     ];
-    expect(parseOwnBlockedPubkeys(events, VIEWER)).toEqual([ALICE]);
+    expect(parseOwnLegacyBlockedPubkeys(events, VIEWER)).toEqual([ALICE]);
+  });
+
+  it('returns empty when an empty retirement replacement supersedes a populated legacy list', () => {
+    const events = [
+      blockListEvent(VIEWER, [ALICE, BOB], { createdAt: 100 }),
+      blockListEvent(VIEWER, [], { createdAt: 200 }),
+    ];
+    expect(parseOwnLegacyBlockedPubkeys(events, VIEWER)).toEqual([]);
   });
 
   it('ignores other authors, non-block d-tags, and self-references', () => {
@@ -159,11 +167,11 @@ describe('parseOwnBlockedPubkeys', () => {
       blockListEvent(VIEWER, [CAROL], { dTag: 'friends' }),
       blockListEvent(VIEWER, [VIEWER, BOB]),
     ];
-    expect(parseOwnBlockedPubkeys(events, VIEWER)).toEqual([BOB]);
+    expect(parseOwnLegacyBlockedPubkeys(events, VIEWER)).toEqual([BOB]);
   });
 
   it('returns empty when the viewer has no block list', () => {
-    expect(parseOwnBlockedPubkeys([], VIEWER)).toEqual([]);
+    expect(parseOwnLegacyBlockedPubkeys([], VIEWER)).toEqual([]);
   });
 });
 
@@ -172,7 +180,7 @@ describe('buildFeedBlocklist', () => {
     const set = buildFeedBlocklist({
       viewerPubkey: VIEWER,
       ownMutedPubkeys: [ALICE],
-      ownBlockedPubkeys: [BOB],
+      ownLegacyBlockedPubkeys: [BOB],
       mutersOfViewer: [CAROL],
       blockersOfViewer: [ALICE, BOB],
     });

--- a/src/lib/blocklistFilter.ts
+++ b/src/lib/blocklistFilter.ts
@@ -5,10 +5,12 @@ import type { NostrEvent } from '@nostrify/nostrify';
 import { MUTE_LIST_KIND } from '@/types/moderation';
 import { latestEventsByKey } from '@/lib/nostrEvents';
 
-// Divine's legacy block list: NIP-51 kind 30000 addressable list with d=block.
-// Any other d-tag on kind 30000 (follow sets, etc.) is NOT a block list.
-export const BLOCK_LIST_KIND = 30000;
-export const BLOCK_LIST_D_TAG = 'block';
+// Legacy block list: NIP-51 kind 30000 addressable list with d=block.
+// Divine clients no longer author it; mobile retired own lists by publishing
+// one empty replacement per account. Web still reads it for pre-retirement
+// accounts, older clients, and other clients that may still publish it.
+export const LEGACY_BLOCK_LIST_KIND = 30000;
+export const LEGACY_BLOCK_LIST_D_TAG = 'block';
 
 function getDTag(event: NostrEvent): string {
   const tag = event.tags.find(t => t[0] === 'd');
@@ -16,7 +18,7 @@ function getDTag(event: NostrEvent): string {
 }
 
 function hasBlockDTag(event: NostrEvent): boolean {
-  return getDTag(event) === BLOCK_LIST_D_TAG;
+  return getDTag(event) === LEGACY_BLOCK_LIST_D_TAG;
 }
 
 function pTagsInclude(event: NostrEvent, pubkey: string): boolean {
@@ -41,13 +43,14 @@ export function parseMutersOfViewer(events: NostrEvent[], viewerPubkey: string):
 }
 
 /**
- * Authors whose latest kind 30000 d=block list p-tags the viewer ("blockers-of-viewer").
+ * Authors whose latest legacy kind 30000 d=block list p-tags the viewer
+ * ("blockers-of-viewer").
  * Addressable events deduplicate by pubkey:kind:d-tag, so a newer kind 30000 list with a
  * different d-tag (e.g. a follow set) never shadows the block list, and only d=block counts.
  */
 export function parseBlockersOfViewer(events: NostrEvent[], viewerPubkey: string): string[] {
   const listEvents = events.filter(
-    e => e.kind === BLOCK_LIST_KIND && e.pubkey !== viewerPubkey
+    e => e.kind === LEGACY_BLOCK_LIST_KIND && e.pubkey !== viewerPubkey
   );
   const latestByAddress = latestEventsByKey(
     listEvents,
@@ -63,13 +66,15 @@ export function parseBlockersOfViewer(events: NostrEvent[], viewerPubkey: string
 }
 
 /**
- * Pubkeys on the viewer's own latest kind 30000 d=block list (blocks published by
- * Divine mobile). Self-references are dropped so a malformed list can never hide
- * the viewer's own content.
+ * Pubkeys on the viewer's own latest legacy kind 30000 d=block list.
+ * Current-era Divine clients publish own blocks on kind 10000 instead, through
+ * useMuteList. This legacy read remains for pre-retirement accounts and older
+ * clients. Self-references are dropped so a malformed list can never hide the
+ * viewer's own content.
  */
-export function parseOwnBlockedPubkeys(events: NostrEvent[], viewerPubkey: string): string[] {
+export function parseOwnLegacyBlockedPubkeys(events: NostrEvent[], viewerPubkey: string): string[] {
   const ownBlockEvents = events.filter(
-    e => e.kind === BLOCK_LIST_KIND && e.pubkey === viewerPubkey && hasBlockDTag(e)
+    e => e.kind === LEGACY_BLOCK_LIST_KIND && e.pubkey === viewerPubkey && hasBlockDTag(e)
   );
   const latest = latestEventsByKey(ownBlockEvents, () => 'own').get('own');
   if (!latest) return [];
@@ -84,11 +89,11 @@ export interface FeedBlocklistSources {
   viewerPubkey?: string;
   /** Pubkeys the viewer muted on their own kind 10000 mute list */
   ownMutedPubkeys?: Iterable<string>;
-  /** Pubkeys the viewer blocked on their own kind 30000 d=block list */
-  ownBlockedPubkeys?: Iterable<string>;
+  /** Pubkeys on the viewer's own legacy kind 30000 d=block list */
+  ownLegacyBlockedPubkeys?: Iterable<string>;
   /** Authors whose kind 10000 mute list p-tags the viewer */
   mutersOfViewer?: Iterable<string>;
-  /** Authors whose kind 30000 d=block list p-tags the viewer */
+  /** Authors whose legacy kind 30000 d=block list p-tags the viewer */
   blockersOfViewer?: Iterable<string>;
 }
 
@@ -100,7 +105,7 @@ export function buildFeedBlocklist(sources: FeedBlocklistSources): Set<string> {
   const set = new Set<string>();
   const buckets = [
     sources.ownMutedPubkeys,
-    sources.ownBlockedPubkeys,
+    sources.ownLegacyBlockedPubkeys,
     sources.mutersOfViewer,
     sources.blockersOfViewer,
   ];


### PR DESCRIPTION
## Summary

- Rename legacy kind 30000 block-list helpers and fields so they no longer read as the current Block source.
- Update feed blocklist comments and architecture docs to say Divine no longer authors own kind 30000 d=block lists while preserving legacy reads.
- Add regression coverage for the empty legacy retirement replacement, continued own kind 10000 filtering, mixed-era sources, and mute/unmute publish kinds.

## Motivation

- Mobile retired authoring the legacy kind 30000 d=block list and publishes an empty replacement per account, but web comments and tests still described it as the live source for own blocks.

## Related Issue

- Closes #582

## Testing

- [x] `npx vitest run src/lib/blocklistFilter.test.ts src/hooks/useFeedBlocklist.test.ts src/hooks/useModeration.test.ts`
- [x] `npm run test`
- [ ] Manual verification completed

## Visuals

- [ ] UI change with screenshots/video attached
- [x] No visual change
- [x] Visuals and text avoid sensitive external brand or partner names unless explicitly approved