### PR TITLE
fix(dm): replay the rumor on retry and collapse duplicate wraps on receive

### DIFF
--- a/src/hooks/useDirectMessages.test.ts
+++ b/src/hooks/useDirectMessages.test.ts
@@ -112,7 +112,7 @@ vi.mock('@/lib/dm', async () => {
 import { DIVINE_SUPPORT_PUBKEY, encodeConversationId } from '@/lib/dm';
 import { DmSupportOnlyError } from '@/lib/dmAccessPolicy';
 import { DmSendBlockedError } from '@/lib/dmSendGuard';
-import { readDmOutbox, writeDmOutbox } from '@/lib/dmOutbox';
+import { createDmClientId, readDmOutbox, writeDmOutbox } from '@/lib/dmOutbox';
 import {
   useDmCapability,
   useDmConversation,
@@ -453,6 +453,105 @@ describe('useDirectMessages', () => {
     // Policy is enforced in onMutate, before any outbox write: a blocked send
     // must not leave an invisible failed record in outbox storage.
     expect(readDmOutbox(TEST_PUBKEY)).toEqual([]);
+  });
+
+  it('replays the first attempt rumor when a failed send is retried', async () => {
+    // #578: a retry that rebuilds the rumor delivers a second message under a
+    // second id. The clock is advanced between attempts so a rebuild would be
+    // visible — created_at is the only varying input to the rumor id.
+    vi.spyOn(Date, 'now').mockReturnValue(1_234_567_890_000);
+    mockPublishDmMessages.mockRejectedValueOnce(new Error('relay never acked'));
+
+    const queryClient = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false },
+        mutations: { retry: false },
+      },
+    });
+
+    const { result } = renderHook(() => useDmSend(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    const clientId = createDmClientId([RECIPIENT_PUBKEY]);
+    await expect(
+      result.current.mutateAsync({
+        clientId,
+        participantPubkeys: [RECIPIENT_PUBKEY],
+        content: 'hello',
+      }),
+    ).rejects.toThrow('relay never acked');
+
+    const [failed] = readDmOutbox(TEST_PUBKEY);
+    expect(failed.clientId).toBe(clientId);
+    expect(failed.deliveryState).toBe('failed');
+    const firstRumor = failed.rumor;
+    expect(firstRumor?.id).toEqual(expect.any(String));
+
+    // The user taps Retry: same clientId, a later clock.
+    vi.spyOn(Date, 'now').mockReturnValue(1_234_567_901_000);
+    await act(async () => {
+      await result.current.mutateAsync({
+        clientId: failed.clientId,
+        participantPubkeys: [RECIPIENT_PUBKEY],
+        content: 'hello',
+      });
+    });
+
+    expect(mockCreateRecipientGiftWraps).toHaveBeenCalledTimes(2);
+    const [firstCall] = mockCreateRecipientGiftWraps.mock.calls[0];
+    const [retryCall] = mockCreateRecipientGiftWraps.mock.calls[1];
+    expect(retryCall.rumor).toEqual(firstRumor);
+    expect(retryCall.rumor.id).toBe(firstCall.rumor.id);
+
+    // The self copy rides the same rumor, per NIP-59. Only the retry reaches
+    // it — the first attempt rejected at the recipient publish, which is the
+    // step before the self wrap is built.
+    expect(mockCreateSelfGiftWrap).toHaveBeenCalledTimes(1);
+    const [selfCall] = mockCreateSelfGiftWrap.mock.calls[0];
+    expect(selfCall.rumor.id).toBe(firstRumor?.id);
+  });
+
+  it('rebuilds the rumor when the stored one no longer matches the message', async () => {
+    // A persisted rumor is only a replay of *this* message. Content drift
+    // means a different message, and replaying would send the stale text.
+    vi.spyOn(Date, 'now').mockReturnValue(1_234_567_890_000);
+    mockPublishDmMessages.mockRejectedValueOnce(new Error('relay never acked'));
+
+    const queryClient = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false },
+        mutations: { retry: false },
+      },
+    });
+
+    const { result } = renderHook(() => useDmSend(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    const clientId = createDmClientId([RECIPIENT_PUBKEY]);
+    await expect(
+      result.current.mutateAsync({
+        clientId,
+        participantPubkeys: [RECIPIENT_PUBKEY],
+        content: 'hello',
+      }),
+    ).rejects.toThrow('relay never acked');
+
+    const [failed] = readDmOutbox(TEST_PUBKEY);
+    expect(failed.clientId).toBe(clientId);
+
+    await act(async () => {
+      await result.current.mutateAsync({
+        clientId: failed.clientId,
+        participantPubkeys: [RECIPIENT_PUBKEY],
+        content: 'hello, edited',
+      });
+    });
+
+    const [retryCall] = mockCreateRecipientGiftWraps.mock.calls[1];
+    expect(retryCall.rumor.id).not.toBe(failed.rumor?.id);
+    expect(retryCall.rumor.content).toBe('hello, edited');
   });
 
   it('adds an optimistic sending message before publish resolves', async () => {

--- a/src/hooks/useDirectMessages.ts
+++ b/src/hooks/useDirectMessages.ts
@@ -24,6 +24,7 @@ import {
 } from '@/lib/dmInboundFilter';
 import { officialAccountsService } from '@/lib/officialAccounts';
 import {
+  buildDmRumor,
   createRecipientGiftWraps,
   createSelfGiftWrap,
   decodeConversationId,
@@ -38,8 +39,10 @@ import {
   type FetchDmMessagesResult,
 } from '@/lib/dm';
 import {
+  attachDmOutboxRumor,
   convertOutboxRecordToDmMessage,
   createDmOutboxRecord,
+  getDmOutboxRecord,
   hydrateDmOutbox,
   markDmOutboxRecordFailed,
   markDmOutboxRecordSending,
@@ -454,32 +457,36 @@ export function useDmSend() {
       }
       assertSupportOnlyDmRecipients(recipients);
 
-      const record = clientId
+      // A retry reuses the record the first attempt left behind, so the
+      // bubble and its persisted rumor survive; anything else starts one.
+      const resumed = clientId
         ? markDmOutboxRecordSending(user.pubkey, clientId, {
           participantPubkeys,
           content,
-        }) || createDmOutboxRecord({
-          ownerPubkey: user.pubkey,
-          participantPubkeys,
-          content,
         })
-        : createDmOutboxRecord({
-          ownerPubkey: user.pubkey,
-          participantPubkeys,
-          content,
-        });
+        : undefined;
 
-      const optimisticMessage = convertOutboxRecordToDmMessage(record);
-      if (!clientId || record.clientId !== clientId) {
+      const record = resumed ?? createDmOutboxRecord({
+        ownerPubkey: user.pubkey,
+        participantPubkeys,
+        content,
+        clientId,
+      });
+
+      // markDmOutboxRecordSending has already written the resumed record; a
+      // freshly built one still needs persisting.
+      if (!resumed) {
         upsertDmOutboxRecord(user.pubkey, record);
       }
+
+      const optimisticMessage = convertOutboxRecordToDmMessage(record);
 
       insertOptimisticDmIntoAllCaches(queryClient, user.pubkey, optimisticMessage);
       return {
         clientId: record.clientId,
       };
     },
-    mutationFn: async ({ participantPubkeys, content }: SendDmInput) => {
+    mutationFn: async ({ clientId, participantPubkeys, content }: SendDmInput) => {
       if (!user?.pubkey) {
         throw new Error('You need to log in before sending a message');
       }
@@ -512,6 +519,24 @@ export function useDmSend() {
         signal: AbortSignal.timeout(5000),
       });
 
+      // Replay the rumor from the previous attempt when there is one, so a
+      // retry re-wraps the same message instead of minting a second one the
+      // recipient would render as a separate bubble (#578). A stored rumor
+      // whose content has drifted from this send is not the same message, so
+      // it is rebuilt rather than replayed.
+      const storedRumor = clientId ? getDmOutboxRecord(user.pubkey, clientId)?.rumor : undefined;
+      const rumor = storedRumor?.content === content && storedRumor.pubkey === user.pubkey
+        ? storedRumor
+        : buildDmRumor({
+          senderPubkey: user.pubkey,
+          recipientPubkeys: recipients,
+          content,
+        });
+
+      if (clientId && rumor !== storedRumor) {
+        attachDmOutboxRumor(user.pubkey, clientId, rumor);
+      }
+
       // Primary path: deliver to the recipients. Failure here rejects the
       // mutation so the UI shows the send as failed.
       const recipientWraps = await createRecipientGiftWraps({
@@ -519,18 +544,21 @@ export function useDmSend() {
         senderPubkey: user.pubkey,
         recipientPubkeys: recipients,
         content,
+        rumor,
       });
       await publishDmMessages(relayUrls, recipientWraps, AbortSignal.timeout(10000));
 
       // Best-effort: self copy for cross-device recovery and server-side
-      // observers (e.g. divine-moderation-service's dm-reader cron). If
-      // either step fails the recipient already got the message — log and
-      // continue.
+      // observers (e.g. divine-moderation-service's dm-reader cron). Wraps the
+      // same rumor as the recipient copy, per NIP-59, so both sides of the
+      // conversation hold one message rather than two. If either step fails
+      // the recipient already got the message — log and continue.
       const selfWrap = await createSelfGiftWrap({
         signer,
         senderPubkey: user.pubkey,
         recipientPubkeys: recipients,
         content,
+        rumor,
       });
       if (selfWrap) {
         try {

--- a/src/lib/dm.test.ts
+++ b/src/lib/dm.test.ts
@@ -2,6 +2,26 @@ import { describe, expect, it, vi } from 'vitest';
 import { NSecSigner, type NostrEvent, type NostrSigner } from '@nostrify/nostrify';
 import { generateSecretKey, getPublicKey } from 'nostr-tools/pure';
 
+// fetchDmMessages builds its own NPool internally, so the relay is stubbed at
+// the module boundary. Everything inside — unwrapping, verification, NIP-44
+// decryption — stays real.
+const relayStub = vi.hoisted(() => ({ events: [] as unknown[] }));
+
+vi.mock('@nostrify/nostrify', async () => {
+  const actual = await vi.importActual<typeof import('@nostrify/nostrify')>('@nostrify/nostrify');
+  return {
+    ...actual,
+    NRelay1: class {},
+    NPool: class {
+      async query() {
+        return relayStub.events;
+      }
+
+      async close() {}
+    },
+  };
+});
+
 import {
   buildDmRumor,
   createRecipientGiftWraps,
@@ -10,6 +30,7 @@ import {
   DM_GIFT_WRAP_KIND,
   DM_RUMOR_KIND,
   encodeConversationId,
+  fetchDmMessages,
   getDmMessagePreview,
   groupDmConversations,
   probeBunkerNip44,
@@ -105,35 +126,103 @@ describe('dm utilities', () => {
   });
 });
 
-// Note: real-crypto round-trip tests for these functions are blocked by
-// src/test/setup.ts overriding global TextEncoder with node:util's
-// TextEncoder, which produces a Uint8Array from a different realm than
-// @noble/hashes' instance check accepts. The failure-path tests below run
-// entirely on mock signers, so they're unaffected.
+describe('fetchDmMessages deduplication', () => {
+  it('renders one message when the same rumor arrives in two gift wraps', async () => {
+    // #578: NIP-59 mints a fresh ephemeral keypair per wrap, so re-publishing
+    // one message produces two kind-1059 events that share nothing on the
+    // outside. The rumor id is the only thing that identifies them as one
+    // message. Exercised against real NIP-44 encryption end to end.
+    const sender = createTestSigner();
+    const recipient = createTestSigner();
+
+    const rumor = buildDmRumor({
+      senderPubkey: sender.pubkey,
+      recipientPubkeys: [recipient.pubkey],
+      content: 'sent once, published twice',
+    });
+
+    const wraps = [
+      ...(await createRecipientGiftWraps({
+        signer: sender.signer,
+        senderPubkey: sender.pubkey,
+        recipientPubkeys: [recipient.pubkey],
+        content: rumor.content,
+        rumor,
+      })),
+      ...(await createRecipientGiftWraps({
+        signer: sender.signer,
+        senderPubkey: sender.pubkey,
+        recipientPubkeys: [recipient.pubkey],
+        content: rumor.content,
+        rumor,
+      })),
+    ];
+
+    expect(wraps).toHaveLength(2);
+    expect(wraps[0].id).not.toBe(wraps[1].id);
+    expect(wraps[0].pubkey).not.toBe(wraps[1].pubkey);
+
+    const result = await fetchWithStubbedRelay(wraps, recipient);
+
+    expect(result.fetchedCount).toBe(2);
+    expect(result.messages).toHaveLength(1);
+    expect(result.messages[0].rumorId).toBe(rumor.id);
+    expect(result.malformedCount).toBe(0);
+  });
+
+  it('keeps two distinct messages that happen to share their text', async () => {
+    // The collapse must key on identity, not content — sending "ok" twice on
+    // purpose is two messages.
+    const sender = createTestSigner();
+    const recipient = createTestSigner();
+
+    const wraps: NostrEvent[] = [];
+    for (const createdAt of [1_700_000_000, 1_700_000_060]) {
+      vi.spyOn(Date, 'now').mockReturnValue(createdAt * 1000);
+      wraps.push(...(await createRecipientGiftWraps({
+        signer: sender.signer,
+        senderPubkey: sender.pubkey,
+        recipientPubkeys: [recipient.pubkey],
+        content: 'ok',
+      })));
+    }
+    vi.restoreAllMocks();
+
+    const result = await fetchWithStubbedRelay(wraps, recipient);
+
+    expect(result.messages).toHaveLength(2);
+    expect(result.messages[0].rumorId).not.toBe(result.messages[1].rumorId);
+  });
+});
 
 describe('createSelfGiftWrap', () => {
   it('wraps the rumor it is given, so the self copy shares the recipient copy id', async () => {
     // NIP-59: a single rumor may be wrapped and addressed for each recipient
     // individually — including the author's own copy. Two rumors would leave
     // the sender holding a different message from the one they sent.
-    const { sealed, signer } = createSealCapturingSigner();
+    const sender = createTestSigner();
+    const recipient = createTestSigner();
 
     const rumor = buildDmRumor({
-      senderPubkey: 'a'.repeat(64),
-      recipientPubkeys: ['b'.repeat(64)],
+      senderPubkey: sender.pubkey,
+      recipientPubkeys: [recipient.pubkey],
       content: 'hi',
     });
 
-    await createSelfGiftWrap({
-      signer,
-      senderPubkey: 'a'.repeat(64),
-      recipientPubkeys: ['b'.repeat(64)],
+    const selfWrap = await createSelfGiftWrap({
+      signer: sender.signer,
+      senderPubkey: sender.pubkey,
+      recipientPubkeys: [recipient.pubkey],
       content: 'hi',
       rumor,
     });
 
-    expect(sealed).toHaveLength(1);
-    expect(JSON.parse(sealed[0])).toEqual(rumor);
+    expect(selfWrap).not.toBeNull();
+    const unwrapped = await unwrapDmGiftWrap(selfWrap!, sender.signer);
+    expect(unwrapped.ok).toBe(true);
+    if (unwrapped.ok) {
+      expect(unwrapped.rumor.id).toBe(rumor.id);
+    }
   });
 
   it('returns null and warns when signer.nip44.encrypt rejects', async () => {
@@ -200,59 +289,32 @@ describe('createRecipientGiftWraps', () => {
 
   it('re-wraps a supplied rumor instead of minting a new one', async () => {
     // A retry hands back the first attempt's rumor. Its id is the only thing
-    // a receiver can dedupe on, so it must reach the seal untouched.
-    //
-    // Asserted on the plaintext handed to the signer rather than the returned
-    // wrap: the wrap step runs real nip44 encryption, which cannot execute
-    // under the jsdom TextEncoder override documented above. Sealing happens
-    // first, so an empty `sealed` still fails this test.
-    const { sealed, signer } = createSealCapturingSigner();
+    // a receiver can dedupe on, so it must survive the round trip untouched.
+    const sender = createTestSigner();
+    const recipient = createTestSigner();
 
     const rumor = buildDmRumor({
-      senderPubkey: 'a'.repeat(64),
-      recipientPubkeys: ['b'.repeat(64)],
+      senderPubkey: sender.pubkey,
+      recipientPubkeys: [recipient.pubkey],
       content: 'hi',
     });
 
-    await createRecipientGiftWraps({
-      signer,
-      senderPubkey: 'a'.repeat(64),
-      recipientPubkeys: ['b'.repeat(64)],
+    const [wrap] = await createRecipientGiftWraps({
+      signer: sender.signer,
+      senderPubkey: sender.pubkey,
+      recipientPubkeys: [recipient.pubkey],
       content: 'hi',
       rumor,
-    }).catch(() => undefined);
+    });
 
-    expect(sealed).toHaveLength(1);
-    expect(JSON.parse(sealed[0])).toEqual(rumor);
+    const unwrapped = await unwrapDmGiftWrap(wrap, recipient.signer);
+    expect(unwrapped.ok).toBe(true);
+    if (unwrapped.ok) {
+      expect(unwrapped.rumor).toEqual(rumor);
+    }
   });
 });
 
-function createSealCapturingSigner(): { sealed: string[]; signer: NostrSigner } {
-  const sealed: string[] = [];
-
-  return {
-    sealed,
-    signer: {
-      getPublicKey: vi.fn().mockResolvedValue('a'.repeat(64)),
-      signEvent: vi.fn().mockResolvedValue({
-        id: 'seal-id',
-        pubkey: 'a'.repeat(64),
-        kind: 13,
-        created_at: 1,
-        tags: [],
-        content: 'ciphertext',
-        sig: 'c'.repeat(128),
-      }),
-      nip44: {
-        encrypt: vi.fn(async (_pubkey: string, plaintext: string) => {
-          sealed.push(plaintext);
-          return 'ciphertext';
-        }),
-        decrypt: vi.fn(),
-      },
-    },
-  };
-}
 
 describe('buildDmRumor', () => {
   const SENDER = 'a'.repeat(64);
@@ -352,6 +414,22 @@ function createTestSigner(): { signer: NSecSigner; pubkey: string } {
   return { signer: new NSecSigner(sk), pubkey: getPublicKey(sk) };
 }
 
+async function fetchWithStubbedRelay(
+  wraps: NostrEvent[],
+  recipient: { signer: NSecSigner; pubkey: string },
+) {
+  relayStub.events = wraps;
+  try {
+    return await fetchDmMessages({
+      signer: recipient.signer,
+      currentUserPubkey: recipient.pubkey,
+      relayUrls: ['wss://relay.example'],
+    });
+  } finally {
+    relayStub.events = [];
+  }
+}
+
 function createDmTestWrap(recipientPubkey: string): NostrEvent {
   return {
     id: 'a'.repeat(64),
@@ -379,14 +457,6 @@ function createMockSigner(
 }
 
 describe('unwrapDmGiftWrap', () => {
-  // The happy-path round-trip (real NIP-44 encrypt → decrypt) is exercised in
-  // useDirectMessages.test.ts which mocks at the import boundary. Here we
-  // cannot run real nip44.v2 because src/test/setup.ts overrides global
-  // TextEncoder with node:util's TextEncoder, which produces a Uint8Array
-  // from a different realm than the @noble/hashes consumer expects, breaking
-  // its instance check. Failure-path tests below all run via mocked signers
-  // so they're unaffected.
-
   it('returns decrypt-failed when the signer.nip44.decrypt RPC throws', async () => {
     const recipient = createTestSigner();
     const wrap = createDmTestWrap(recipient.pubkey);

--- a/src/lib/dm.test.ts
+++ b/src/lib/dm.test.ts
@@ -3,10 +3,12 @@ import { NSecSigner, type NostrEvent, type NostrSigner } from '@nostrify/nostrif
 import { generateSecretKey, getPublicKey } from 'nostr-tools/pure';
 
 import {
+  buildDmRumor,
   createRecipientGiftWraps,
   createSelfGiftWrap,
   decodeConversationId,
   DM_GIFT_WRAP_KIND,
+  DM_RUMOR_KIND,
   encodeConversationId,
   getDmMessagePreview,
   groupDmConversations,
@@ -110,6 +112,30 @@ describe('dm utilities', () => {
 // entirely on mock signers, so they're unaffected.
 
 describe('createSelfGiftWrap', () => {
+  it('wraps the rumor it is given, so the self copy shares the recipient copy id', async () => {
+    // NIP-59: a single rumor may be wrapped and addressed for each recipient
+    // individually — including the author's own copy. Two rumors would leave
+    // the sender holding a different message from the one they sent.
+    const { sealed, signer } = createSealCapturingSigner();
+
+    const rumor = buildDmRumor({
+      senderPubkey: 'a'.repeat(64),
+      recipientPubkeys: ['b'.repeat(64)],
+      content: 'hi',
+    });
+
+    await createSelfGiftWrap({
+      signer,
+      senderPubkey: 'a'.repeat(64),
+      recipientPubkeys: ['b'.repeat(64)],
+      content: 'hi',
+      rumor,
+    });
+
+    expect(sealed).toHaveLength(1);
+    expect(JSON.parse(sealed[0])).toEqual(rumor);
+  });
+
   it('returns null and warns when signer.nip44.encrypt rejects', async () => {
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
     const cause = new Error('bunker rejected encrypt-to-self');
@@ -170,6 +196,100 @@ describe('createRecipientGiftWraps', () => {
       recipientPubkeys: [],
       content: 'hi',
     })).rejects.toThrow(/at least one recipient/);
+  });
+
+  it('re-wraps a supplied rumor instead of minting a new one', async () => {
+    // A retry hands back the first attempt's rumor. Its id is the only thing
+    // a receiver can dedupe on, so it must reach the seal untouched.
+    //
+    // Asserted on the plaintext handed to the signer rather than the returned
+    // wrap: the wrap step runs real nip44 encryption, which cannot execute
+    // under the jsdom TextEncoder override documented above. Sealing happens
+    // first, so an empty `sealed` still fails this test.
+    const { sealed, signer } = createSealCapturingSigner();
+
+    const rumor = buildDmRumor({
+      senderPubkey: 'a'.repeat(64),
+      recipientPubkeys: ['b'.repeat(64)],
+      content: 'hi',
+    });
+
+    await createRecipientGiftWraps({
+      signer,
+      senderPubkey: 'a'.repeat(64),
+      recipientPubkeys: ['b'.repeat(64)],
+      content: 'hi',
+      rumor,
+    }).catch(() => undefined);
+
+    expect(sealed).toHaveLength(1);
+    expect(JSON.parse(sealed[0])).toEqual(rumor);
+  });
+});
+
+function createSealCapturingSigner(): { sealed: string[]; signer: NostrSigner } {
+  const sealed: string[] = [];
+
+  return {
+    sealed,
+    signer: {
+      getPublicKey: vi.fn().mockResolvedValue('a'.repeat(64)),
+      signEvent: vi.fn().mockResolvedValue({
+        id: 'seal-id',
+        pubkey: 'a'.repeat(64),
+        kind: 13,
+        created_at: 1,
+        tags: [],
+        content: 'ciphertext',
+        sig: 'c'.repeat(128),
+      }),
+      nip44: {
+        encrypt: vi.fn(async (_pubkey: string, plaintext: string) => {
+          sealed.push(plaintext);
+          return 'ciphertext';
+        }),
+        decrypt: vi.fn(),
+      },
+    },
+  };
+}
+
+describe('buildDmRumor', () => {
+  const SENDER = 'a'.repeat(64);
+  const RECIPIENT = 'b'.repeat(64);
+
+  it('mints a different id once the clock advances', () => {
+    // This is why a retry cannot rebuild: created_at is the only varying
+    // input to the id hash, and a failed send burns the publish timeout
+    // before Retry is reachable.
+    vi.spyOn(Date, 'now').mockReturnValue(1_700_000_000_000);
+    const first = buildDmRumor({ senderPubkey: SENDER, recipientPubkeys: [RECIPIENT], content: 'hi' });
+
+    vi.spyOn(Date, 'now').mockReturnValue(1_700_000_011_000);
+    const second = buildDmRumor({ senderPubkey: SENDER, recipientPubkeys: [RECIPIENT], content: 'hi' });
+
+    expect(second.id).not.toBe(first.id);
+    expect(second.content).toBe(first.content);
+  });
+
+  it('tags the sender and every recipient as participants', () => {
+    const rumor = buildDmRumor({
+      senderPubkey: SENDER,
+      recipientPubkeys: [RECIPIENT, RECIPIENT, 'not-a-pubkey'],
+      content: 'hi',
+    });
+
+    expect(rumor.kind).toBe(DM_RUMOR_KIND);
+    expect(rumor.pubkey).toBe(SENDER);
+    expect(rumor.tags).toEqual([['p', SENDER], ['p', RECIPIENT]]);
+  });
+
+  it('throws when given no valid recipients', () => {
+    expect(() => buildDmRumor({
+      senderPubkey: SENDER,
+      recipientPubkeys: ['not-a-pubkey'],
+      content: 'hi',
+    })).toThrow(/at least one recipient/);
   });
 });
 

--- a/src/lib/dm.ts
+++ b/src/lib/dm.ts
@@ -203,7 +203,7 @@ function createRelayPool(relayUrls: string[]): NPool<NRelay1> {
   });
 }
 
-function isRumorEvent(value: unknown): value is DmRumorEvent {
+export function isRumorEvent(value: unknown): value is DmRumorEvent {
   if (!value || typeof value !== 'object') return false;
 
   const rumor = value as Partial<DmRumorEvent>;
@@ -755,7 +755,7 @@ export function calculateUnsignedEventHash(
     event.content,
   ]);
 
-  return bytesToHex(sha256(Uint8Array.from(new TextEncoder().encode(serializedEvent))));
+  return bytesToHex(sha256(new TextEncoder().encode(serializedEvent)));
 }
 
 export function decodeConversationId(conversationId: string): string[] {
@@ -786,48 +786,6 @@ export function getDmMessagePreview(message: DmMessage): string {
   }
 
   return 'Sent a message';
-}
-
-interface BuildOptimisticDmMessageInput {
-  currentUserPubkey: string;
-  participantPubkeys: string[];
-  content: string;
-  share?: DmSharePayload;
-  wraps: NostrEvent[];
-  createdAt?: number;
-}
-
-export function buildOptimisticDmMessage(input: BuildOptimisticDmMessageInput): DmMessage | null {
-  const {
-    currentUserPubkey,
-    participantPubkeys,
-    content,
-    share,
-    wraps,
-    createdAt = Math.round(Date.now() / 1000),
-  } = input;
-
-  const peerPubkeys = [...new Set(participantPubkeys.filter((pubkey) => pubkey !== currentUserPubkey))].sort();
-  if (!peerPubkeys.length) {
-    return null;
-  }
-
-  const participantList = [...new Set([currentUserPubkey, ...peerPubkeys])].sort();
-  const selfWrap = wraps.find((wrap) => wrap.tags.some((tag) => tag[0] === 'p' && tag[1] === currentUserPubkey));
-  const wrapId = selfWrap?.id || `optimistic:${currentUserPubkey}:${peerPubkeys.join(',')}:${createdAt}`;
-
-  return {
-    conversationId: encodeConversationId(peerPubkeys),
-    wrapId,
-    rumorId: wrapId,
-    senderPubkey: currentUserPubkey,
-    participantPubkeys: participantList,
-    peerPubkeys,
-    content,
-    createdAt,
-    isOutgoing: true,
-    share,
-  };
 }
 
 export function groupDmConversations(

--- a/src/lib/dm.ts
+++ b/src/lib/dm.ts
@@ -620,6 +620,7 @@ export async function fetchDmMessages(input: FetchDmMessagesInput): Promise<Fetc
     );
 
     const messages: DmMessage[] = [];
+    const seenRumorIds = new Set<string>();
     let decryptFailures = 0;
     let malformedCount = 0;
 
@@ -627,8 +628,21 @@ export async function fetchDmMessages(input: FetchDmMessagesInput): Promise<Fetc
       const outcome = outcomes[i];
       if (outcome.ok) {
         const built = buildMessageFromRumor(events[i], outcome.rumor, currentUserPubkey);
-        if (built) messages.push(built);
-        else malformedCount++;
+        if (!built) {
+          malformedCount++;
+          continue;
+        }
+
+        // Collapse on the rumor id, not the wrap id. NIP-59 mints a fresh
+        // ephemeral keypair per gift wrap and randomizes the wrap/seal
+        // created_at, and NIP-44 randomizes the nonce, so two wraps of one
+        // message share nothing on the outside — keying the list on wrapId
+        // renders a re-published message twice (#578). This holds against
+        // any source of a duplicate wrap, not only this client's retries.
+        if (seenRumorIds.has(built.rumorId)) continue;
+        seenRumorIds.add(built.rumorId);
+
+        messages.push(built);
       } else if (outcome.reason === 'decrypt-failed') {
         decryptFailures++;
       } else {

--- a/src/lib/dm.ts
+++ b/src/lib/dm.ts
@@ -63,7 +63,7 @@ export interface DmConversation {
   unreadCount: number;
 }
 
-interface DmRumorEvent {
+export interface DmRumorEvent {
   id: string;
   pubkey: string;
   kind: number;
@@ -72,12 +72,20 @@ interface DmRumorEvent {
   content: string;
 }
 
-export interface CreateDmGiftWrapsInput {
-  signer: NostrSigner;
+export interface BuildDmRumorInput {
   senderPubkey: string;
   recipientPubkeys: string[];
   content: string;
   additionalTags?: string[][];
+}
+
+export interface CreateDmGiftWrapsInput extends BuildDmRumorInput {
+  signer: NostrSigner;
+  /**
+   * Rumor to wrap. Omit to mint a fresh one. Pass the rumor from a previous
+   * attempt to re-wrap the same message — see `buildDmRumor` (#578).
+   */
+  rumor?: DmRumorEvent;
 }
 
 export interface FetchDmMessagesInput {
@@ -388,6 +396,33 @@ function createWrapEvent(seal: NostrEvent, targetPubkey: string): NostrEvent {
 }
 
 /**
+ * Build the kind-14 rumor for a NIP-17 send.
+ *
+ * The rumor id is a message's only stable identity: NIP-59 mints a fresh
+ * ephemeral keypair per gift wrap and randomizes the wrap/seal `created_at`,
+ * and NIP-44 v2 randomizes the nonce, so nothing in the outer layers repeats
+ * between two wraps of the same message. Callers that may send a message more
+ * than once — a retry, or the recipient copy plus the self copy — must mint
+ * the rumor once here and hand it to both wrap builders, or each attempt
+ * delivers a message the receiver cannot recognize as a duplicate (#578).
+ *
+ * NIP-59: "If a rumor is intended for more than one party, or if the author
+ * wants to retain an encrypted copy, a single rumor may be wrapped and
+ * addressed for each recipient individually."
+ */
+export function buildDmRumor(input: BuildDmRumorInput): DmRumorEvent {
+  const { senderPubkey, recipientPubkeys, content, additionalTags = [] } = input;
+  const recipients = recipientPubkeys.filter(isPubkey);
+
+  if (!recipients.length) {
+    throw new Error('Direct messages require at least one recipient');
+  }
+
+  const allParticipants = [...new Set([senderPubkey, ...recipients])];
+  return createRumorEvent(senderPubkey, allParticipants, content, additionalTags);
+}
+
+/**
  * Create gift wraps targeted at the recipients of a NIP-17 DM.
  *
  * Throws on any failure. This is the primary path: if it can't produce
@@ -405,15 +440,14 @@ function createWrapEvent(seal: NostrEvent, targetPubkey: string): NostrEvent {
  * let a protected minor DM a non-approved account.
  */
 export async function createRecipientGiftWraps(input: CreateDmGiftWrapsInput): Promise<NostrEvent[]> {
-  const { signer, senderPubkey, recipientPubkeys, content, additionalTags = [] } = input;
+  const { signer, recipientPubkeys } = input;
   const recipients = recipientPubkeys.filter(isPubkey);
 
   if (!recipients.length) {
     throw new Error('Direct messages require at least one recipient');
   }
 
-  const allParticipants = [...new Set([senderPubkey, ...recipients])];
-  const rumor = createRumorEvent(senderPubkey, allParticipants, content, additionalTags);
+  const rumor = input.rumor ?? buildDmRumor(input);
 
   const wraps: NostrEvent[] = [];
   for (const recipient of recipients) {
@@ -432,13 +466,15 @@ export async function createRecipientGiftWraps(input: CreateDmGiftWrapsInput): P
  * throw on null; the recipient delivery has already happened (or failed
  * loudly via `createRecipientGiftWraps`), and the self copy is purely a
  * recovery path.
+ *
+ * Pass the same `rumor` handed to `createRecipientGiftWraps` so both copies
+ * of a message share one id — otherwise the sender's recovered copy is a
+ * different message from the one the recipient holds (#578).
  */
 export async function createSelfGiftWrap(input: CreateDmGiftWrapsInput): Promise<NostrEvent | null> {
   try {
-    const { signer, senderPubkey, recipientPubkeys, content, additionalTags = [] } = input;
-    const recipients = recipientPubkeys.filter(isPubkey);
-    const allParticipants = [...new Set([senderPubkey, ...recipients])];
-    const rumor = createRumorEvent(senderPubkey, allParticipants, content, additionalTags);
+    const { signer, senderPubkey } = input;
+    const rumor = input.rumor ?? buildDmRumor(input);
     const seal = await createSealEvent(signer, senderPubkey, rumor);
     return createWrapEvent(seal, senderPubkey);
   } catch (cause) {

--- a/src/lib/dmOutbox.test.ts
+++ b/src/lib/dmOutbox.test.ts
@@ -1,8 +1,12 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { buildDmRumor, type DmRumorEvent } from './dm';
 import {
+  attachDmOutboxRumor,
   createDmOutboxRecord,
+  getDmOutboxRecord,
   hydrateDmOutbox,
+  markDmOutboxRecordSending,
   readDmOutbox,
   upsertDmOutboxRecord,
   writeDmOutbox,
@@ -100,6 +104,52 @@ describe('dmOutbox', () => {
         deliveryState: 'failed',
       }),
     ]);
+  });
+
+  it('keeps the attached rumor across a retry marked sending', () => {
+    // The retry path re-wraps this rumor, so losing it on the way through
+    // markDmOutboxRecordSending would silently restore the double-delivery.
+    const record = createDmOutboxRecord({
+      ownerPubkey: TEST_PUBKEY,
+      participantPubkeys: [RECIPIENT_PUBKEY],
+      content: 'hello',
+    });
+    upsertDmOutboxRecord(TEST_PUBKEY, record);
+
+    const rumor = buildDmRumor({
+      senderPubkey: TEST_PUBKEY,
+      recipientPubkeys: [RECIPIENT_PUBKEY],
+      content: 'hello',
+    });
+    attachDmOutboxRumor(TEST_PUBKEY, record.clientId, rumor);
+
+    const retried = markDmOutboxRecordSending(TEST_PUBKEY, record.clientId, {
+      participantPubkeys: [RECIPIENT_PUBKEY],
+      content: 'hello',
+    });
+
+    expect(retried?.rumor).toEqual(rumor);
+    expect(retried?.retryCount).toBe(1);
+    expect(getDmOutboxRecord(TEST_PUBKEY, record.clientId)?.rumor).toEqual(rumor);
+  });
+
+  it('drops a persisted rumor that is not a well-formed event', () => {
+    // localStorage is user-writable and survives app versions; a corrupt
+    // rumor must cost the replay, not the pending message.
+    const record = createDmOutboxRecord({
+      ownerPubkey: TEST_PUBKEY,
+      participantPubkeys: [RECIPIENT_PUBKEY],
+      content: 'hello',
+    });
+
+    writeDmOutbox(TEST_PUBKEY, [{
+      ...record,
+      rumor: { id: 'only-an-id' } as unknown as DmRumorEvent,
+    }]);
+
+    const [stored] = readDmOutbox(TEST_PUBKEY);
+    expect(stored.rumor).toBeUndefined();
+    expect(stored.content).toBe('hello');
   });
 
   it('does not throw when localStorage writes fail', () => {

--- a/src/lib/dmOutbox.test.ts
+++ b/src/lib/dmOutbox.test.ts
@@ -152,6 +152,50 @@ describe('dmOutbox', () => {
     expect(stored.content).toBe('hello');
   });
 
+  it('drops a persisted rumor whose kind is not a DM rumor', () => {
+    const record = createDmOutboxRecord({
+      ownerPubkey: TEST_PUBKEY,
+      participantPubkeys: [RECIPIENT_PUBKEY],
+      content: 'hello',
+    });
+    const rumor = {
+      ...buildDmRumor({
+        senderPubkey: TEST_PUBKEY,
+        recipientPubkeys: [RECIPIENT_PUBKEY],
+        content: 'hello',
+      }),
+      kind: 1,
+    };
+
+    writeDmOutbox(TEST_PUBKEY, [{ ...record, rumor }]);
+
+    const [stored] = readDmOutbox(TEST_PUBKEY);
+    expect(stored.rumor).toBeUndefined();
+    expect(stored.content).toBe('hello');
+  });
+
+  it('drops a persisted rumor whose id no longer hashes to its contents', () => {
+    const record = createDmOutboxRecord({
+      ownerPubkey: TEST_PUBKEY,
+      participantPubkeys: [RECIPIENT_PUBKEY],
+      content: 'hello',
+    });
+    const rumor = {
+      ...buildDmRumor({
+        senderPubkey: TEST_PUBKEY,
+        recipientPubkeys: [RECIPIENT_PUBKEY],
+        content: 'hello',
+      }),
+      content: 'tampered',
+    };
+
+    writeDmOutbox(TEST_PUBKEY, [{ ...record, rumor }]);
+
+    const [stored] = readDmOutbox(TEST_PUBKEY);
+    expect(stored.rumor).toBeUndefined();
+    expect(stored.content).toBe('hello');
+  });
+
   it('does not throw when localStorage writes fail', () => {
     const record = createDmOutboxRecord({
       ownerPubkey: TEST_PUBKEY,

--- a/src/lib/dmOutbox.ts
+++ b/src/lib/dmOutbox.ts
@@ -1,4 +1,10 @@
-import { encodeConversationId, type DmDeliveryState, type DmMessage, type DmSharePayload } from './dm';
+import {
+  encodeConversationId,
+  type DmDeliveryState,
+  type DmMessage,
+  type DmRumorEvent,
+  type DmSharePayload,
+} from './dm';
 
 const DM_OUTBOX_STORAGE_PREFIX = 'dm:outbox:';
 const DM_RECONCILIATION_WINDOW_SECONDS = 5;
@@ -14,6 +20,14 @@ export interface DmOutboxRecord {
   deliveryState: DmDeliveryState;
   errorMessage?: string;
   retryCount: number;
+  /**
+   * The kind-14 rumor built for the first attempt. A retry re-wraps this
+   * rumor instead of minting a new one, so every attempt carries the same
+   * rumor id — the only identity a receiver can dedupe on (#578). Absent on
+   * records written before the rumor was persisted, and on records whose
+   * first attempt failed before the rumor was built.
+   */
+  rumor?: DmRumorEvent;
 }
 
 interface CreateDmOutboxRecordInput {
@@ -21,6 +35,7 @@ interface CreateDmOutboxRecordInput {
   participantPubkeys: string[];
   content: string;
   share?: DmSharePayload;
+  clientId?: string;
 }
 
 function getStorageKey(ownerPubkey: string): string {
@@ -43,19 +58,43 @@ function getLocalStorage(): Storage | undefined {
   }
 }
 
-function buildClientId(ownerPubkey: string, participantPubkeys: string[], createdAt: number): string {
+function buildClientId(participantPubkeys: string[], createdAt: number): string {
   if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
     return `dm-${crypto.randomUUID()}`;
   }
 
   const randomPart = Math.random().toString(36).slice(2, 10);
-  return `dm-${ownerPubkey.slice(0, 8)}-${participantPubkeys.join('-').slice(0, 16)}-${createdAt}-${randomPart}`;
+  return `dm-${participantPubkeys.join('-').slice(0, 16)}-${createdAt}-${randomPart}`;
+}
+
+function isPersistedRumor(value: unknown): value is DmRumorEvent {
+  if (!value || typeof value !== 'object') {
+    return false;
+  }
+
+  const rumor = value as Partial<DmRumorEvent>;
+
+  return (
+    typeof rumor.id === 'string' &&
+    typeof rumor.pubkey === 'string' &&
+    typeof rumor.kind === 'number' &&
+    typeof rumor.created_at === 'number' &&
+    typeof rumor.content === 'string' &&
+    Array.isArray(rumor.tags) &&
+    rumor.tags.every((tag) => Array.isArray(tag) && tag.every((entry) => typeof entry === 'string'))
+  );
 }
 
 function normalizeRecord(record: DmOutboxRecord): DmOutboxRecord {
+  // A malformed persisted rumor drops rather than invalidating the whole
+  // record: the pending message is still sendable, it just mints a fresh
+  // rumor instead of replaying one that cannot be trusted.
+  const { rumor, ...rest } = record;
+
   return {
-    ...record,
+    ...rest,
     participantPubkeys: [...new Set(record.participantPubkeys)].sort(),
+    ...(isPersistedRumor(rumor) ? { rumor } : {}),
   };
 }
 
@@ -116,12 +155,23 @@ function isDmOutboxRecord(value: unknown): value is DmOutboxRecord {
   );
 }
 
+/**
+ * Mint the client-side identity for a send.
+ *
+ * Called at the moment the user sends, so the id exists before the mutation
+ * runs and every later step — the outbox record, the persisted rumor, a retry
+ * — keys off the same value (#578).
+ */
+export function createDmClientId(participantPubkeys: string[]): string {
+  return buildClientId([...new Set(participantPubkeys)].sort(), nowInSeconds());
+}
+
 export function createDmOutboxRecord(input: CreateDmOutboxRecordInput): DmOutboxRecord {
   const createdAt = nowInSeconds();
   const participantPubkeys = [...new Set(input.participantPubkeys)].sort();
 
   return {
-    clientId: buildClientId(input.ownerPubkey, participantPubkeys, createdAt),
+    clientId: input.clientId || buildClientId(participantPubkeys, createdAt),
     ownerPubkey: input.ownerPubkey,
     participantPubkeys,
     content: input.content,
@@ -280,6 +330,27 @@ export function mergeFetchedAndOutboxMessages(
     messages,
     reconciledClientIds,
   };
+}
+
+/**
+ * Persist the rumor built for a send so a later retry re-wraps the same one.
+ *
+ * Called once the rumor exists, which is after `onMutate` has already written
+ * the record — hence a separate write rather than a field on creation.
+ */
+export function attachDmOutboxRumor(
+  ownerPubkey: string,
+  clientId: string,
+  rumor: DmRumorEvent,
+): DmOutboxRecord | undefined {
+  const record = getDmOutboxRecord(ownerPubkey, clientId);
+  if (!record) {
+    return undefined;
+  }
+
+  const updatedRecord = { ...record, rumor };
+  upsertDmOutboxRecord(ownerPubkey, updatedRecord);
+  return updatedRecord;
 }
 
 export function markDmOutboxRecordSent(ownerPubkey: string, clientId: string): DmOutboxRecord | undefined {

--- a/src/lib/dmOutbox.ts
+++ b/src/lib/dmOutbox.ts
@@ -1,5 +1,8 @@
 import {
+  calculateUnsignedEventHash,
+  DM_RUMOR_KIND,
   encodeConversationId,
+  isRumorEvent,
   type DmDeliveryState,
   type DmMessage,
   type DmRumorEvent,
@@ -68,20 +71,10 @@ function buildClientId(participantPubkeys: string[], createdAt: number): string 
 }
 
 function isPersistedRumor(value: unknown): value is DmRumorEvent {
-  if (!value || typeof value !== 'object') {
-    return false;
-  }
-
-  const rumor = value as Partial<DmRumorEvent>;
-
   return (
-    typeof rumor.id === 'string' &&
-    typeof rumor.pubkey === 'string' &&
-    typeof rumor.kind === 'number' &&
-    typeof rumor.created_at === 'number' &&
-    typeof rumor.content === 'string' &&
-    Array.isArray(rumor.tags) &&
-    rumor.tags.every((tag) => Array.isArray(tag) && tag.every((entry) => typeof entry === 'string'))
+    isRumorEvent(value) &&
+    value.kind === DM_RUMOR_KIND &&
+    calculateUnsignedEventHash(value) === value.id
   );
 }
 

--- a/src/pages/ConversationPage.test.tsx
+++ b/src/pages/ConversationPage.test.tsx
@@ -350,7 +350,10 @@ describe('ConversationPage', () => {
     await user.type(composer, 'hello');
     await user.keyboard('{Enter}');
 
+    // clientId is minted at the call site so a retry can replay the same
+    // rumor rather than build a second one (#578).
     await waitFor(() => expect(mockSendMutateAsync).toHaveBeenCalledWith({
+      clientId: expect.stringMatching(/^dm-/),
       participantPubkeys: [RECIPIENT_PUBKEY],
       content: 'hello',
     }));
@@ -372,7 +375,10 @@ describe('ConversationPage', () => {
     await user.type(composer, 'hello');
     await user.keyboard('{Enter}');
 
+    // clientId is minted at the call site so a retry can replay the same
+    // rumor rather than build a second one (#578).
     await waitFor(() => expect(mockSendMutateAsync).toHaveBeenCalledWith({
+      clientId: expect.stringMatching(/^dm-/),
       participantPubkeys: [RECIPIENT_PUBKEY],
       content: 'hello',
     }));

--- a/src/pages/ConversationPage.tsx
+++ b/src/pages/ConversationPage.tsx
@@ -25,6 +25,7 @@ import {
   getSupportDmConversationPath,
   isSupportOnlyDmPeerSet,
 } from '@/lib/dmAccessPolicy';
+import { createDmClientId } from '@/lib/dmOutbox';
 import { isThreadAllowedForProtectedMinor } from '@/lib/dmInboundFilter';
 import { officialAccountsService } from '@/lib/officialAccounts';
 import { isMinorDmRestricted } from '@/lib/protectedMinor';
@@ -265,6 +266,11 @@ export function ConversationPage() {
 
     try {
       await sendMessage.mutateAsync({
+        // Minted here rather than inside the mutation so the send has an
+        // identity before any wrap is built — that is what lets a retry find
+        // the first attempt's rumor and replay it instead of minting a second
+        // message the recipient cannot collapse (#578).
+        clientId: createDmClientId(peerPubkeys),
         participantPubkeys: peerPubkeys,
         content: trimmedDraft,
       });

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -1,6 +1,16 @@
 import '@testing-library/jest-dom';
-import { TextDecoder, TextEncoder } from 'node:util';
+import { TextDecoder, TextEncoder as NodeTextEncoder } from 'node:util';
 import { vi } from 'vitest';
+
+// node:util's TextEncoder returns a Uint8Array from Node's realm, which
+// @noble/hashes rejects on its `instanceof Uint8Array` check — that is what
+// blocked every real-crypto round trip in this suite. Re-wrap the output in a
+// same-realm Uint8Array so nostr-tools' signing and NIP-44 paths are testable.
+class TextEncoder extends NodeTextEncoder {
+  encode(input?: string): Uint8Array {
+    return Uint8Array.from(super.encode(input));
+  }
+}
 
 Object.defineProperty(global, 'TextEncoder', {
   writable: true,


### PR DESCRIPTION
## Summary

- Retry now replays the rumor from the first attempt instead of rebuilding it, so a retried send carries one message id rather than two.
- The receive path collapses gift wraps by kind-14 rumor id, which is what actually clears the duplicate bubble.
- The self copy wraps the same rumor as the recipient copy, per NIP-59.
- The test suite can now run real nostr crypto under jsdom, so the gift-wrap tests exercise the true encrypt/decrypt round trip.

## Motivation

`handleRetry` passed the original `clientId` back into the mutation, but `mutationFn` destructured only `{ participantPubkeys, content }` and called `createRecipientGiftWraps`, which minted a fresh rumor. The rumor id is a hash over `created_at`, and a failed send burns the 10s publish timeout before Retry is reachable, so the second attempt always carried a different id.

**Reproduced end-to-end** against a WebSocket relay that stores the `EVENT` frame but withholds the NIP-01 `OK` — the condition the issue describes. `NRelay1.event()` sends the frame, then awaits `ok:${event.id}` under the caller's signal, so the abort fires with the message already stored. The client shows the bubble red, the user taps Retry, and the recipient receives two copies:

```
attempt 1: client saw failure, relay stored 1 event(s)
after retry: relay stored 2 event(s)
recipient rendered messages: 2
rumor ids: [ 'c1264f31…', '98043ce4…' ]
contents:  [ 'ship it', 'ship it' ]
```

### Why the sender-side fix alone was not enough

The issue's suggested direction rests on "a retry replays the same rumor id, which the receiver does collapse." That holds for divine-mobile, whose `direct_messages` table takes the rumor id as its primary key. It did not hold here: `fetchDmMessages` pushed one message per unwrapped wrap with no rumor-id dedupe, and the thread list keys on `clientId || wrapId`.

Applying only the sender-side change produced one rumor id on the wire — correct — and still rendered two bubbles. NIP-59 mints a fresh ephemeral keypair per wrap and randomizes the wrap/seal `created_at`, and NIP-44 randomizes the nonce, so two wraps of one rumor share nothing on the outside. Confirmed against a live relay that both wraps are stored and both are served back; a relay cannot dedupe here because it never sees the rumor.

Both halves are in this PR. The receive-side collapse holds against any duplicate wrap, not only this client's retries.

### Supporting changes

`mutationFn` could not find its outbox record on a first send, because the `clientId` only existed inside `onMutate`. The client id is now minted at the call site, so a send has an identity before any wrap is built. `onMutate`'s write guard tracks whether the record was resumed rather than inferring it from the client id differing.

The self copy previously called `createRumorEvent` again, and ran *after* the network publish — so any round trip crossing a second boundary gave the sender's own copy a different id from the recipient's. NIP-59: "If a rumor is intended for more than one party, or if the author wants to retain an encrypted copy, a single rumor may be wrapped and addressed for each recipient individually."

## Related Issue

- Closes #578

## Follow-up (not in this PR)

`divine-moderation-service` dedupes `dm_log` on the gift-wrap id (`src/nostr/dm-reader.mjs:178`, `dm-store.mjs:55-62`), which a re-wrap always changes. The moderator Messages UI will keep double-logging until that keys on the rumor id too. It needs a column plus a backfill in another repo, so tracked in divinevideo/divine-moderation-service#202. The report/review path is already covered, since `recordReportForReview` keys its `INSERT OR IGNORE` on the rumor's `created_at`, which is stable once the rumor is replayed.

## Testing

- [x] `npm run test` — 278 files, 2245 tests passing; lint warnings unchanged at 17 (0 errors)
- [x] Manual verification completed — end-to-end against a local WebSocket relay with `okConfirms: false`, and against `nostr-rs-relay 0.10.0` in Docker to confirm both wraps are stored and served

Post-fix, the same end-to-end harness renders one bubble:

```
FIXED sender — rumor ids: [ 'a376f25d…' ]
FIXED sender — messages rendered: 1
```

## Visuals

- [ ] UI change with screenshots/video attached
- [x] No visual change
- [x] Visuals and text avoid sensitive external brand or partner names unless explicitly approved


