### PR TITLE
ci(merged-blocker): remind blocked issues after PR merge

### DIFF
--- a/.github/workflows/merged_blocker_reminder.yml
+++ b/.github/workflows/merged_blocker_reminder.yml
@@ -6,7 +6,6 @@ on:
 
 permissions:
   issues: write
-  pull-requests: read
 
 jobs:
   remind-blocked-issues:

--- a/.github/workflows/merged_blocker_reminder.yml
+++ b/.github/workflows/merged_blocker_reminder.yml
@@ -32,10 +32,14 @@ jobs:
             async function ensureLabel(name) {
               try {
                 await github.rest.issues.getLabel({ owner, repo, name });
+                return;
               } catch (error) {
                 if (error.status !== 404) {
                   throw error;
                 }
+              }
+
+              try {
                 await github.rest.issues.createLabel({
                   owner,
                   repo,
@@ -43,6 +47,11 @@ jobs:
                   color: labels[name].color,
                   description: labels[name].description,
                 });
+              } catch (error) {
+                // 422 means a concurrently merged PR created it first.
+                if (error.status !== 422) {
+                  throw error;
+                }
               }
             }
 
@@ -57,15 +66,14 @@ jobs:
               });
             }
 
-            await ensureLabel('blocked');
-            await ensureLabel('ready');
-
             const issues = await github.paginate(github.rest.issues.listForRepo, {
               owner,
               repo,
               state: 'open',
               per_page: 100,
             });
+
+            const blockedIssues = [];
 
             for (const issue of issues) {
               if (issue.pull_request) {
@@ -77,12 +85,21 @@ jobs:
               const comments = issue.comments > 0 ? await listComments(issue.number) : [];
 
               if (
-                !blockerPattern.test(issue.body ?? '') &&
-                !comments.some((comment) => blockerPattern.test(comment.body ?? ''))
+                blockerPattern.test(issue.body ?? '') ||
+                comments.some((comment) => blockerPattern.test(comment.body ?? ''))
               ) {
-                continue;
+                blockedIssues.push({ issue, comments });
               }
+            }
 
+            if (blockedIssues.length === 0) {
+              return;
+            }
+
+            await ensureLabel('blocked');
+            await ensureLabel('ready');
+
+            for (const { issue, comments } of blockedIssues) {
               const existingLabelNames = issue.labels.map((label) =>
                 typeof label === 'string' ? label : label.name,
               );

--- a/.github/workflows/merged_blocker_reminder.yml
+++ b/.github/workflows/merged_blocker_reminder.yml
@@ -46,31 +46,15 @@ jobs:
               }
             }
 
-            async function issueMentionsMergedPr(issue) {
-              if (blockerPattern.test(issue.body ?? '')) {
-                return true;
-              }
+            const marker = `<!-- merged-blocker-reminder:${prNumber} -->`;
 
-              const comments = await github.paginate(github.rest.issues.listComments, {
-                owner,
-                repo,
-                issue_number: issue.number,
-                per_page: 100,
-              });
-
-              return comments.some((comment) => blockerPattern.test(comment.body ?? ''));
-            }
-
-            async function alreadyCommented(issueNumber) {
-              const marker = `<!-- merged-blocker-reminder:${prNumber} -->`;
-              const comments = await github.paginate(github.rest.issues.listComments, {
+            async function listComments(issueNumber) {
+              return github.paginate(github.rest.issues.listComments, {
                 owner,
                 repo,
                 issue_number: issueNumber,
                 per_page: 100,
               });
-
-              return comments.some((comment) => comment.body?.includes(marker));
             }
 
             await ensureLabel('blocked');
@@ -84,7 +68,18 @@ jobs:
             });
 
             for (const issue of issues) {
-              if (issue.pull_request || !(await issueMentionsMergedPr(issue))) {
+              if (issue.pull_request) {
+                continue;
+              }
+
+              // Fetched at most once per issue and reused for both the blocker
+              // match and the duplicate-comment check.
+              const comments = issue.comments > 0 ? await listComments(issue.number) : [];
+
+              if (
+                !blockerPattern.test(issue.body ?? '') &&
+                !comments.some((comment) => blockerPattern.test(comment.body ?? ''))
+              ) {
                 continue;
               }
 
@@ -110,7 +105,7 @@ jobs:
                 });
               }
 
-              if (await alreadyCommented(issue.number)) {
+              if (comments.some((comment) => comment.body?.includes(marker))) {
                 continue;
               }
 
@@ -119,7 +114,7 @@ jobs:
                 repo,
                 issue_number: issue.number,
                 body: [
-                  `<!-- merged-blocker-reminder:${prNumber} -->`,
+                  marker,
                   `PR #${prNumber} has merged, so this issue is ready to pick back up.`,
                   '',
                   'Re-check the issue body and merged PR copy before implementing.',

--- a/.github/workflows/merged_blocker_reminder.yml
+++ b/.github/workflows/merged_blocker_reminder.yml
@@ -1,0 +1,128 @@
+name: Merged Blocker Reminder
+
+on:
+  pull_request_target:
+    types: [closed]
+
+permissions:
+  issues: write
+  pull-requests: read
+
+jobs:
+  remind-blocked-issues:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - name: Mark issues ready when their blocker PR merges
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+            const prNumber = pr.number;
+            const { owner, repo } = context.repo;
+            const blockerPattern = new RegExp(
+              String.raw`\bblocked\s+(?:on|by)(?:\s+(?:pr|pull request))?\s+#${prNumber}\b`,
+              'i',
+            );
+            const labels = {
+              blocked: { color: 'cfd3d7', description: 'Waiting on another issue or pull request' },
+              ready: { color: '0e8a16', description: 'Unblocked and ready to pick up' },
+            };
+
+            async function ensureLabel(name) {
+              try {
+                await github.rest.issues.getLabel({ owner, repo, name });
+              } catch (error) {
+                if (error.status !== 404) {
+                  throw error;
+                }
+                await github.rest.issues.createLabel({
+                  owner,
+                  repo,
+                  name,
+                  color: labels[name].color,
+                  description: labels[name].description,
+                });
+              }
+            }
+
+            async function issueMentionsMergedPr(issue) {
+              if (blockerPattern.test(issue.body ?? '')) {
+                return true;
+              }
+
+              const comments = await github.paginate(github.rest.issues.listComments, {
+                owner,
+                repo,
+                issue_number: issue.number,
+                per_page: 100,
+              });
+
+              return comments.some((comment) => blockerPattern.test(comment.body ?? ''));
+            }
+
+            async function alreadyCommented(issueNumber) {
+              const marker = `<!-- merged-blocker-reminder:${prNumber} -->`;
+              const comments = await github.paginate(github.rest.issues.listComments, {
+                owner,
+                repo,
+                issue_number: issueNumber,
+                per_page: 100,
+              });
+
+              return comments.some((comment) => comment.body?.includes(marker));
+            }
+
+            await ensureLabel('blocked');
+            await ensureLabel('ready');
+
+            const issues = await github.paginate(github.rest.issues.listForRepo, {
+              owner,
+              repo,
+              state: 'open',
+              per_page: 100,
+            });
+
+            for (const issue of issues) {
+              if (issue.pull_request || !(await issueMentionsMergedPr(issue))) {
+                continue;
+              }
+
+              const existingLabelNames = issue.labels.map((label) =>
+                typeof label === 'string' ? label : label.name,
+              );
+
+              if (existingLabelNames.includes('blocked')) {
+                await github.rest.issues.removeLabel({
+                  owner,
+                  repo,
+                  issue_number: issue.number,
+                  name: 'blocked',
+                });
+              }
+
+              if (!existingLabelNames.includes('ready')) {
+                await github.rest.issues.addLabels({
+                  owner,
+                  repo,
+                  issue_number: issue.number,
+                  labels: ['ready'],
+                });
+              }
+
+              if (await alreadyCommented(issue.number)) {
+                continue;
+              }
+
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number: issue.number,
+                body: [
+                  `<!-- merged-blocker-reminder:${prNumber} -->`,
+                  `PR #${prNumber} has merged, so this issue is ready to pick back up.`,
+                  '',
+                  'Re-check the issue body and merged PR copy before implementing.',
+                ].join('\n'),
+              });
+            }


### PR DESCRIPTION
## Summary

- Add a GitHub Actions workflow that marks open issues ready when their blocker PR merges.
- Match issue bodies or comments that say `blocked on #123`, `blocked by #123`, or `blocked by PR #123`.

> Avoid naming corporate partners, customers, or other sensitive external brands in this PR title or body. Use generic descriptors unless a maintainer explicitly approves the public reference.

## Motivation

- Keep follow-up issues from sitting unnoticed after the PR they depend on has merged.

## Related Issue

- N/A

## Testing

- [ ] `npm run test`
- [x] Manual verification completed: `actionlint .github/workflows/merged_blocker_reminder.yml` and YAML parse both pass.

## Visuals

- [ ] UI change with screenshots/video attached
- [x] No visual change
- [x] Visuals and text avoid sensitive external brand or partner names unless explicitly approved