### PR TITLE
ci: route review requests with CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,20 +4,23 @@
 # gets asked. Without it, requesting a reviewer is a step the author has to
 # remember, and a skipped request looks exactly like a completed one.
 #
-# Order matters: the LAST matching pattern wins. Keep the catch-all first.
+# divine-web is not in the per-repo mapping in divine-context
+# PR_REVIEW_TEAMS.md, so the default applies: @divinevideo/reviewers owns
+# review requests for the whole repository.
 #
-# Only paths that exist in this repository are listed. A pattern matching no
-# path is silently inert, as is a team without write access here — GitHub
-# reports neither.
+# Two ways a line here can fail, one silent, one reported:
+# - A pattern matching no path is silently inert.
+# - A team without write access to this repository is an "Unknown owner":
+#   GitHub flags it on this file's page and at
+#   /repos/divinevideo/divine-web/codeowners/errors, which takes a ref, so a
+#   branch can be checked before merge:
+#   gh api "repos/divinevideo/divine-web/codeowners/errors?ref=<branch>"
+#
+# If platform routing is added later, the team needs write access here first
+# (the "Unknown owner" check above covers that), and compute-js/ — the Fastly
+# edge config with the live service id, backends, KV and secret stores — is
+# the path that earns it. wrangler.toml is a three-line Cloudflare Pages
+# build config. Order matters if lines are added: the LAST matching pattern
+# wins, so keep the catch-all first.
 
 * @divinevideo/reviewers
-
-# Platform-sensitive paths, per PR_REVIEW_TEAMS.md: production deployment and
-# routing. wrangler.toml carries the Worker's routes, bindings and environment,
-# so an incorrect final state here misdirects live traffic rather than breaking
-# one feature.
-/.github/workflows/   @divinevideo/platform
-/wrangler.toml        @divinevideo/platform
-
-# Changing who reviews what is itself a platform decision.
-/.github/CODEOWNERS   @divinevideo/platform

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,23 @@
+# Routes review requests automatically when a pull request opens.
+#
+# Branch protection decides whether a pull request may merge; this decides who
+# gets asked. Without it, requesting a reviewer is a step the author has to
+# remember, and a skipped request looks exactly like a completed one.
+#
+# Order matters: the LAST matching pattern wins. Keep the catch-all first.
+#
+# Only paths that exist in this repository are listed. A pattern matching no
+# path is silently inert, as is a team without write access here — GitHub
+# reports neither.
+
+* @divinevideo/reviewers
+
+# Platform-sensitive paths, per PR_REVIEW_TEAMS.md: production deployment and
+# routing. wrangler.toml carries the Worker's routes, bindings and environment,
+# so an incorrect final state here misdirects live traffic rather than breaking
+# one feature.
+/.github/workflows/   @divinevideo/platform
+/wrangler.toml        @divinevideo/platform
+
+# Changing who reviews what is itself a platform decision.
+/.github/CODEOWNERS   @divinevideo/platform


### PR DESCRIPTION
## Summary

Adds `.github/CODEOWNERS` so review requests are routed automatically when a pull request opens.

## Why here first

**9 authors, 128 commits in the last 90 days** — the widest contributor spread of any divine repo, so unrouted review costs the most here.

Branch protection decides whether a pull request *may* merge. Nothing decided *who should look*, so pull requests wait on someone noticing. Requesting the mapped team is documented in `divine-context/PR_REVIEW.md`, but it is a step the author must remember, and a skipped request looks exactly like a completed one.

CODEOWNERS is applied by GitHub the moment the PR opens — no author action, no agent action, identical for both.

## Routing

```
*                      @divinevideo/reviewers
```

divine-web is not in the per-repo mapping in `PR_REVIEW_TEAMS.md`, so the default reviewer team owns the whole repository.

An earlier revision of this PR also routed `.github/workflows/`, `wrangler.toml` and this file to `@divinevideo/platform`. That team has no write access to divine-web, so GitHub reported all three lines as unknown owners and they routed no one. If platform routing is added later, the team needs write access here first. `compute-js/` — the Fastly edge config carrying the live service id, backends, KV and secret stores — is the path that earns the "misdirects live traffic" rationale. `wrangler.toml` in this repo is a three-key Cloudflare Pages build config (name, output dir, compatibility date).

## Two failure modes worth a reviewer's eye

1. **A team without write access to this repository is an "Unknown owner"** — the line routes no one, and because the last matching pattern wins, its paths do not fall back to the catch-all. This one is reported: GitHub flags it on the file's page and at `/repos/divinevideo/divine-web/codeowners/errors`, which takes a `ref`, so a branch can be checked before merge.
2. **A pattern matching no existing path is silently inert.** GitHub reports nothing for this one.

Last matching pattern wins, so the catch-all is deliberately first.

On this branch the errors endpoint returns `{"errors":[]}`.

## Not included

`require_code_owner_reviews` on branch protection, which would make these approvals mandatory. Worth doing after a week of this simply requesting — if the routing is wrong, the failure should be "wrong person asked", not "nobody can merge".

## After merge

Confirm routing two ways: the errors endpoint above returning empty on `main`, and a throwaway PR to see reviewers appear unprompted. The first works pre-merge and catches owner problems; the second demonstrates the request behavior.
