### PR TITLE
ci(blocker-reminder): harden merged blocker follow-ups

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -48,7 +48,7 @@ body:
     id: regression
     attributes:
       label: Regression Notes
-      description: If known, note whether this worked before and what changed.
+      description: If known, note whether this worked before and what changed. If another PR blocks this issue, write `blocked on #123`, `blocked by #123`, or `blocked by PR #123`.
       placeholder: Optional context about when the regression started.
   - type: textarea
     id: screenshots

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -31,7 +31,7 @@ body:
     id: proposal
     attributes:
       label: Proposed Approach
-      description: Describe the desired behavior or UX at a high level.
+      description: Describe the desired behavior or UX at a high level. If another PR blocks this issue, write `blocked on #123`, `blocked by #123`, or `blocked by PR #123`.
       placeholder: Outline the proposed change.
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/general.yml
+++ b/.github/ISSUE_TEMPLATE/general.yml
@@ -21,5 +21,5 @@ body:
     id: details
     attributes:
       label: Details
-      description: Add context, constraints, links, or acceptance criteria.
+      description: Add context, constraints, links, acceptance criteria, or blockers. If another PR blocks this issue, write `blocked on #123`, `blocked by #123`, or `blocked by PR #123`.
       placeholder: What needs to happen?

--- a/.github/workflows/merged_blocker_reminder.yml
+++ b/.github/workflows/merged_blocker_reminder.yml
@@ -20,9 +20,10 @@ jobs:
             const prNumber = pr.number;
             const { owner, repo } = context.repo;
             const blockerReferencePattern = new RegExp(
-              String.raw`\bblocked\s+(?:on|by)(?:\s+(?:pr|pull request))?\s+#\d+(?:\s*(?:,|and|&)\s*(?:(?:pr|pull request)\s+)?#\d+)*`,
+              String.raw`\bblocked\s+(?:on|by)(?:\s+(?:pr|pull request))?\s+#\d+(?:\s*(?:,\s*(?:and\s+)?|and\s+|&\s*)(?:(?:pr|pull request)\s+)?#\d+)*`,
               'gi',
             );
+            const trustedCommentAssociations = new Set(['OWNER', 'MEMBER', 'COLLABORATOR']);
             const labels = {
               blocked: { color: 'cfd3d7', description: 'Waiting on another issue or pull request' },
               ready: { color: '0e8a16', description: 'Unblocked and ready to pick up' },
@@ -59,12 +60,29 @@ jobs:
 
             function extractBlockerNumbers(text) {
               const numbers = new Set();
-              for (const match of text.matchAll(blockerReferencePattern)) {
-                for (const numberMatch of match[0].matchAll(/#(\d+)/g)) {
-                  numbers.add(Number(numberMatch[1]));
+              for (const line of text.split(/\r?\n/)) {
+                const normalizedLine = line.trimStart();
+                if (normalizedLine.startsWith('>') || /\bnot\s+blocked\s+(?:on|by)\b/i.test(normalizedLine)) {
+                  continue;
+                }
+
+                blockerReferencePattern.lastIndex = 0;
+                for (const match of normalizedLine.matchAll(blockerReferencePattern)) {
+                  for (const numberMatch of match[0].matchAll(/#(\d+)/g)) {
+                    numbers.add(Number(numberMatch[1]));
+                  }
                 }
               }
               return numbers;
+            }
+
+            function extractTrustedBlockerNumbers(issueBody, comments) {
+              return new Set([
+                ...extractBlockerNumbers(issueBody ?? ''),
+                ...comments
+                  .filter((comment) => trustedCommentAssociations.has(comment.author_association))
+                  .flatMap((comment) => [...extractBlockerNumbers(comment.body ?? '')]),
+              ]);
             }
 
             async function listComments(issueNumber) {
@@ -81,12 +99,23 @@ jobs:
                 return blockerStateCache.get(blockerNumber);
               }
 
-              const { data } = await github.rest.issues.get({
-                owner,
-                repo,
-                issue_number: blockerNumber,
-              });
-              const closed = data.state === 'closed';
+              let closed = false;
+
+              try {
+                const { data } = await github.rest.issues.get({
+                  owner,
+                  repo,
+                  issue_number: blockerNumber,
+                });
+                closed = data.state === 'closed' && (!data.pull_request || data.pull_request.merged_at !== null);
+              } catch (error) {
+                // A reference we cannot resolve keeps the issue blocked.
+                if (error.status !== 404) {
+                  throw error;
+                }
+                console.warn(`Blocker #${blockerNumber} does not exist; treating it as open.`);
+              }
+
               blockerStateCache.set(blockerNumber, closed);
               return closed;
             }
@@ -108,13 +137,10 @@ jobs:
               // Fetched at most once per issue and reused for both the blocker
               // match and the duplicate-comment check.
               const comments = issue.comments > 0 ? await listComments(issue.number) : [];
-              const blockerNumbers = new Set([
-                ...extractBlockerNumbers(issue.body ?? ''),
-                ...comments.flatMap((comment) => [...extractBlockerNumbers(comment.body ?? '')]),
-              ]);
+              const blockerNumbers = extractTrustedBlockerNumbers(issue.body, comments);
 
               if (blockerNumbers.has(prNumber)) {
-                blockedIssues.push({ issue, comments });
+                blockedIssues.push({ issue, comments, blockerNumbers });
               }
             }
 
@@ -125,11 +151,7 @@ jobs:
             await ensureLabel('blocked');
             await ensureLabel('ready');
 
-            for (const { issue, comments } of blockedIssues) {
-              const blockerNumbers = new Set([
-                ...extractBlockerNumbers(issue.body ?? ''),
-                ...comments.flatMap((comment) => [...extractBlockerNumbers(comment.body ?? '')]),
-              ]);
+            for (const { issue, comments, blockerNumbers } of blockedIssues) {
               const allBlockersClosed = (
                 await Promise.all([...blockerNumbers].map((number) => isBlockerClosed(number)))
               ).every(Boolean);

--- a/.github/workflows/merged_blocker_reminder.yml
+++ b/.github/workflows/merged_blocker_reminder.yml
@@ -59,18 +59,24 @@ jobs:
             const blockerStateCache = new Map([[prNumber, true]]);
 
             function extractBlockerNumbers(text) {
-              const numbers = new Set();
-              for (const line of text.split(/\r?\n/)) {
-                const normalizedLine = line.trimStart();
-                if (normalizedLine.startsWith('>') || /\bnot\s+blocked\s+(?:on|by)\b/i.test(normalizedLine)) {
-                  continue;
-                }
+              // Quoted and negated lines are dropped first, then the survivors are
+              // rejoined so a blocker list that wraps mid-list still matches as one.
+              const scannable = text
+                .split(/\r?\n/)
+                .filter((line) => {
+                  const normalizedLine = line.trimStart();
+                  return (
+                    !normalizedLine.startsWith('>') &&
+                    !/\bnot\s+blocked\s+(?:on|by)\b/i.test(normalizedLine)
+                  );
+                })
+                .join('\n');
 
-                blockerReferencePattern.lastIndex = 0;
-                for (const match of normalizedLine.matchAll(blockerReferencePattern)) {
-                  for (const numberMatch of match[0].matchAll(/#(\d+)/g)) {
-                    numbers.add(Number(numberMatch[1]));
-                  }
+              const numbers = new Set();
+              blockerReferencePattern.lastIndex = 0;
+              for (const match of scannable.matchAll(blockerReferencePattern)) {
+                for (const numberMatch of match[0].matchAll(/#(\d+)/g)) {
+                  numbers.add(Number(numberMatch[1]));
                 }
               }
               return numbers;

--- a/.github/workflows/merged_blocker_reminder.yml
+++ b/.github/workflows/merged_blocker_reminder.yml
@@ -19,9 +19,9 @@ jobs:
             const pr = context.payload.pull_request;
             const prNumber = pr.number;
             const { owner, repo } = context.repo;
-            const blockerPattern = new RegExp(
-              String.raw`\bblocked\s+(?:on|by)(?:\s+(?:pr|pull request))?\s+#${prNumber}\b`,
-              'i',
+            const blockerReferencePattern = new RegExp(
+              String.raw`\bblocked\s+(?:on|by)(?:\s+(?:pr|pull request))?\s+#\d+(?:\s*(?:,|and|&)\s*(?:(?:pr|pull request)\s+)?#\d+)*`,
+              'gi',
             );
             const labels = {
               blocked: { color: 'cfd3d7', description: 'Waiting on another issue or pull request' },
@@ -55,6 +55,17 @@ jobs:
             }
 
             const marker = `<!-- merged-blocker-reminder:${prNumber} -->`;
+            const blockerStateCache = new Map([[prNumber, true]]);
+
+            function extractBlockerNumbers(text) {
+              const numbers = new Set();
+              for (const match of text.matchAll(blockerReferencePattern)) {
+                for (const numberMatch of match[0].matchAll(/#(\d+)/g)) {
+                  numbers.add(Number(numberMatch[1]));
+                }
+              }
+              return numbers;
+            }
 
             async function listComments(issueNumber) {
               return github.paginate(github.rest.issues.listComments, {
@@ -63,6 +74,21 @@ jobs:
                 issue_number: issueNumber,
                 per_page: 100,
               });
+            }
+
+            async function isBlockerClosed(blockerNumber) {
+              if (blockerStateCache.has(blockerNumber)) {
+                return blockerStateCache.get(blockerNumber);
+              }
+
+              const { data } = await github.rest.issues.get({
+                owner,
+                repo,
+                issue_number: blockerNumber,
+              });
+              const closed = data.state === 'closed';
+              blockerStateCache.set(blockerNumber, closed);
+              return closed;
             }
 
             const issues = await github.paginate(github.rest.issues.listForRepo, {
@@ -82,11 +108,12 @@ jobs:
               // Fetched at most once per issue and reused for both the blocker
               // match and the duplicate-comment check.
               const comments = issue.comments > 0 ? await listComments(issue.number) : [];
+              const blockerNumbers = new Set([
+                ...extractBlockerNumbers(issue.body ?? ''),
+                ...comments.flatMap((comment) => [...extractBlockerNumbers(comment.body ?? '')]),
+              ]);
 
-              if (
-                blockerPattern.test(issue.body ?? '') ||
-                comments.some((comment) => blockerPattern.test(comment.body ?? ''))
-              ) {
+              if (blockerNumbers.has(prNumber)) {
                 blockedIssues.push({ issue, comments });
               }
             }
@@ -99,17 +126,36 @@ jobs:
             await ensureLabel('ready');
 
             for (const { issue, comments } of blockedIssues) {
+              const blockerNumbers = new Set([
+                ...extractBlockerNumbers(issue.body ?? ''),
+                ...comments.flatMap((comment) => [...extractBlockerNumbers(comment.body ?? '')]),
+              ]);
+              const allBlockersClosed = (
+                await Promise.all([...blockerNumbers].map((number) => isBlockerClosed(number)))
+              ).every(Boolean);
+
+              if (!allBlockersClosed) {
+                continue;
+              }
+
               const existingLabelNames = issue.labels.map((label) =>
                 typeof label === 'string' ? label : label.name,
               );
 
               if (existingLabelNames.includes('blocked')) {
-                await github.rest.issues.removeLabel({
-                  owner,
-                  repo,
-                  issue_number: issue.number,
-                  name: 'blocked',
-                });
+                try {
+                  await github.rest.issues.removeLabel({
+                    owner,
+                    repo,
+                    issue_number: issue.number,
+                    name: 'blocked',
+                  });
+                } catch (error) {
+                  // Another merged blocker run may have removed it first.
+                  if (error.status !== 404) {
+                    throw error;
+                  }
+                }
               }
 
               if (!existingLabelNames.includes('ready')) {

--- a/.github/workflows/merged_blocker_reminder.yml
+++ b/.github/workflows/merged_blocker_reminder.yml
@@ -113,7 +113,7 @@ jobs:
                   repo,
                   issue_number: blockerNumber,
                 });
-                closed = data.state === 'closed' && (!data.pull_request || data.pull_request.merged_at !== null);
+                closed = data.state === 'closed' && (!data.pull_request || Boolean(data.pull_request.merged_at));
               } catch (error) {
                 // A reference we cannot resolve keeps the issue blocked.
                 if (error.status !== 404) {

--- a/tests/merged-blocker-reminder.test.ts
+++ b/tests/merged-blocker-reminder.test.ts
@@ -134,6 +134,42 @@ describe('merged blocker reminder workflow', () => {
     expect(issueApi.createComment).not.toHaveBeenCalled();
   });
 
+  it('keeps an issue blocked when a wrapped blocker list still has an open blocker', async () => {
+    const issueApi = await runWorkflow({
+      blockerStates: { 100: 'closed', 999: 'open' },
+      issues: [
+        {
+          body: 'Blocked on #100, #123,\n#456, and #999.',
+          comments: 0,
+          labels: [{ name: 'blocked' }],
+          number: 42,
+        },
+      ],
+    });
+
+    expect(issueApi.removeLabel).not.toHaveBeenCalled();
+    expect(issueApi.addLabels).not.toHaveBeenCalled();
+    expect(issueApi.createComment).not.toHaveBeenCalled();
+  });
+
+  it('still ignores a quoted blocker reference on the line after a real one', async () => {
+    const issueApi = await runWorkflow({
+      blockerStates: { 999: 'open' },
+      issues: [
+        {
+          body: 'Blocked on #123.\n> blocked on #999',
+          comments: 0,
+          labels: [{ name: 'blocked' }],
+          number: 42,
+        },
+      ],
+    });
+
+    expect(issueApi.addLabels).toHaveBeenCalledWith(
+      expect.objectContaining({ issue_number: 42, labels: ['ready'] }),
+    );
+  });
+
   it('treats an unresolvable blocker reference as open', async () => {
     const issueApi = await runWorkflow({
       issues: [

--- a/tests/merged-blocker-reminder.test.ts
+++ b/tests/merged-blocker-reminder.test.ts
@@ -13,8 +13,17 @@ type IssueFixture = {
 };
 
 type CommentFixture = {
+  author_association?: string;
   body?: string;
 };
+
+type BlockerFixture =
+  | 'closed'
+  | 'open'
+  | {
+      pull_request?: { merged_at: string | null };
+      state: 'closed' | 'open';
+    };
 
 function extractWorkflowScript(): string {
   const lines = readFileSync('.github/workflows/merged_blocker_reminder.yml', 'utf8').split('\n');
@@ -35,23 +44,35 @@ async function runWorkflow({
   blockerStates = {},
   commentsByIssue = {},
   issues,
+  missingBlockers = [],
   prNumber = 123,
   removeLabelError,
 }: {
-  blockerStates?: Record<number, 'open' | 'closed'>;
+  blockerStates?: Record<number, BlockerFixture>;
   commentsByIssue?: Record<number, CommentFixture[]>;
   issues: IssueFixture[];
+  missingBlockers?: number[];
   prNumber?: number;
   removeLabelError?: { status: number };
 }) {
   const script = extractWorkflowScript();
+  const missingBlockerNumbers = new Set(missingBlockers);
   const issueApi = {
     addLabels: vi.fn().mockResolvedValue({}),
     createComment: vi.fn().mockResolvedValue({}),
     createLabel: vi.fn().mockResolvedValue({}),
-    get: vi.fn(async ({ issue_number }: { issue_number: number }) => ({
-      data: { state: blockerStates[issue_number] ?? 'open' },
-    })),
+    get: vi.fn(async ({ issue_number }: { issue_number: number }) => {
+      if (missingBlockerNumbers.has(issue_number)) {
+        const error = new Error('Not Found') as Error & { status: number };
+        error.status = 404;
+        throw error;
+      }
+
+      const blockerState = blockerStates[issue_number] ?? 'open';
+      const data = typeof blockerState === 'string' ? { state: blockerState } : blockerState;
+
+      return { data };
+    }),
     getLabel: vi.fn().mockResolvedValue({}),
     listComments: vi.fn(async ({ issue_number }: { issue_number: number }) => commentsByIssue[issue_number] ?? []),
     listForRepo: vi.fn().mockResolvedValue(issues),
@@ -95,11 +116,157 @@ describe('merged blocker reminder workflow', () => {
     expect(issueApi.createComment).not.toHaveBeenCalled();
   });
 
+  it('keeps an issue blocked when an Oxford-comma blocker list still has an open blocker', async () => {
+    const issueApi = await runWorkflow({
+      blockerStates: { 100: 'closed', 999: 'open' },
+      issues: [
+        {
+          body: 'Blocked on #100, #123, and #999.',
+          comments: 0,
+          labels: [{ name: 'blocked' }],
+          number: 42,
+        },
+      ],
+    });
+
+    expect(issueApi.removeLabel).not.toHaveBeenCalled();
+    expect(issueApi.addLabels).not.toHaveBeenCalled();
+    expect(issueApi.createComment).not.toHaveBeenCalled();
+  });
+
+  it('treats an unresolvable blocker reference as open', async () => {
+    const issueApi = await runWorkflow({
+      issues: [
+        {
+          body: 'Blocked on #123 and #999999.',
+          comments: 0,
+          labels: [{ name: 'blocked' }],
+          number: 42,
+        },
+      ],
+      missingBlockers: [999999],
+    });
+
+    expect(issueApi.removeLabel).not.toHaveBeenCalled();
+    expect(issueApi.addLabels).not.toHaveBeenCalled();
+    expect(issueApi.createComment).not.toHaveBeenCalled();
+  });
+
+  it('continues processing issues after an unresolvable blocker reference', async () => {
+    const issueApi = await runWorkflow({
+      issues: [
+        {
+          body: 'Blocked on #123 and #999999.',
+          comments: 0,
+          labels: [{ name: 'blocked' }],
+          number: 41,
+        },
+        {
+          body: 'Blocked on #123.',
+          comments: 0,
+          labels: [{ name: 'blocked' }],
+          number: 42,
+        },
+      ],
+      missingBlockers: [999999],
+    });
+
+    expect(issueApi.removeLabel).toHaveBeenCalledTimes(1);
+    expect(issueApi.removeLabel).toHaveBeenCalledWith(
+      expect.objectContaining({ issue_number: 42, name: 'blocked' }),
+    );
+    expect(issueApi.addLabels).toHaveBeenCalledWith(
+      expect.objectContaining({ issue_number: 42, labels: ['ready'] }),
+    );
+  });
+
+  it('ignores blocker references in untrusted comments', async () => {
+    const issueApi = await runWorkflow({
+      commentsByIssue: {
+        42: [{ author_association: 'NONE', body: 'Blocked on #123.' }],
+      },
+      issues: [
+        {
+          body: '',
+          comments: 1,
+          labels: [],
+          number: 42,
+        },
+      ],
+    });
+
+    expect(issueApi.removeLabel).not.toHaveBeenCalled();
+    expect(issueApi.addLabels).not.toHaveBeenCalled();
+    expect(issueApi.createComment).not.toHaveBeenCalled();
+  });
+
+  it('uses blocker references in trusted comments', async () => {
+    const issueApi = await runWorkflow({
+      commentsByIssue: {
+        42: [{ author_association: 'MEMBER', body: 'Blocked on #123.' }],
+      },
+      issues: [
+        {
+          body: '',
+          comments: 1,
+          labels: [{ name: 'blocked' }],
+          number: 42,
+        },
+      ],
+    });
+
+    expect(issueApi.removeLabel).toHaveBeenCalledWith(
+      expect.objectContaining({ issue_number: 42, name: 'blocked' }),
+    );
+    expect(issueApi.addLabels).toHaveBeenCalledWith(
+      expect.objectContaining({ issue_number: 42, labels: ['ready'] }),
+    );
+  });
+
+  it('ignores quoted and negated blocker references', async () => {
+    const issueApi = await runWorkflow({
+      issues: [
+        {
+          body: ['Not blocked on #123.', '> blocked on #123'].join('\n'),
+          comments: 0,
+          labels: [{ name: 'blocked' }],
+          number: 42,
+        },
+      ],
+    });
+
+    expect(issueApi.removeLabel).not.toHaveBeenCalled();
+    expect(issueApi.addLabels).not.toHaveBeenCalled();
+    expect(issueApi.createComment).not.toHaveBeenCalled();
+  });
+
+  it('keeps an issue blocked when a blocker PR was closed without merging', async () => {
+    const issueApi = await runWorkflow({
+      blockerStates: {
+        100: { pull_request: { merged_at: null }, state: 'closed' },
+      },
+      issues: [
+        {
+          body: 'Blocked on #100 and #123.',
+          comments: 0,
+          labels: [{ name: 'blocked' }],
+          number: 42,
+        },
+      ],
+    });
+
+    expect(issueApi.removeLabel).not.toHaveBeenCalled();
+    expect(issueApi.addLabels).not.toHaveBeenCalled();
+    expect(issueApi.createComment).not.toHaveBeenCalled();
+  });
+
   it('marks an issue ready when every referenced blocker is closed', async () => {
     const issueApi = await runWorkflow({
-      blockerStates: { 100: 'closed' },
+      blockerStates: {
+        100: { pull_request: { merged_at: '2026-08-15T18:45:37Z' }, state: 'closed' },
+      },
       commentsByIssue: {
-        42: [{ body: 'Blocked by PR #100 and #123.' }],
+        42: [{ author_association: 'MEMBER', body: 'Blocked by PR #100 and #123.' }],
       },
       issues: [
         {

--- a/tests/merged-blocker-reminder.test.ts
+++ b/tests/merged-blocker-reminder.test.ts
@@ -1,0 +1,146 @@
+import { readFileSync } from 'node:fs';
+
+import { describe, expect, it, vi } from 'vitest';
+
+const AsyncFunction = Object.getPrototypeOf(async function () {}).constructor;
+
+type IssueFixture = {
+  body?: string;
+  comments?: number;
+  labels?: Array<string | { name: string }>;
+  number: number;
+  pull_request?: unknown;
+};
+
+type CommentFixture = {
+  body?: string;
+};
+
+function extractWorkflowScript(): string {
+  const lines = readFileSync('.github/workflows/merged_blocker_reminder.yml', 'utf8').split('\n');
+  const scriptStart = lines.findIndex((line) => line.trim() === 'script: |');
+
+  if (scriptStart === -1) {
+    throw new Error('No github-script block found');
+  }
+
+  return lines
+    .slice(scriptStart + 1)
+    .filter((line) => line.startsWith('            ') || line.trim() === '')
+    .map((line) => line.replace(/^ {12}/, ''))
+    .join('\n');
+}
+
+async function runWorkflow({
+  blockerStates = {},
+  commentsByIssue = {},
+  issues,
+  prNumber = 123,
+  removeLabelError,
+}: {
+  blockerStates?: Record<number, 'open' | 'closed'>;
+  commentsByIssue?: Record<number, CommentFixture[]>;
+  issues: IssueFixture[];
+  prNumber?: number;
+  removeLabelError?: { status: number };
+}) {
+  const script = extractWorkflowScript();
+  const issueApi = {
+    addLabels: vi.fn().mockResolvedValue({}),
+    createComment: vi.fn().mockResolvedValue({}),
+    createLabel: vi.fn().mockResolvedValue({}),
+    get: vi.fn(async ({ issue_number }: { issue_number: number }) => ({
+      data: { state: blockerStates[issue_number] ?? 'open' },
+    })),
+    getLabel: vi.fn().mockResolvedValue({}),
+    listComments: vi.fn(async ({ issue_number }: { issue_number: number }) => commentsByIssue[issue_number] ?? []),
+    listForRepo: vi.fn().mockResolvedValue(issues),
+    removeLabel: vi.fn(async () => {
+      if (removeLabelError) {
+        throw removeLabelError;
+      }
+      return {};
+    }),
+  };
+  const github = {
+    paginate: vi.fn((endpoint, params) => endpoint(params)),
+    rest: { issues: issueApi },
+  };
+  const context = {
+    payload: { pull_request: { number: prNumber } },
+    repo: { owner: 'divinevideo', repo: 'divine-web' },
+  };
+
+  await new AsyncFunction('github', 'context', script)(github, context);
+
+  return issueApi;
+}
+
+describe('merged blocker reminder workflow', () => {
+  it('does not mark an issue ready while another referenced blocker is still open', async () => {
+    const issueApi = await runWorkflow({
+      blockerStates: { 100: 'open' },
+      issues: [
+        {
+          body: 'Blocked on #100 and #123.',
+          comments: 0,
+          labels: [{ name: 'blocked' }],
+          number: 42,
+        },
+      ],
+    });
+
+    expect(issueApi.removeLabel).not.toHaveBeenCalled();
+    expect(issueApi.addLabels).not.toHaveBeenCalled();
+    expect(issueApi.createComment).not.toHaveBeenCalled();
+  });
+
+  it('marks an issue ready when every referenced blocker is closed', async () => {
+    const issueApi = await runWorkflow({
+      blockerStates: { 100: 'closed' },
+      commentsByIssue: {
+        42: [{ body: 'Blocked by PR #100 and #123.' }],
+      },
+      issues: [
+        {
+          body: '',
+          comments: 1,
+          labels: [{ name: 'blocked' }],
+          number: 42,
+        },
+      ],
+    });
+
+    expect(issueApi.removeLabel).toHaveBeenCalledWith(
+      expect.objectContaining({ issue_number: 42, name: 'blocked' }),
+    );
+    expect(issueApi.addLabels).toHaveBeenCalledWith(
+      expect.objectContaining({ issue_number: 42, labels: ['ready'] }),
+    );
+    expect(issueApi.createComment).toHaveBeenCalledWith(
+      expect.objectContaining({
+        body: expect.stringContaining('<!-- merged-blocker-reminder:123 -->'),
+        issue_number: 42,
+      }),
+    );
+  });
+
+  it('tolerates a raced blocked-label removal', async () => {
+    const issueApi = await runWorkflow({
+      issues: [
+        {
+          body: 'Blocked on #123.',
+          comments: 0,
+          labels: [{ name: 'blocked' }],
+          number: 42,
+        },
+      ],
+      removeLabelError: { status: 404 },
+    });
+
+    expect(issueApi.addLabels).toHaveBeenCalledWith(
+      expect.objectContaining({ issue_number: 42, labels: ['ready'] }),
+    );
+    expect(issueApi.createComment).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

- Keep blocked issues blocked until every referenced blocker is closed.
- Tolerate raced `blocked` label removal when concurrent blocker reminders run.
- Document the `blocked on #123` convention in issue templates and add workflow tests.

> Avoid naming corporate partners, customers, or other sensitive external brands in this PR title or body. Use generic descriptors unless a maintainer explicitly approves the public reference.

## Motivation

- Prevent multi-blocker issues from being marked ready too early.
- Make the merged blocker reminder safer under concurrent runs and easier to maintain.

## Related Issue

- N/A

## Testing

- [x] `npm run test`
- [x] Manual verification completed: `actionlint .github/workflows/merged_blocker_reminder.yml`, YAML parse for the changed workflow/templates, and #597 one-time cleanup verified.

## Visuals

- [ ] UI change with screenshots/video attached
- [x] No visual change
- [x] Visuals and text avoid sensitive external brand or partner names unless explicitly approved