### PR TITLE
fix(lists): read e-tag video list membership

### DIFF
--- a/src/components/AddToListDialog.tsx
+++ b/src/components/AddToListDialog.tsx
@@ -31,6 +31,7 @@ import { memberMatchesCoordinate, memberMatchesVideoId } from '@/lib/parseVideoL
 
 interface AddToListDialogProps {
   videoId: string;
+  videoEventId?: string;
   videoPubkey: string;
   open: boolean;
   onClose: () => void;
@@ -38,6 +39,7 @@ interface AddToListDialogProps {
 
 export function AddToListDialog({
   videoId,
+  videoEventId,
   videoPubkey,
   open,
   onClose
@@ -47,7 +49,7 @@ export function AddToListDialog({
   const { toast } = useToast();
   const queryClient = useQueryClient();
   const { data: userLists, isLoading: listsLoading } = useVideoLists(user?.pubkey);
-  const { data: publicLists, isLoading: publicListsLoading } = useVideosInLists(videoId);
+  const { data: publicLists, isLoading: publicListsLoading } = useVideosInLists(videoId, videoEventId);
   const addToList = useAddVideoToList();
   const createList = useCreateVideoList();
 
@@ -68,6 +70,7 @@ export function AddToListDialog({
           listId: list.id,
           ownerPubkey: list.pubkey,
           videoCoordinate,
+          videoEventId,
         }),
       );
 
@@ -215,7 +218,7 @@ export function AddToListDialog({
                   <div className="space-y-2">
                     {userLists.map((list) => {
                       const isInList = list.members.some((member) => (
-                        memberMatchesCoordinate(member, videoCoordinate) || memberMatchesVideoId(member, videoId)
+                        memberMatchesCoordinate(member, videoCoordinate) || memberMatchesVideoId(member, videoId, videoEventId)
                       ));
                       return (
                         <div

--- a/src/components/AddToListDialog.tsx
+++ b/src/components/AddToListDialog.tsx
@@ -27,6 +27,7 @@ import { format } from 'date-fns';
 import { useToast } from '@/hooks/useToast';
 import { buildListPath } from '@/lib/eventRouting';
 import { SHORT_VIDEO_KIND } from '@/types/video';
+import { memberMatchesCoordinate, memberMatchesVideoId } from '@/lib/parseVideoListFromEvent';
 
 interface AddToListDialogProps {
   videoId: string;
@@ -182,7 +183,7 @@ export function AddToListDialog({
                     <div className="min-w-0">
                       <div className="text-sm font-medium truncate">{list.name}</div>
                       <div className="text-xs text-muted-foreground truncate">
-                        {t('addToListDialog.videoCount', { count: list.videoCoordinates.length })} • {format(new Date(list.createdAt * 1000), 'MMM d, yyyy')}
+                        {t('addToListDialog.videoCount', { count: list.memberCount })} • {format(new Date(list.createdAt * 1000), 'MMM d, yyyy')}
                       </div>
                     </div>
                     <ExternalLink className="h-4 w-4 text-muted-foreground shrink-0" />
@@ -213,7 +214,9 @@ export function AddToListDialog({
                 <ScrollArea className="h-64 w-full rounded-md border p-4">
                   <div className="space-y-2">
                     {userLists.map((list) => {
-                      const isInList = list.videoCoordinates.includes(videoCoordinate);
+                      const isInList = list.members.some((member) => (
+                        memberMatchesCoordinate(member, videoCoordinate) || memberMatchesVideoId(member, videoId)
+                      ));
                       return (
                         <div
                           key={list.id}
@@ -244,7 +247,7 @@ export function AddToListDialog({
                             )}
                           </Label>
                           <span className="text-xs text-muted-foreground">
-                            {t('addToListDialog.videoCount', { count: list.videoCoordinates.length })}
+                            {t('addToListDialog.videoCount', { count: list.memberCount })}
                           </span>
                         </div>
                       );

--- a/src/components/EditListDialog.tsx
+++ b/src/components/EditListDialog.tsx
@@ -81,7 +81,7 @@ export function EditListDialog({ open, onClose, list }: EditListDialogProps) {
         name,
         description: description || undefined,
         image: imageUrl || undefined,
-        videoCoordinates: list.videoCoordinates, // Preserve existing videos
+        videoCoordinates: [],
         members: list.members,
         sourceTags: list.sourceTags,
         tags: tags.length > 0 ? tags : undefined,

--- a/src/components/EditListDialog.tsx
+++ b/src/components/EditListDialog.tsx
@@ -82,6 +82,8 @@ export function EditListDialog({ open, onClose, list }: EditListDialogProps) {
         description: description || undefined,
         image: imageUrl || undefined,
         videoCoordinates: list.videoCoordinates, // Preserve existing videos
+        members: list.members,
+        sourceTags: list.sourceTags,
         tags: tags.length > 0 ? tags : undefined,
         playOrder,
         isCollaborative,

--- a/src/components/FullscreenVideoItem.tsx
+++ b/src/components/FullscreenVideoItem.tsx
@@ -117,7 +117,7 @@ export function FullscreenVideoItem({
   const { mutate: deleteVideo, isPending: isDeleting } = useDeleteVideo();
   const canDelete = useCanDeleteVideo(video);
   const { data: reactions } = useVideoReactions(video.id, video.pubkey, video.vineId);
-  const { data: lists } = useVideosInLists(video.vineId ?? undefined);
+  const { data: lists } = useVideosInLists(video.vineId ?? undefined, video.id);
   const playbackCountLabel = video.isVineMigrated
     ? formatClassicVineViewBreakdown(viewCount, video.loopCount ?? 0)
     : formatLoopCount(viewCount);
@@ -565,6 +565,7 @@ export function FullscreenVideoItem({
       {video.vineId && showAddToListDialog && (
         <AddToListDialog
           videoId={video.vineId}
+          videoEventId={video.id}
           videoPubkey={video.pubkey}
           open={showAddToListDialog}
           onClose={() => setShowAddToListDialog(false)}

--- a/src/components/ProfileListsSection.test.tsx
+++ b/src/components/ProfileListsSection.test.tsx
@@ -47,8 +47,8 @@ describe('ProfileListsSection', () => {
     ]));
     mockUseVideoLists.mockReturnValue({
       ...listResult([
-        { id: 'video-new', name: 'Video new', pubkey: OWNER, createdAt: 30, videoCoordinates: [], public: true },
-        { id: 'video-mid', name: 'Video mid', pubkey: OWNER, createdAt: 20, videoCoordinates: [], public: true },
+        { id: 'video-new', name: 'Video new', pubkey: OWNER, createdAt: 30, members: [], memberCount: 0, videoCoordinates: [], public: true, sourceTags: [] },
+        { id: 'video-mid', name: 'Video mid', pubkey: OWNER, createdAt: 20, members: [], memberCount: 0, videoCoordinates: [], public: true, sourceTags: [] },
       ]),
       isError: true,
     });

--- a/src/components/VideoCard.tsx
+++ b/src/components/VideoCard.tsx
@@ -141,7 +141,7 @@ export function VideoCard({
     ? video.hlsUrl || optimalHlsUrl
     : undefined;
   const effectiveHlsUrl = hlsFallbackUrl || ((isClassicVine || isShortForm) ? undefined : (video.hlsUrl || (optimalHlsUrl !== video.videoUrl ? optimalHlsUrl : undefined)));
-  const { data: lists } = useVideosInLists(video.vineId ?? undefined);
+  const { data: lists } = useVideosInLists(video.vineId ?? undefined, video.id);
 
   // NEW: Get reposter data from reposts array
   const hasReposts = video.reposts && video.reposts.length > 0;
@@ -533,6 +533,7 @@ export function VideoCard({
       {video.vineId && showAddToListDialog && (
         <AddToListDialog
           videoId={video.vineId}
+          videoEventId={video.id}
           videoPubkey={video.pubkey}
           open={showAddToListDialog}
           onClose={() => setShowAddToListDialog(false)}

--- a/src/components/VideoListBadges.tsx
+++ b/src/components/VideoListBadges.tsx
@@ -141,7 +141,7 @@ export function VideoListBadges({
           listId={list.id}
           listName={list.name}
           listPubkey={list.pubkey}
-          videoCount={list.videoCoordinates.length}
+          videoCount={list.memberCount}
         />
       ))}
 

--- a/src/components/VideoListBadges.tsx
+++ b/src/components/VideoListBadges.tsx
@@ -21,6 +21,7 @@ import { AddToListDialog } from './AddToListDialog';
 
 interface VideoListBadgesProps {
   videoId: string;
+  videoEventId?: string;
   videoPubkey: string;
   compact?: boolean;
   showAddButton?: boolean;
@@ -69,12 +70,13 @@ function ListBadge({
 
 export function VideoListBadges({
   videoId,
+  videoEventId,
   videoPubkey,
   compact = false,
   showAddButton = true,
   className = ''
 }: VideoListBadgesProps) {
-  const { data: lists, isLoading } = useVideosInLists(videoId);
+  const { data: lists, isLoading } = useVideosInLists(videoId, videoEventId);
   const [showAddDialog, setShowAddDialog] = useState(false);
 
   if (isLoading) {
@@ -103,6 +105,7 @@ export function VideoListBadges({
         {showAddDialog && (
           <AddToListDialog
             videoId={videoId}
+            videoEventId={videoEventId}
             videoPubkey={videoPubkey}
             open={showAddDialog}
             onClose={() => setShowAddDialog(false)}
@@ -184,6 +187,7 @@ export function VideoListBadges({
       {showAddDialog && (
         <AddToListDialog
           videoId={videoId}
+          videoEventId={videoEventId}
           videoPubkey={videoPubkey}
           open={showAddDialog}
           onClose={() => setShowAddDialog(false)}

--- a/src/hooks/useVideoLists.test.ts
+++ b/src/hooks/useVideoLists.test.ts
@@ -210,6 +210,26 @@ describe('useVideoLists hooks', () => {
       expect(mockNostrQuery.mock.calls[0][0][0]).not.toHaveProperty('#a');
       expect(result.current.data?.map((list) => list.id)).toEqual(['matching']);
     });
+
+    it('matches e-tag membership by event id', async () => {
+      const { useVideosInLists } = await import('./useVideoLists');
+      const eventId = '2'.repeat(64);
+
+      mockNostrQuery.mockResolvedValue([
+        listEvent({
+          tags: [
+            ['d', 'matching-e'],
+            ['title', 'Matching e'],
+            ['e', eventId],
+          ],
+        }),
+      ]);
+      const { result } = renderHook(() => useVideosInLists('my-dtag', eventId), { wrapper: createWrapper() });
+
+      await waitFor(() => expect(result.current.isFetched).toBe(true));
+
+      expect(result.current.data?.map((list) => list.id)).toEqual(['matching-e']);
+    });
   });
 
   describe('useCreateVideoList', () => {
@@ -315,19 +335,19 @@ describe('useVideoLists hooks', () => {
         id: 'mobile-list',
         name: 'Renamed',
         videoCoordinates: [],
-        members: [{ type: 'e', value: eventId }],
+        members: [{ type: 'e', value: eventId, sourceTag: ['e', eventId, 'wss://relay.example', 'root'] }],
         sourceTags: [
           ['d', 'mobile-list'],
           ['title', 'Old'],
           ['client', 'divine-mobile'],
-          ['e', eventId],
+          ['e', eventId, 'wss://relay.example', 'root'],
         ],
       });
 
       const tags = (mockPublishAsync.mock.calls[0][0] as { tags: string[][] }).tags;
       expect(tags).toContainEqual(['title', 'Renamed']);
       expect(tags).toContainEqual(['client', 'divine-mobile']);
-      expect(tags.filter((tag) => tag[0] === 'e')).toEqual([['e', eventId]]);
+      expect(tags.filter((tag) => tag[0] === 'e')).toEqual([['e', eventId, 'wss://relay.example', 'root']]);
     });
 
     it('prepends new list to video-lists cache on success (before refetch)', async () => {
@@ -470,6 +490,32 @@ describe('useVideoLists hooks', () => {
       expect(tags.filter((t) => t[0] === 'e')).toEqual([['e', eventId]]);
       expect(tags.filter((t) => t[0] === 'a')).toEqual([['a', incoming]]);
     });
+
+    it('returns without publishing when video already exists as an e-tag member', async () => {
+      const eventId = '6'.repeat(64);
+      const incoming = `${SHORT_VIDEO_KIND}:${TEST_PUBKEY}:vid-1`;
+      mockNostrQuery.mockResolvedValue([
+        listEvent({
+          tags: [
+            ['d', 'my-list'],
+            ['title', 'Mobile list'],
+            ['e', eventId],
+          ],
+        }),
+      ]);
+      const { useAddVideoToList } = await import('./useVideoLists');
+      const { result } = renderHook(() => useAddVideoToList(), { wrapper: createWrapper() });
+
+      mockPublishAsync.mockClear();
+      await result.current.mutateAsync({
+        listId: 'my-list',
+        ownerPubkey: TEST_PUBKEY,
+        videoCoordinate: incoming,
+        videoEventId: eventId,
+      });
+
+      expect(mockPublishAsync).not.toHaveBeenCalled();
+    });
   });
 
   describe('useRemoveVideoFromList', () => {
@@ -482,7 +528,7 @@ describe('useVideoLists hooks', () => {
         result.current.mutateAsync({
           listId: 'x',
           ownerPubkey: TEST_PUBKEY,
-          videoCoordinate: `${SHORT_VIDEO_KIND}:${TEST_PUBKEY}:v`,
+          videoMember: { type: 'a', value: `${SHORT_VIDEO_KIND}:${TEST_PUBKEY}:v` },
         })
       ).rejects.toThrow('List not found');
     });
@@ -496,7 +542,7 @@ describe('useVideoLists hooks', () => {
         result.current.mutateAsync({
           listId: 'any',
           ownerPubkey: TEST_PUBKEY,
-          videoCoordinate: `${SHORT_VIDEO_KIND}:${TEST_PUBKEY}:v`,
+          videoMember: { type: 'a', value: `${SHORT_VIDEO_KIND}:${TEST_PUBKEY}:v` },
         })
       ).rejects.toThrow('Invalid list format');
     });
@@ -527,7 +573,7 @@ describe('useVideoLists hooks', () => {
       await result.current.mutateAsync({
         listId: 'my-list',
         ownerPubkey: TEST_PUBKEY,
-        videoCoordinate: coord1,
+        videoMember: { type: 'a', value: coord1 },
       });
 
       expect(mockPublishAsync).toHaveBeenCalledTimes(1);
@@ -540,8 +586,8 @@ describe('useVideoLists hooks', () => {
       expect(tags).toContainEqual(['t', 'tag1']);
       expect(tags).toContainEqual(['collaborative', 'true']);
       expect(tags).toContainEqual(['collaborator', OTHER_PUBKEY]);
-      expect(tags).toContainEqual(['thumbnail', 'th']);
-      expect(tags).toContainEqual(['playorder', 'reverse']);
+      expect(tags).toContainEqual(['thumbnail-event', 'th']);
+      expect(tags).toContainEqual(['play-order', 'reverse']);
       expect(tags.filter((t) => t[0] === 'a').map((t) => t[1])).toEqual([coord2]);
     });
 

--- a/src/hooks/useVideoLists.test.ts
+++ b/src/hooks/useVideoLists.test.ts
@@ -350,6 +350,29 @@ describe('useVideoLists hooks', () => {
       expect(tags.filter((tag) => tag[0] === 'e')).toEqual([['e', eventId, 'wss://relay.example', 'root']]);
     });
 
+    it('drops empty and nameless source tags instead of re-signing them', async () => {
+      const { useCreateVideoList } = await import('./useVideoLists');
+      const { result } = renderHook(() => useCreateVideoList(), { wrapper: createWrapper() });
+
+      await result.current.mutateAsync({
+        id: 'mobile-list',
+        name: 'Renamed',
+        videoCoordinates: [],
+        members: [],
+        sourceTags: [
+          ['d', 'mobile-list'],
+          ['title', 'Old'],
+          [],
+          [''],
+          ['client', 'divine-mobile'],
+        ],
+      });
+
+      const tags = (mockPublishAsync.mock.calls[0][0] as { tags: string[][] }).tags;
+      expect(tags).toContainEqual(['client', 'divine-mobile']);
+      expect(tags.every((tag) => tag.length > 0 && tag[0] !== '')).toBe(true);
+    });
+
     it('prepends new list to video-lists cache on success (before refetch)', async () => {
       const queryClient = new QueryClient({
         defaultOptions: {

--- a/src/hooks/useVideoLists.test.ts
+++ b/src/hooks/useVideoLists.test.ts
@@ -272,8 +272,8 @@ describe('useVideoLists hooks', () => {
             ['t', 'y'],
             ['collaborative', 'true'],
             ['collaborator', OTHER_PUBKEY],
-            ['thumbnail-event', 'thumb1'],
-            ['play-order', 'shuffle'],
+            ['thumbnail', 'thumb1'],
+            ['playorder', 'shuffle'],
             ['a', `${SHORT_VIDEO_KIND}:${TEST_PUBKEY}:a`],
           ]),
         })
@@ -282,7 +282,7 @@ describe('useVideoLists hooks', () => {
       await waitFor(() => expect(videoLists.result.current.isFetching).toBe(false));
     });
 
-    it('omits play-order tag when playOrder is chronological or omitted', async () => {
+    it('omits playorder tag when playOrder is chronological or omitted', async () => {
       const { useCreateVideoList } = await import('./useVideoLists');
       const { result } = renderHook(() => useCreateVideoList(), { wrapper: createWrapper() });
 
@@ -294,7 +294,7 @@ describe('useVideoLists hooks', () => {
         playOrder: 'chronological',
       });
       let tags = (mockPublishAsync.mock.calls[0][0] as { tags: string[][] }).tags;
-      expect(tags.find((t) => t[0] === 'play-order')).toBeUndefined();
+      expect(tags.find((t) => t[0] === 'playorder')).toBeUndefined();
 
       mockPublishAsync.mockClear();
       await result.current.mutateAsync({
@@ -303,7 +303,31 @@ describe('useVideoLists hooks', () => {
         videoCoordinates: [],
       });
       tags = (mockPublishAsync.mock.calls[0][0] as { tags: string[][] }).tags;
-      expect(tags.find((t) => t[0] === 'play-order')).toBeUndefined();
+      expect(tags.find((t) => t[0] === 'playorder')).toBeUndefined();
+    });
+
+    it('preserves source membership and unknown tags when updating metadata', async () => {
+      const { useCreateVideoList } = await import('./useVideoLists');
+      const { result } = renderHook(() => useCreateVideoList(), { wrapper: createWrapper() });
+      const eventId = '2'.repeat(64);
+
+      await result.current.mutateAsync({
+        id: 'mobile-list',
+        name: 'Renamed',
+        videoCoordinates: [],
+        members: [{ type: 'e', value: eventId }],
+        sourceTags: [
+          ['d', 'mobile-list'],
+          ['title', 'Old'],
+          ['client', 'divine-mobile'],
+          ['e', eventId],
+        ],
+      });
+
+      const tags = (mockPublishAsync.mock.calls[0][0] as { tags: string[][] }).tags;
+      expect(tags).toContainEqual(['title', 'Renamed']);
+      expect(tags).toContainEqual(['client', 'divine-mobile']);
+      expect(tags.filter((tag) => tag[0] === 'e')).toEqual([['e', eventId]]);
     });
 
     it('prepends new list to video-lists cache on success (before refetch)', async () => {
@@ -417,6 +441,35 @@ describe('useVideoLists hooks', () => {
       expect(tags).toContainEqual(['image', 'https://cover.example/img.jpg']);
       expect(tags.filter((t) => t[0] === 'a').map((t) => t[1])).toEqual([existing, incoming]);
     });
+
+    it('adds one coordinate without dropping existing e-tag members', async () => {
+      const eventId = '3'.repeat(64);
+      const incoming = `${SHORT_VIDEO_KIND}:${TEST_PUBKEY}:new-vid`;
+      mockNostrQuery.mockResolvedValue([
+        listEvent({
+          tags: [
+            ['d', 'my-list'],
+            ['title', 'Mobile list'],
+            ['client', 'divine-mobile'],
+            ['e', eventId],
+          ],
+        }),
+      ]);
+      const { useAddVideoToList } = await import('./useVideoLists');
+      const { result } = renderHook(() => useAddVideoToList(), { wrapper: createWrapper() });
+
+      mockPublishAsync.mockClear();
+      await result.current.mutateAsync({
+        listId: 'my-list',
+        ownerPubkey: TEST_PUBKEY,
+        videoCoordinate: incoming,
+      });
+
+      const tags = (mockPublishAsync.mock.calls[0][0] as { tags: string[][] }).tags;
+      expect(tags).toContainEqual(['client', 'divine-mobile']);
+      expect(tags.filter((t) => t[0] === 'e')).toEqual([['e', eventId]]);
+      expect(tags.filter((t) => t[0] === 'a')).toEqual([['a', incoming]]);
+    });
   });
 
   describe('useRemoveVideoFromList', () => {
@@ -487,9 +540,39 @@ describe('useVideoLists hooks', () => {
       expect(tags).toContainEqual(['t', 'tag1']);
       expect(tags).toContainEqual(['collaborative', 'true']);
       expect(tags).toContainEqual(['collaborator', OTHER_PUBKEY]);
-      expect(tags).toContainEqual(['thumbnail-event', 'th']);
-      expect(tags).toContainEqual(['play-order', 'reverse']);
+      expect(tags).toContainEqual(['thumbnail', 'th']);
+      expect(tags).toContainEqual(['playorder', 'reverse']);
       expect(tags.filter((t) => t[0] === 'a').map((t) => t[1])).toEqual([coord2]);
+    });
+
+    it('removes an e-tag member without dropping the rest of the list', async () => {
+      const keepEventId = '4'.repeat(64);
+      const removeEventId = '5'.repeat(64);
+      const coord = `${SHORT_VIDEO_KIND}:${TEST_PUBKEY}:coord`;
+      mockNostrQuery.mockResolvedValue([
+        listEvent({
+          tags: [
+            ['d', 'my-list'],
+            ['title', 'Mobile list'],
+            ['e', keepEventId],
+            ['e', removeEventId],
+            ['a', coord],
+          ],
+        }),
+      ]);
+      const { useRemoveVideoFromList } = await import('./useVideoLists');
+      const { result } = renderHook(() => useRemoveVideoFromList(), { wrapper: createWrapper() });
+
+      mockPublishAsync.mockClear();
+      await result.current.mutateAsync({
+        listId: 'my-list',
+        ownerPubkey: TEST_PUBKEY,
+        videoMember: { type: 'e', value: removeEventId },
+      });
+
+      const tags = (mockPublishAsync.mock.calls[0][0] as { tags: string[][] }).tags;
+      expect(tags.filter((t) => t[0] === 'e')).toEqual([['e', keepEventId]]);
+      expect(tags.filter((t) => t[0] === 'a')).toEqual([['a', coord]]);
     });
   });
 
@@ -526,16 +609,22 @@ describe('useVideoLists hooks', () => {
           name: 'Keep',
           pubkey: TEST_PUBKEY,
           createdAt: 1,
+          members: [],
+          memberCount: 0,
           videoCoordinates: [],
           public: true,
+          sourceTags: [],
         },
         {
           id: 'del-me',
           name: 'Delete',
           pubkey: TEST_PUBKEY,
           createdAt: 2,
+          members: [],
+          memberCount: 0,
           videoCoordinates: [],
           public: true,
+          sourceTags: [],
         },
       ]);
 
@@ -613,7 +702,7 @@ describe('useVideoLists hooks', () => {
         ],
         expect.any(Object)
       );
-      expect((result.current.data ?? []).every((l) => l.videoCoordinates.length > 0)).toBe(true);
+      expect((result.current.data ?? []).every((l) => l.memberCount > 0)).toBe(true);
     });
   });
 });

--- a/src/hooks/useVideoLists.ts
+++ b/src/hooks/useVideoLists.ts
@@ -94,7 +94,7 @@ function buildListTags(
   }
 
   const preservedSourceTags = (list.sourceTags ?? [])
-    .filter((tag) => !ownedTags.has(tag[0]))
+    .filter((tag) => tag[0] && !ownedTags.has(tag[0]))
     .map(tag => [...tag]);
 
   tags.push(...preservedSourceTags);

--- a/src/hooks/useVideoLists.ts
+++ b/src/hooks/useVideoLists.ts
@@ -6,28 +6,47 @@ import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { useCurrentUser } from '@/hooks/useCurrentUser';
 import { useNostrPublish } from '@/hooks/useNostrPublish';
 import type { NostrEvent, NostrFilter } from '@nostrify/nostrify';
-import { VIDEO_KINDS } from '@/types/video';
-import { deduplicateVideoLists, parseVideoListFromEvent, type PlayOrder, type VideoList } from '@/lib/parseVideoListFromEvent';
+import {
+  deduplicateVideoLists,
+  isVideoCoordinate,
+  memberMatchesCoordinate,
+  memberMatchesVideoId,
+  parseVideoListFromEvent,
+  videoListMemberKey,
+  videoListMemberToTag,
+  type PlayOrder,
+  type VideoList,
+  type VideoListMember,
+} from '@/lib/parseVideoListFromEvent';
 import { resolveListPermissions } from '@/lib/listPermissions';
 import { debugLog } from '@/lib/debug';
 
 export type { PlayOrder, VideoList };
 
-function videoCoordinateMatchesId(coordinate: string, videoId: string): boolean {
-  const firstSeparator = coordinate.indexOf(':');
-  const secondSeparator = coordinate.indexOf(':', firstSeparator + 1);
-  if (firstSeparator < 0 || secondSeparator < 0) return false;
-
-  const kind = Number(coordinate.slice(0, firstSeparator));
-  const identifier = coordinate.slice(secondSeparator + 1);
-
-  return VIDEO_KINDS.includes(kind) && identifier === videoId;
+function memberFromCoordinate(videoCoordinate: string): VideoListMember {
+  return { type: 'a', value: videoCoordinate };
 }
 
 function buildListTags(
-  list: Pick<VideoList, 'id' | 'name' | 'description' | 'image' | 'tags' | 'isCollaborative' | 'allowedCollaborators' | 'thumbnailEventId' | 'playOrder'>,
-  videoCoordinates: string[],
+  list: Pick<VideoList, 'id' | 'name' | 'description' | 'image' | 'tags' | 'isCollaborative' | 'allowedCollaborators' | 'thumbnailEventId' | 'playOrder'> & Partial<Pick<VideoList, 'sourceTags'>>,
+  members: VideoListMember[],
 ): string[][] {
+  const ownedTags = new Set([
+    'd',
+    'title',
+    'description',
+    'image',
+    't',
+    'collaborative',
+    'collaborator',
+    'thumbnail',
+    'thumbnail-event',
+    'playorder',
+    'play-order',
+    'e',
+    'a',
+  ]);
+
   const tags: string[][] = [
     ['d', list.id],
     ['title', list.name],
@@ -57,18 +76,48 @@ function buildListTags(
   }
 
   if (list.thumbnailEventId) {
-    tags.push(['thumbnail-event', list.thumbnailEventId]);
+    tags.push(['thumbnail', list.thumbnailEventId]);
   }
 
   if (list.playOrder && list.playOrder !== 'chronological') {
-    tags.push(['play-order', list.playOrder]);
+    tags.push(['playorder', list.playOrder]);
   }
 
-  videoCoordinates.forEach((coord) => {
-    tags.push(['a', coord]);
-  });
+  const preservedSourceTags = (list.sourceTags ?? [])
+    .filter((tag) => !ownedTags.has(tag[0]))
+    .map(tag => [...tag]);
+
+  tags.push(...preservedSourceTags);
+  tags.push(...members.map(videoListMemberToTag));
 
   return tags;
+}
+
+function toVideoListSnapshot(
+  list: Pick<VideoList, 'id' | 'name' | 'description' | 'image' | 'pubkey' | 'tags' | 'isCollaborative' | 'allowedCollaborators' | 'thumbnailEventId' | 'playOrder'>,
+  members: VideoListMember[],
+  sourceTags: string[][],
+): VideoList {
+  return {
+    id: list.id,
+    name: list.name,
+    description: list.description,
+    image: list.image,
+    pubkey: list.pubkey,
+    createdAt: Math.floor(Date.now() / 1000),
+    members,
+    memberCount: members.length,
+    videoCoordinates: members
+      .filter((member): member is Extract<VideoListMember, { type: 'a' }> => member.type === 'a')
+      .map(member => member.value),
+    public: true,
+    tags: list.tags,
+    isCollaborative: list.isCollaborative,
+    allowedCollaborators: list.allowedCollaborators,
+    thumbnailEventId: list.thumbnailEventId,
+    playOrder: list.playOrder || 'chronological',
+    sourceTags,
+  };
 }
 
 async function fetchListByOwner(
@@ -181,9 +230,7 @@ export function useVideosInLists(videoId?: string) {
       }], { signal });
 
       const lists = deduplicateVideoLists(events)
-        .filter((list) => list.videoCoordinates.some((coordinate) => (
-          videoCoordinateMatchesId(coordinate, videoId)
-        )));
+        .filter((list) => list.members.some((member) => memberMatchesVideoId(member, videoId)));
 
       return lists;
     },
@@ -212,13 +259,17 @@ export function useCreateVideoList() {
       isCollaborative,
       allowedCollaborators,
       thumbnailEventId,
-      playOrder
+      playOrder,
+      members,
+      sourceTags,
     }: {
       id: string;
       name: string;
       description?: string;
       image?: string;
       videoCoordinates: string[];
+      members?: VideoListMember[];
+      sourceTags?: string[][];
       tags?: string[];
       isCollaborative?: boolean;
       allowedCollaborators?: string[];
@@ -227,50 +278,21 @@ export function useCreateVideoList() {
     }) => {
       if (!user) throw new Error('Must be logged in to create lists');
 
-      const tags: string[][] = [
-        ['d', id],
-        ['title', name]
-      ];
-
-      if (description) {
-        tags.push(['description', description]);
-      }
-
-      if (image) {
-        tags.push(['image', image]);
-      }
-
-      // Add categorization tags
-      if (listTags && listTags.length > 0) {
-        listTags.forEach(tag => {
-          tags.push(['t', tag]);
-        });
-      }
-
-      // Add collaborative settings
-      if (isCollaborative) {
-        tags.push(['collaborative', 'true']);
-        if (allowedCollaborators && allowedCollaborators.length > 0) {
-          allowedCollaborators.forEach(pubkey => {
-            tags.push(['collaborator', pubkey]);
-          });
-        }
-      }
-
-      // Add featured thumbnail
-      if (thumbnailEventId) {
-        tags.push(['thumbnail-event', thumbnailEventId]);
-      }
-
-      // Add play order
-      if (playOrder && playOrder !== 'chronological') {
-        tags.push(['play-order', playOrder]);
-      }
-
-      // Add video coordinates as 'a' tags
-      videoCoordinates.forEach(coord => {
-        tags.push(['a', coord]);
-      });
+      const listMembers = members ?? videoCoordinates
+        .filter(isVideoCoordinate)
+        .map(memberFromCoordinate);
+      const tags = buildListTags({
+        id,
+        name,
+        description,
+        image,
+        tags: listTags,
+        isCollaborative,
+        allowedCollaborators,
+        thumbnailEventId,
+        playOrder,
+        sourceTags,
+      }, listMembers);
 
       await publishEvent({
         kind: 30005,
@@ -279,21 +301,18 @@ export function useCreateVideoList() {
       });
 
       // Return the created list data for optimistic update
-      return {
+      return toVideoListSnapshot({
         id,
         name,
         description,
         image,
         pubkey: user.pubkey,
-        createdAt: Math.floor(Date.now() / 1000),
-        videoCoordinates,
-        public: true,
         tags: listTags,
         isCollaborative,
         allowedCollaborators,
         thumbnailEventId,
-        playOrder: playOrder || 'chronological'
-      } as VideoList;
+        playOrder,
+      }, listMembers, tags);
     },
     onSuccess: (newList) => {
       // Optimistically add the new list to the cache immediately
@@ -346,12 +365,13 @@ export function useAddVideoToList() {
         throw new Error('You do not have permission to edit this list');
       }
 
-      // Check if video already in list
-      if (currentList.videoCoordinates.includes(videoCoordinate)) {
+      const incomingMember = memberFromCoordinate(videoCoordinate);
+
+      if (currentList.members.some((member) => memberMatchesCoordinate(member, videoCoordinate))) {
         return; // Already in list
       }
 
-      const tags = buildListTags(currentList, [...currentList.videoCoordinates, videoCoordinate]);
+      const tags = buildListTags(currentList, [...currentList.members, incomingMember]);
 
       await publishEvent({
         kind: 30005,
@@ -381,13 +401,16 @@ export function useRemoveVideoFromList() {
     mutationFn: async ({
       listId,
       ownerPubkey,
-      videoCoordinate
+      videoCoordinate,
+      videoMember,
     }: {
       listId: string;
       ownerPubkey: string;
-      videoCoordinate: string;
+      videoCoordinate?: string;
+      videoMember?: VideoListMember;
     }) => {
       if (!user) throw new Error('Must be logged in to modify lists');
+      if (!videoCoordinate && !videoMember) throw new Error('Missing video to remove');
 
       const signal = AbortSignal.timeout(5000);
       const currentList = await fetchListByOwner(nostr, ownerPubkey, listId, signal);
@@ -400,12 +423,11 @@ export function useRemoveVideoFromList() {
         throw new Error('You do not have permission to edit this list');
       }
 
-      // Filter out the video to remove
-      const updatedCoordinates = currentList.videoCoordinates.filter(
-        coord => coord !== videoCoordinate
-      );
+      const updatedMembers = videoMember
+        ? currentList.members.filter(member => videoListMemberKey(member) !== videoListMemberKey(videoMember))
+        : currentList.members.filter(member => !memberMatchesCoordinate(member, videoCoordinate!));
 
-      const tags = buildListTags(currentList, updatedCoordinates);
+      const tags = buildListTags(currentList, updatedMembers);
 
       await publishEvent({
         kind: 30005,
@@ -445,11 +467,11 @@ export function useTrendingVideoLists() {
       }], { signal });
 
       const lists = deduplicateVideoLists(events)
-        .filter((list) => list.videoCoordinates.length > 0)
+        .filter((list) => list.memberCount > 0)
         .sort((a, b) => {
           // Sort by number of videos and recency
-          const scoreA = a.videoCoordinates.length * 10 + (a.createdAt / 1000);
-          const scoreB = b.videoCoordinates.length * 10 + (b.createdAt / 1000);
+          const scoreA = a.memberCount * 10 + (a.createdAt / 1000);
+          const scoreB = b.memberCount * 10 + (b.createdAt / 1000);
           return scoreB - scoreA;
         })
         .slice(0, 20); // Top 20 lists
@@ -531,7 +553,7 @@ export function useFollowedUsersLists(followedPubkeys: string[] | undefined) {
       }], { signal });
 
       const lists = deduplicateVideoLists(events)
-        .filter((list) => list.videoCoordinates.length > 0)
+        .filter((list) => list.memberCount > 0)
         .sort((a, b) => b.createdAt - a.createdAt);
 
       return lists;

--- a/src/hooks/useVideoLists.ts
+++ b/src/hooks/useVideoLists.ts
@@ -27,6 +27,10 @@ function memberFromCoordinate(videoCoordinate: string): VideoListMember {
   return { type: 'a', value: videoCoordinate };
 }
 
+function getPreferredSourceTagName(sourceTags: string[][] | undefined, supportedNames: string[], fallback: string): string {
+  return sourceTags?.find(tag => supportedNames.includes(tag[0]))?.[0] ?? fallback;
+}
+
 function buildListTags(
   list: Pick<VideoList, 'id' | 'name' | 'description' | 'image' | 'tags' | 'isCollaborative' | 'allowedCollaborators' | 'thumbnailEventId' | 'playOrder'> & Partial<Pick<VideoList, 'sourceTags'>>,
   members: VideoListMember[],
@@ -76,11 +80,17 @@ function buildListTags(
   }
 
   if (list.thumbnailEventId) {
-    tags.push(['thumbnail', list.thumbnailEventId]);
+    tags.push([
+      getPreferredSourceTagName(list.sourceTags, ['thumbnail', 'thumbnail-event'], 'thumbnail'),
+      list.thumbnailEventId,
+    ]);
   }
 
   if (list.playOrder && list.playOrder !== 'chronological') {
-    tags.push(['playorder', list.playOrder]);
+    tags.push([
+      getPreferredSourceTagName(list.sourceTags, ['playorder', 'play-order'], 'playorder'),
+      list.playOrder,
+    ]);
   }
 
   const preservedSourceTags = (list.sourceTags ?? [])
@@ -209,11 +219,11 @@ export function useVideoLists(pubkey?: string) {
 /**
  * Hook to fetch videos that are in lists
  */
-export function useVideosInLists(videoId?: string) {
+export function useVideosInLists(videoId?: string, videoEventId?: string) {
   const { nostr } = useNostr();
 
   return useQuery({
-    queryKey: ['videos-in-lists', videoId],
+    queryKey: ['videos-in-lists', videoId, videoEventId],
     queryFn: async (context) => {
       if (!videoId) return [];
 
@@ -230,7 +240,7 @@ export function useVideosInLists(videoId?: string) {
       }], { signal });
 
       const lists = deduplicateVideoLists(events)
-        .filter((list) => list.members.some((member) => memberMatchesVideoId(member, videoId)));
+        .filter((list) => list.members.some((member) => memberMatchesVideoId(member, videoId, videoEventId)));
 
       return lists;
     },
@@ -346,11 +356,13 @@ export function useAddVideoToList() {
     mutationFn: async ({
       listId,
       ownerPubkey,
-      videoCoordinate
+      videoCoordinate,
+      videoEventId,
     }: {
       listId: string;
       ownerPubkey: string;
       videoCoordinate: string;
+      videoEventId?: string;
     }) => {
       if (!user) throw new Error('Must be logged in to modify lists');
 
@@ -366,8 +378,11 @@ export function useAddVideoToList() {
       }
 
       const incomingMember = memberFromCoordinate(videoCoordinate);
+      const incomingVideoId = videoCoordinate.split(':').at(-1) ?? '';
 
-      if (currentList.members.some((member) => memberMatchesCoordinate(member, videoCoordinate))) {
+      if (currentList.members.some((member) => (
+        memberMatchesCoordinate(member, videoCoordinate) || memberMatchesVideoId(member, incomingVideoId, videoEventId)
+      ))) {
         return; // Already in list
       }
 
@@ -401,16 +416,13 @@ export function useRemoveVideoFromList() {
     mutationFn: async ({
       listId,
       ownerPubkey,
-      videoCoordinate,
       videoMember,
     }: {
       listId: string;
       ownerPubkey: string;
-      videoCoordinate?: string;
-      videoMember?: VideoListMember;
+      videoMember: VideoListMember;
     }) => {
       if (!user) throw new Error('Must be logged in to modify lists');
-      if (!videoCoordinate && !videoMember) throw new Error('Missing video to remove');
 
       const signal = AbortSignal.timeout(5000);
       const currentList = await fetchListByOwner(nostr, ownerPubkey, listId, signal);
@@ -423,9 +435,8 @@ export function useRemoveVideoFromList() {
         throw new Error('You do not have permission to edit this list');
       }
 
-      const updatedMembers = videoMember
-        ? currentList.members.filter(member => videoListMemberKey(member) !== videoListMemberKey(videoMember))
-        : currentList.members.filter(member => !memberMatchesCoordinate(member, videoCoordinate!));
+      const updatedMembers = currentList.members
+        .filter(member => videoListMemberKey(member) !== videoListMemberKey(videoMember));
 
       const tags = buildListTags(currentList, updatedMembers);
 

--- a/src/lib/listVideos.test.ts
+++ b/src/lib/listVideos.test.ts
@@ -3,7 +3,7 @@
 import { describe, expect, it, vi } from 'vitest';
 import type { NostrEvent, NostrFilter } from '@nostrify/nostrify';
 import { SHORT_VIDEO_KIND } from '@/types/video';
-import type { VideoListMember } from '@/lib/parseVideoListFromEvent';
+import { LIST_VIDEO_KINDS, type VideoListMember } from '@/lib/parseVideoListFromEvent';
 import { fetchListVideos } from './listVideos';
 
 const OWNER = 'a'.repeat(64);
@@ -38,8 +38,8 @@ describe('fetchListVideos', () => {
 
     const filters = query.mock.calls[0][0] as NostrFilter[];
     expect(filters).toHaveLength(2);
-    expect(filters[0]).toMatchObject({ kinds: [SHORT_VIDEO_KIND], ids: ids.slice(0, 200), limit: 200 });
-    expect(filters[1]).toMatchObject({ kinds: [SHORT_VIDEO_KIND], ids: ids.slice(200), limit: 1 });
+    expect(filters[0]).toMatchObject({ kinds: LIST_VIDEO_KINDS, ids: ids.slice(0, 200), limit: 200 });
+    expect(filters[1]).toMatchObject({ kinds: LIST_VIDEO_KINDS, ids: ids.slice(200), limit: 1 });
   });
 
   it('merges e and a results, dedupes, and returns videos in member order', async () => {
@@ -58,5 +58,17 @@ describe('fetchListVideos', () => {
 
     expect(videos.map(video => video.id)).toEqual([coordEventId, eventId]);
     expect(videos.map(video => video.listMember)).toEqual(members.slice(0, 2));
+  });
+
+  it('resolves legacy kind e-tag members', async () => {
+    const eventId = '3'.repeat(64);
+    const members: VideoListMember[] = [{ type: 'e', value: eventId }];
+    const query = vi.fn().mockResolvedValue([
+      videoEvent({ id: eventId, kind: 34235, tags: [['d', 'legacy']] }),
+    ]);
+
+    const videos = await fetchListVideos({ query }, members, new AbortController().signal);
+
+    expect(videos.map(video => video.id)).toEqual([eventId]);
   });
 });

--- a/src/lib/listVideos.test.ts
+++ b/src/lib/listVideos.test.ts
@@ -1,0 +1,62 @@
+// ABOUTME: Unit tests for resolving video-list members into ordered video data
+
+import { describe, expect, it, vi } from 'vitest';
+import type { NostrEvent, NostrFilter } from '@nostrify/nostrify';
+import { SHORT_VIDEO_KIND } from '@/types/video';
+import type { VideoListMember } from '@/lib/parseVideoListFromEvent';
+import { fetchListVideos } from './listVideos';
+
+const OWNER = 'a'.repeat(64);
+
+function videoEvent(overrides: Partial<NostrEvent> = {}): NostrEvent {
+  const id = overrides.id ?? '1'.repeat(64);
+  const dTag = overrides.tags?.find(tag => tag[0] === 'd')?.[1] ?? `d-${id[0]}`;
+  return {
+    ...overrides,
+    id,
+    pubkey: overrides.pubkey ?? OWNER,
+    kind: overrides.kind ?? SHORT_VIDEO_KIND,
+    created_at: 1700,
+    tags: [
+      ['d', dTag],
+      ['title', `Video ${dTag}`],
+      ['imeta', `url https://media.example/${dTag}.mp4`, 'm video/mp4'],
+      ...(overrides.tags?.filter(tag => tag[0] !== 'd') ?? []),
+    ],
+    content: '',
+    sig: 's'.repeat(128),
+  };
+}
+
+describe('fetchListVideos', () => {
+  it('chunks e-tag id filters and keeps video routing kinds', async () => {
+    const ids = Array.from({ length: 201 }, (_, index) => index.toString(16).padStart(64, '0'));
+    const members: VideoListMember[] = ids.map(value => ({ type: 'e', value }));
+    const query = vi.fn().mockResolvedValue([]);
+
+    await fetchListVideos({ query }, members, new AbortController().signal);
+
+    const filters = query.mock.calls[0][0] as NostrFilter[];
+    expect(filters).toHaveLength(2);
+    expect(filters[0]).toMatchObject({ kinds: [SHORT_VIDEO_KIND], ids: ids.slice(0, 200), limit: 200 });
+    expect(filters[1]).toMatchObject({ kinds: [SHORT_VIDEO_KIND], ids: ids.slice(200), limit: 1 });
+  });
+
+  it('merges e and a results, dedupes, and returns videos in member order', async () => {
+    const eventId = '1'.repeat(64);
+    const coordEventId = '2'.repeat(64);
+    const first = videoEvent({ id: eventId, tags: [['d', 'first']] });
+    const second = videoEvent({ id: coordEventId, tags: [['d', 'second']] });
+    const members: VideoListMember[] = [
+      { type: 'a', value: `${SHORT_VIDEO_KIND}:${OWNER}:second` },
+      { type: 'e', value: eventId },
+      { type: 'e', value: coordEventId },
+    ];
+    const query = vi.fn().mockResolvedValue([first, second]);
+
+    const videos = await fetchListVideos({ query }, members, new AbortController().signal);
+
+    expect(videos.map(video => video.id)).toEqual([coordEventId, eventId]);
+    expect(videos.map(video => video.listMember)).toEqual(members.slice(0, 2));
+  });
+});

--- a/src/lib/listVideos.ts
+++ b/src/lib/listVideos.ts
@@ -1,7 +1,7 @@
 // ABOUTME: Resolves ordered video list members into parsed video grid data
 
 import type { NostrEvent, NostrFilter } from '@nostrify/nostrify';
-import { SHORT_VIDEO_KIND, VIDEO_KINDS, type ParsedVideoData } from '@/types/video';
+import { SHORT_VIDEO_KIND, type ParsedVideoData } from '@/types/video';
 import {
   LIST_VIDEO_KINDS,
   type VideoListMember,
@@ -49,7 +49,7 @@ function buildListVideoFilters(members: VideoListMember[]): NostrFilter[] {
 
   for (const ids of chunk(eventIds, IDS_CHUNK_SIZE)) {
     filters.push({
-      kinds: VIDEO_KINDS,
+      kinds: LIST_VIDEO_KINDS,
       ids,
       limit: ids.length,
     });

--- a/src/lib/listVideos.ts
+++ b/src/lib/listVideos.ts
@@ -1,0 +1,147 @@
+// ABOUTME: Resolves ordered video list members into parsed video grid data
+
+import type { NostrEvent, NostrFilter } from '@nostrify/nostrify';
+import { SHORT_VIDEO_KIND, VIDEO_KINDS, type ParsedVideoData } from '@/types/video';
+import {
+  LIST_VIDEO_KINDS,
+  type VideoListMember,
+} from '@/lib/parseVideoListFromEvent';
+import {
+  getLoopCount,
+  getOriginalCommentCount,
+  getOriginalLikeCount,
+  getOriginalRepostCount,
+  getOriginalVineTimestamp,
+  getOriginPlatform,
+  getProofModeData,
+  getThumbnailUrl,
+  getVineId,
+  isVineMigrated,
+  parseVideoEvent,
+} from '@/lib/videoParser';
+
+export interface ListVideoData extends ParsedVideoData {
+  listMember: VideoListMember;
+}
+
+const IDS_CHUNK_SIZE = 200;
+
+function chunk<T>(items: T[], size: number): T[][] {
+  const chunks: T[][] = [];
+  for (let index = 0; index < items.length; index += size) {
+    chunks.push(items.slice(index, index + size));
+  }
+  return chunks;
+}
+
+function coordinateKey(member: VideoListMember): string | null {
+  if (member.type !== 'a') return null;
+  const [kind, pubkey, dTag] = member.value.split(':');
+  if (!LIST_VIDEO_KINDS.includes(Number(kind)) || !pubkey || !dTag) return null;
+  return `${pubkey}:${dTag}`;
+}
+
+function buildListVideoFilters(members: VideoListMember[]): NostrFilter[] {
+  const filters: NostrFilter[] = [];
+  const eventIds = members
+    .filter((member): member is Extract<VideoListMember, { type: 'e' }> => member.type === 'e')
+    .map(member => member.value);
+
+  for (const ids of chunk(eventIds, IDS_CHUNK_SIZE)) {
+    filters.push({
+      kinds: VIDEO_KINDS,
+      ids,
+      limit: ids.length,
+    });
+  }
+
+  const pubkeyGroups = new Map<string, string[]>();
+  for (const member of members) {
+    if (member.type !== 'a') continue;
+    const [kind, pubkey, dTag] = member.value.split(':');
+    if (!LIST_VIDEO_KINDS.includes(Number(kind)) || !pubkey || !dTag) continue;
+    pubkeyGroups.set(pubkey, [...(pubkeyGroups.get(pubkey) ?? []), dTag]);
+  }
+
+  for (const [pubkey, dTags] of pubkeyGroups) {
+    filters.push({
+      kinds: LIST_VIDEO_KINDS,
+      authors: [pubkey],
+      '#d': Array.from(new Set(dTags)),
+      limit: dTags.length,
+    });
+  }
+
+  return filters;
+}
+
+function parseListVideoEvent(event: NostrEvent): ParsedVideoData | null {
+  const vineId = getVineId(event);
+  if (!vineId) return null;
+
+  const videoEvent = parseVideoEvent(event);
+  if (!videoEvent?.videoMetadata?.url) return null;
+
+  return {
+    id: event.id,
+    pubkey: event.pubkey,
+    kind: SHORT_VIDEO_KIND,
+    createdAt: event.created_at,
+    originalVineTimestamp: getOriginalVineTimestamp(event),
+    content: event.content,
+    videoUrl: videoEvent.videoMetadata.url,
+    fallbackVideoUrls: videoEvent.videoMetadata?.fallbackUrls,
+    hlsUrl: videoEvent.videoMetadata?.hlsUrl,
+    thumbnailUrl: getThumbnailUrl(videoEvent),
+    title: videoEvent.title,
+    duration: videoEvent.videoMetadata?.duration,
+    hashtags: videoEvent.hashtags || [],
+    vineId,
+    loopCount: getLoopCount(event),
+    likeCount: getOriginalLikeCount(event),
+    repostCount: getOriginalRepostCount(event),
+    commentCount: getOriginalCommentCount(event),
+    proofMode: getProofModeData(event),
+    origin: getOriginPlatform(event),
+    isVineMigrated: isVineMigrated(event),
+    reposts: [],
+  };
+}
+
+export async function fetchListVideos(
+  nostr: { query: (filters: NostrFilter[], options: { signal: AbortSignal }) => Promise<NostrEvent[]> },
+  members: VideoListMember[],
+  signal: AbortSignal
+): Promise<ListVideoData[]> {
+  if (members.length === 0) return [];
+
+  const filters = buildListVideoFilters(members);
+  if (filters.length === 0) return [];
+
+  const events = await nostr.query(filters, { signal });
+  const eventMap = new Map<string, ParsedVideoData>();
+  const coordinateMap = new Map<string, ParsedVideoData>();
+
+  for (const event of events) {
+    const video = parseListVideoEvent(event);
+    if (!video) continue;
+
+    eventMap.set(event.id, video);
+    coordinateMap.set(`${event.pubkey}:${video.vineId}`, video);
+  }
+
+  const orderedVideos: ListVideoData[] = [];
+  const seenVideoIds = new Set<string>();
+
+  for (const member of members) {
+    const video = member.type === 'e'
+      ? eventMap.get(member.value)
+      : coordinateMap.get(coordinateKey(member) ?? '');
+
+    if (!video || seenVideoIds.has(video.id)) continue;
+    seenVideoIds.add(video.id);
+    orderedVideos.push({ ...video, listMember: member });
+  }
+
+  return orderedVideos;
+}

--- a/src/lib/parseVideoListFromEvent.test.ts
+++ b/src/lib/parseVideoListFromEvent.test.ts
@@ -7,6 +7,8 @@ import { deduplicateVideoLists, parseVideoListFromEvent } from './parseVideoList
 
 const OWNER = 'b'.repeat(64);
 const COORD = `${SHORT_VIDEO_KIND}:${OWNER}:my-video`;
+const LEGACY_COORD = `34235:${OWNER}:legacy-video`;
+const EVENT_ID = '1'.repeat(64);
 
 function baseEvent(overrides: Partial<NostrEvent> = {}): NostrEvent {
   return {
@@ -37,6 +39,8 @@ describe('parseVideoListFromEvent', () => {
       image: undefined,
       pubkey: OWNER,
       createdAt: 1700,
+      members: [],
+      memberCount: 0,
       videoCoordinates: [],
       public: true,
       tags: [],
@@ -44,6 +48,7 @@ describe('parseVideoListFromEvent', () => {
       allowedCollaborators: [],
       thumbnailEventId: undefined,
       playOrder: 'chronological',
+      sourceTags: [['d', 'list-d']],
     });
   });
 
@@ -63,6 +68,40 @@ describe('parseVideoListFromEvent', () => {
       ],
     });
     expect(parseVideoListFromEvent(ev)?.videoCoordinates).toEqual([COORD]);
+  });
+
+  it('parses e tags as ordered members and counts them', () => {
+    const ev = baseEvent({
+      tags: [
+        ['d', 'l1'],
+        ['e', EVENT_ID],
+        ['e', 'not-an-event-id'],
+      ],
+    });
+    const list = parseVideoListFromEvent(ev);
+    expect(list?.members).toEqual([{ type: 'e', value: EVENT_ID }]);
+    expect(list?.memberCount).toBe(1);
+    expect(list?.videoCoordinates).toEqual([]);
+  });
+
+  it('preserves mixed e and a membership order', () => {
+    const secondEventId = '2'.repeat(64);
+    const ev = baseEvent({
+      tags: [
+        ['d', 'l1'],
+        ['e', EVENT_ID],
+        ['a', COORD],
+        ['e', secondEventId],
+        ['a', LEGACY_COORD],
+      ],
+    });
+
+    expect(parseVideoListFromEvent(ev)?.members).toEqual([
+      { type: 'e', value: EVENT_ID },
+      { type: 'a', value: COORD },
+      { type: 'e', value: secondEventId },
+      { type: 'a', value: LEGACY_COORD },
+    ]);
   });
 
   it('collects t tags in order', () => {
@@ -99,11 +138,14 @@ describe('parseVideoListFromEvent', () => {
     expect(parseVideoListFromEvent(ev)?.isCollaborative).toBe(false);
   });
 
-  it('parses thumbnail-event', () => {
+  it.each([
+    ['thumbnail-event', 'note1abc'],
+    ['thumbnail', EVENT_ID],
+  ])('parses %s', (tagName, expected) => {
     const ev = baseEvent({
-      tags: [['d', 'l1'], ['thumbnail-event', 'note1abc']],
+      tags: [['d', 'l1'], [tagName, expected]],
     });
-    expect(parseVideoListFromEvent(ev)?.thumbnailEventId).toBe('note1abc');
+    expect(parseVideoListFromEvent(ev)?.thumbnailEventId).toBe(expected);
   });
 
   it.each([
@@ -114,6 +156,11 @@ describe('parseVideoListFromEvent', () => {
   ] as const)('play-order %s → %s', (tagValue, expected) => {
     const ev = baseEvent({ tags: [['d', 'l1'], ['play-order', tagValue]] });
     expect(parseVideoListFromEvent(ev)?.playOrder).toBe(expected);
+  });
+
+  it('parses mobile playorder tag', () => {
+    const ev = baseEvent({ tags: [['d', 'l1'], ['playorder', 'manual']] });
+    expect(parseVideoListFromEvent(ev)?.playOrder).toBe('manual');
   });
 
   it('defaults play-order to chronological when tag absent', () => {

--- a/src/lib/parseVideoListFromEvent.test.ts
+++ b/src/lib/parseVideoListFromEvent.test.ts
@@ -79,7 +79,7 @@ describe('parseVideoListFromEvent', () => {
       ],
     });
     const list = parseVideoListFromEvent(ev);
-    expect(list?.members).toEqual([{ type: 'e', value: EVENT_ID }]);
+    expect(list?.members.map(({ type, value }) => ({ type, value }))).toEqual([{ type: 'e', value: EVENT_ID }]);
     expect(list?.memberCount).toBe(1);
     expect(list?.videoCoordinates).toEqual([]);
   });
@@ -96,11 +96,41 @@ describe('parseVideoListFromEvent', () => {
       ],
     });
 
-    expect(parseVideoListFromEvent(ev)?.members).toEqual([
+    expect(parseVideoListFromEvent(ev)?.members.map(({ type, value }) => ({ type, value }))).toEqual([
       { type: 'e', value: EVENT_ID },
       { type: 'a', value: COORD },
       { type: 'e', value: secondEventId },
       { type: 'a', value: LEGACY_COORD },
+    ]);
+  });
+
+  it('preserves full source tags for list members', () => {
+    const ev = baseEvent({
+      tags: [
+        ['d', 'l1'],
+        ['e', EVENT_ID, 'wss://relay.example', 'root'],
+        ['a', COORD, 'wss://relay.example'],
+      ],
+    });
+
+    expect(parseVideoListFromEvent(ev)?.members.map(member => member.sourceTag)).toEqual([
+      ['e', EVENT_ID, 'wss://relay.example', 'root'],
+      ['a', COORD, 'wss://relay.example'],
+    ]);
+  });
+
+  it('normalizes uppercase e tag event ids', () => {
+    const uppercaseEventId = 'ABCDEF'.repeat(10) + 'ABCD';
+    const lowercaseEventId = uppercaseEventId.toLowerCase();
+    const ev = baseEvent({
+      tags: [
+        ['d', 'l1'],
+        ['e', uppercaseEventId],
+      ],
+    });
+
+    expect(parseVideoListFromEvent(ev)?.members).toEqual([
+      { type: 'e', value: lowercaseEventId, sourceTag: ['e', lowercaseEventId] },
     ]);
   });
 

--- a/src/lib/parseVideoListFromEvent.ts
+++ b/src/lib/parseVideoListFromEvent.ts
@@ -4,6 +4,11 @@ import type { NostrEvent } from '@nostrify/nostrify';
 import { VIDEO_KINDS } from '@/types/video';
 
 export type PlayOrder = 'chronological' | 'reverse' | 'manual' | 'shuffle';
+export type VideoListMember = { type: 'e'; value: string } | { type: 'a'; value: string };
+
+export const LIST_VIDEO_KINDS = [34235, ...VIDEO_KINDS];
+
+const HEX_EVENT_ID_RE = /^[0-9a-f]{64}$/i;
 
 export interface VideoList {
   id: string;
@@ -12,6 +17,8 @@ export interface VideoList {
   image?: string;
   pubkey: string;
   createdAt: number;
+  members: VideoListMember[];
+  memberCount: number;
   videoCoordinates: string[];
   public: boolean;
   tags?: string[];
@@ -19,15 +26,47 @@ export interface VideoList {
   allowedCollaborators?: string[];
   thumbnailEventId?: string;
   playOrder?: PlayOrder;
+  sourceTags: string[][];
 }
 
 export function videoListAddress(list: VideoList): string {
   return `${list.pubkey}:30005:${list.id}`;
 }
 
+export function isVideoEventId(value: string): boolean {
+  return HEX_EVENT_ID_RE.test(value);
+}
+
+export function isVideoCoordinate(value: string): boolean {
+  return LIST_VIDEO_KINDS.some(kind => value.startsWith(`${kind}:`));
+}
+
+export function videoListMemberToTag(member: VideoListMember): string[] {
+  return [member.type, member.value];
+}
+
+export function videoListMemberKey(member: VideoListMember): string {
+  return `${member.type}:${member.value}`;
+}
+
+export function memberMatchesCoordinate(member: VideoListMember, coordinate: string): boolean {
+  return member.type === 'a' && member.value === coordinate;
+}
+
+export function memberMatchesVideoId(member: VideoListMember, videoId: string): boolean {
+  if (member.type === 'e') {
+    return member.value === videoId;
+  }
+
+  const firstSeparator = member.value.indexOf(':');
+  const secondSeparator = member.value.indexOf(':', firstSeparator + 1);
+  if (firstSeparator < 0 || secondSeparator < 0) return false;
+
+  return member.value.slice(secondSeparator + 1) === videoId;
+}
+
 /**
  * Parse a video list event (kind 30005) into a VideoList, or null if invalid.
- * Uses {@link VIDEO_KINDS} for `a` tag coordinates so supported kinds stay in one place.
  */
 export function parseVideoListFromEvent(event: NostrEvent): VideoList | null {
   const dTag = event.tags.find(tag => tag[0] === 'd')?.[1];
@@ -37,12 +76,16 @@ export function parseVideoListFromEvent(event: NostrEvent): VideoList | null {
   const description = event.tags.find(tag => tag[0] === 'description')?.[1];
   const image = event.tags.find(tag => tag[0] === 'image')?.[1];
 
-  const videoCoordinates = event.tags
-    .filter(tag => {
-      if (tag[0] !== 'a' || !tag[1]) return false;
-      return VIDEO_KINDS.some(kind => tag[1]!.startsWith(`${kind}:`));
-    })
-    .map(tag => tag[1]!);
+  const members: VideoListMember[] = event.tags.flatMap((tag): VideoListMember[] => {
+    if (!tag[1]) return [];
+    if (tag[0] === 'e' && isVideoEventId(tag[1])) return [{ type: 'e', value: tag[1] }];
+    if (tag[0] === 'a' && isVideoCoordinate(tag[1])) return [{ type: 'a', value: tag[1] }];
+    return [];
+  });
+
+  const videoCoordinates = members
+    .filter((member): member is Extract<VideoListMember, { type: 'a' }> => member.type === 'a')
+    .map(member => member.value);
 
   const tags = event.tags
     .filter(tag => tag[0] === 't')
@@ -53,22 +96,17 @@ export function parseVideoListFromEvent(event: NostrEvent): VideoList | null {
     .filter(tag => tag[0] === 'collaborator')
     .map(tag => tag[1]!);
 
-  const thumbnailEventId = event.tags.find(tag => tag[0] === 'thumbnail-event')?.[1];
+  const thumbnailEventId =
+    event.tags.find(tag => tag[0] === 'thumbnail')?.[1] ??
+    event.tags.find(tag => tag[0] === 'thumbnail-event')?.[1];
 
-  const playOrderTag = event.tags.find(tag => tag[0] === 'play-order')?.[1];
+  const playOrderTag =
+    event.tags.find(tag => tag[0] === 'playorder')?.[1] ??
+    event.tags.find(tag => tag[0] === 'play-order')?.[1];
   const playOrder: PlayOrder =
     playOrderTag === 'reverse' || playOrderTag === 'manual' || playOrderTag === 'shuffle'
       ? playOrderTag
       : 'chronological';
-
-  let privateCoordinates: string[] = [];
-  if (event.content) {
-    try {
-      privateCoordinates = [];
-    } catch {
-      // Ignore decryption errors
-    }
-  }
 
   return {
     id: dTag,
@@ -77,13 +115,16 @@ export function parseVideoListFromEvent(event: NostrEvent): VideoList | null {
     image,
     pubkey: event.pubkey,
     createdAt: event.created_at,
-    videoCoordinates: [...videoCoordinates, ...privateCoordinates],
+    members,
+    memberCount: members.length,
+    videoCoordinates,
     public: true,
     tags,
     isCollaborative,
     allowedCollaborators,
     thumbnailEventId,
     playOrder,
+    sourceTags: event.tags.map(tag => [...tag]),
   };
 }
 

--- a/src/lib/parseVideoListFromEvent.ts
+++ b/src/lib/parseVideoListFromEvent.ts
@@ -4,7 +4,10 @@ import type { NostrEvent } from '@nostrify/nostrify';
 import { VIDEO_KINDS } from '@/types/video';
 
 export type PlayOrder = 'chronological' | 'reverse' | 'manual' | 'shuffle';
-export type VideoListMember = { type: 'e'; value: string } | { type: 'a'; value: string };
+type VideoListMemberBase = { value: string; sourceTag?: string[] };
+export type VideoListMember =
+  | ({ type: 'e' } & VideoListMemberBase)
+  | ({ type: 'a' } & VideoListMemberBase);
 
 export const LIST_VIDEO_KINDS = [34235, ...VIDEO_KINDS];
 
@@ -42,6 +45,7 @@ export function isVideoCoordinate(value: string): boolean {
 }
 
 export function videoListMemberToTag(member: VideoListMember): string[] {
+  if (member.sourceTag) return [...member.sourceTag];
   return [member.type, member.value];
 }
 
@@ -53,9 +57,9 @@ export function memberMatchesCoordinate(member: VideoListMember, coordinate: str
   return member.type === 'a' && member.value === coordinate;
 }
 
-export function memberMatchesVideoId(member: VideoListMember, videoId: string): boolean {
+export function memberMatchesVideoId(member: VideoListMember, videoId: string, videoEventId?: string): boolean {
   if (member.type === 'e') {
-    return member.value === videoId;
+    return !!videoEventId && member.value === videoEventId.toLowerCase();
   }
 
   const firstSeparator = member.value.indexOf(':');
@@ -78,8 +82,13 @@ export function parseVideoListFromEvent(event: NostrEvent): VideoList | null {
 
   const members: VideoListMember[] = event.tags.flatMap((tag): VideoListMember[] => {
     if (!tag[1]) return [];
-    if (tag[0] === 'e' && isVideoEventId(tag[1])) return [{ type: 'e', value: tag[1] }];
-    if (tag[0] === 'a' && isVideoCoordinate(tag[1])) return [{ type: 'a', value: tag[1] }];
+    if (tag[0] === 'e' && isVideoEventId(tag[1])) {
+      const value = tag[1].toLowerCase();
+      return [{ type: 'e', value, sourceTag: [tag[0], value, ...tag.slice(2)] }];
+    }
+    if (tag[0] === 'a' && isVideoCoordinate(tag[1])) {
+      return [{ type: 'a', value: tag[1], sourceTag: [...tag] }];
+    }
     return [];
   });
 

--- a/src/lib/parseVideoListFromEvent.ts
+++ b/src/lib/parseVideoListFromEvent.ts
@@ -36,7 +36,7 @@ export function videoListAddress(list: VideoList): string {
   return `${list.pubkey}:30005:${list.id}`;
 }
 
-export function isVideoEventId(value: string): boolean {
+function isVideoEventId(value: string): boolean {
   return HEX_EVENT_ID_RE.test(value);
 }
 

--- a/src/lib/profileLists.test.ts
+++ b/src/lib/profileLists.test.ts
@@ -28,8 +28,11 @@ const videoList: VideoList = {
   name: 'Favorites',
   pubkey: OWNER,
   createdAt: 10,
+  members: [{ type: 'a', value: '34236:owner:one' }],
+  memberCount: 1,
   videoCoordinates: ['34236:owner:one'],
   public: true,
+  sourceTags: [['d', 'favorites'], ['a', '34236:owner:one']],
 };
 
 describe('profile list presentation', () => {

--- a/src/lib/profileLists.ts
+++ b/src/lib/profileLists.ts
@@ -43,7 +43,7 @@ export function toDiscoverableVideoList(list: VideoList): DiscoverableList {
     image: list.image,
     ownerPubkey: list.pubkey,
     createdAt: list.createdAt,
-    itemCount: list.videoCoordinates.length,
+    itemCount: list.memberCount,
     href: buildListPath(list.pubkey, list.id),
   };
 }

--- a/src/pages/ListDetailPage.tsx
+++ b/src/pages/ListDetailPage.tsx
@@ -29,103 +29,8 @@ import { useAppContext } from '@/hooks/useAppContext';
 import { getListShareData } from '@/lib/shareUtils';
 import { getSafeProfileImage } from '@/lib/imageUtils';
 import { getEventLookupRelayUrls } from '@/config/relays';
-import type { NostrEvent, NostrFilter } from '@nostrify/nostrify';
-import { SHORT_VIDEO_KIND, VIDEO_KINDS, type ParsedVideoData } from '@/types/video';
-import { parseVideoEvent, getVineId, getThumbnailUrl, getOriginalVineTimestamp, getLoopCount, getProofModeData, getOriginalLikeCount, getOriginalRepostCount, getOriginalCommentCount, getOriginPlatform, isVineMigrated } from '@/lib/videoParser';
+import { fetchListVideos } from '@/lib/listVideos';
 import { resolveListPermissions } from '@/lib/listPermissions';
-
-async function fetchListVideos(
-  nostr: { query: (filters: NostrFilter[], options: { signal: AbortSignal }) => Promise<NostrEvent[]> },
-  coordinates: string[],
-  signal: AbortSignal
-): Promise<ParsedVideoData[]> {
-  if (coordinates.length === 0) return [];
-
-  // Parse coordinates to extract pubkeys and d-tags
-  const filters: NostrFilter[] = [];
-  const coordinateMap = new Map<string, { pubkey: string; dTag: string }>();
-
-  coordinates.forEach(coord => {
-    const [kind, pubkey, dTag] = coord.split(':');
-    const kindNum = parseInt(kind, 10);
-    if (VIDEO_KINDS.includes(kindNum) && pubkey && dTag) {
-      coordinateMap.set(`${pubkey}:${dTag}`, { pubkey, dTag });
-    }
-  });
-
-  // Group by pubkey for efficient querying
-  const pubkeyGroups = new Map<string, string[]>();
-  coordinateMap.forEach(({ pubkey, dTag }) => {
-    if (!pubkeyGroups.has(pubkey)) {
-      pubkeyGroups.set(pubkey, []);
-    }
-    pubkeyGroups.get(pubkey)!.push(dTag);
-  });
-
-  // Create filters for each pubkey group
-  pubkeyGroups.forEach((dTags, pubkey) => {
-    filters.push({
-      kinds: VIDEO_KINDS,
-      authors: [pubkey],
-      '#d': dTags,
-      limit: dTags.length
-    });
-  });
-
-  if (filters.length === 0) return [];
-
-  const events = await nostr.query(filters, { signal });
-
-  // Parse and order videos according to list order
-  const videoMap = new Map<string, ParsedVideoData>();
-
-  events.forEach(event => {
-    const vineId = getVineId(event);
-    if (!vineId) return;
-
-    const videoEvent = parseVideoEvent(event);
-    if (!videoEvent?.videoMetadata?.url) return;
-
-    const key = `${event.pubkey}:${vineId}`;
-    videoMap.set(key, {
-      id: event.id,
-      pubkey: event.pubkey,
-      kind: SHORT_VIDEO_KIND,
-      createdAt: event.created_at,
-      originalVineTimestamp: getOriginalVineTimestamp(event),
-      content: event.content,
-      videoUrl: videoEvent.videoMetadata.url,
-      fallbackVideoUrls: videoEvent.videoMetadata?.fallbackUrls,
-      hlsUrl: videoEvent.videoMetadata?.hlsUrl,
-      thumbnailUrl: getThumbnailUrl(videoEvent),
-      title: videoEvent.title,
-      duration: videoEvent.videoMetadata?.duration,
-      hashtags: videoEvent.hashtags || [],
-      vineId,
-      loopCount: getLoopCount(event),
-      likeCount: getOriginalLikeCount(event),
-      repostCount: getOriginalRepostCount(event),
-      commentCount: getOriginalCommentCount(event),
-      proofMode: getProofModeData(event),
-      origin: getOriginPlatform(event),
-      isVineMigrated: isVineMigrated(event),
-      reposts: [] // List videos don't include repost data
-    });
-  });
-
-  // Return videos in the order they appear in the list
-  const orderedVideos: ParsedVideoData[] = [];
-  coordinates.forEach(coord => {
-    const [_, pubkey, dTag] = coord.split(':');
-    const key = `${pubkey}:${dTag}`;
-    const video = videoMap.get(key);
-    if (video) {
-      orderedVideos.push(video);
-    }
-  });
-
-  return orderedVideos;
-}
 
 const PlayOrderIcon = ({ order }: { order?: PlayOrder }) => {
   switch (order) {
@@ -265,7 +170,7 @@ export default function ListDetailPage() {
 
   // Fetch videos in the list
   const { data: videos, isLoading: videosLoading } = useQuery({
-    queryKey: ['list-videos', pubkey, listId, list?.videoCoordinates],
+    queryKey: ['list-videos', pubkey, listId, list?.members],
     queryFn: async (context) => {
       if (!list) return [];
 
@@ -274,7 +179,7 @@ export default function ListDetailPage() {
         AbortSignal.timeout(10000)
       ]);
 
-      return fetchListVideos(nostr, list.videoCoordinates, signal);
+      return fetchListVideos(nostr, list.members, signal);
     },
     enabled: !!list
   });
@@ -394,7 +299,7 @@ export default function ListDetailPage() {
                 <div className="flex items-center gap-4 text-sm text-muted-foreground flex-wrap">
                   <div className="flex items-center gap-1">
                     <Video className="h-4 w-4" />
-                    <span>{t('listDetailPage.videoCount', { count: list.videoCoordinates.length })}</span>
+                    <span>{t('listDetailPage.videoCount', { count: list.memberCount })}</span>
                   </div>
                   <div className="flex items-center gap-1">
                     <Clock className="h-4 w-4" />
@@ -463,7 +368,6 @@ export default function ListDetailPage() {
             {permissions.canEditContent ? (
               <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
                 {videos.map((video) => {
-                  const videoCoord = `${video.kind}:${video.pubkey}:${video.vineId}`;
                   return (
                     <div key={video.id} className="relative group">
                       <VideoGrid
@@ -491,7 +395,7 @@ export default function ListDetailPage() {
                                   await removeVideo.mutateAsync({
                                     listId: list.id,
                                     ownerPubkey: listOwnerPubkey || list.pubkey,
-                                    videoCoordinate: videoCoord
+                                    videoMember: video.listMember,
                                   });
                                   toast({
                                     title: t('listDetailPage.videoRemovedTitle'),

--- a/src/pages/ListsPage.tsx
+++ b/src/pages/ListsPage.tsx
@@ -76,7 +76,7 @@ function ListCard({ list }: { list: VideoListModel }) {
           <div className="flex items-center gap-4 text-sm">
             <div className="flex items-center gap-1">
               <Video className="h-4 w-4 text-muted-foreground" />
-              <span>{t('addToListDialog.videoCount', { count: list.memberCount })}</span>
+              <span>{t('listDetailPage.videoCount', { count: list.memberCount })}</span>
             </div>
             <div className="flex items-center gap-1">
               <Clock className="h-4 w-4 text-muted-foreground" />

--- a/src/pages/ListsPage.tsx
+++ b/src/pages/ListsPage.tsx
@@ -22,18 +22,10 @@ import { CreateListDialog } from '@/components/CreateListDialog';
 import { CreatePeopleListDialog } from '@/components/CreatePeopleListDialog';
 import { formatDistanceToNow } from 'date-fns';
 import { getSafeProfileImage } from '@/lib/imageUtils';
+import type { VideoList as VideoListModel } from '@/lib/parseVideoListFromEvent';
 
-interface ListCardProps {
-  id: string;
-  name: string;
-  description?: string;
-  image?: string;
-  pubkey: string;
-  createdAt: number;
-  videoCoordinates: string[];
-}
-
-function ListCard({ list }: { list: ListCardProps }) {
+function ListCard({ list }: { list: VideoListModel }) {
+  const { t } = useTranslation();
   const author = useAuthor(list.pubkey);
   const authorMetadata = author.data?.metadata;
   const authorName = authorMetadata?.name || genUserName(list.pubkey);
@@ -84,7 +76,7 @@ function ListCard({ list }: { list: ListCardProps }) {
           <div className="flex items-center gap-4 text-sm">
             <div className="flex items-center gap-1">
               <Video className="h-4 w-4 text-muted-foreground" />
-              <span>{list.videoCoordinates.length} videos</span>
+              <span>{t('addToListDialog.videoCount', { count: list.memberCount })}</span>
             </div>
             <div className="flex items-center gap-1">
               <Clock className="h-4 w-4 text-muted-foreground" />

--- a/src/pages/ProfileListsPage.test.tsx
+++ b/src/pages/ProfileListsPage.test.tsx
@@ -39,7 +39,17 @@ describe('ProfileListsPage', () => {
       refetch: mockRefetchPeople,
     });
     mockUseVideoLists.mockReturnValue({
-      data: [{ id: 'videos', name: 'My videos', pubkey: OWNER, createdAt: 10, videoCoordinates: [], public: true }],
+      data: [{
+        id: 'videos',
+        name: 'My videos',
+        pubkey: OWNER,
+        createdAt: 10,
+        members: [],
+        memberCount: 0,
+        videoCoordinates: [],
+        public: true,
+        sourceTags: [],
+      }],
       isLoading: false,
       isError: false,
       refetch: mockRefetchVideos,


### PR DESCRIPTION
## Summary

- Parse kind 30005 video-list membership from ordered `e` and `a` tags, including mobile tag spellings for `playorder` and `thumbnail`.
- Preserve source list tags when editing lists so web add/remove/rename no longer drops mobile-created `e` members.
- Resolve list detail videos from chunked event-id filters plus coordinate filters, then order and dedupe by the original list members.
- Switch list counts and filters to `memberCount` so e-tag lists no longer show as empty.

> Avoid naming corporate partners, customers, or other sensitive external brands in this PR title or body. Use generic descriptors unless a maintainer explicitly approves the public reference.

## Motivation

- Real Divine video lists are mostly stored with `e` tag membership. Web only read `a` tags, so lists rendered as 0 videos and web edits could republish a replaceable list without its existing members.

## Related Issue

- Closes #604

## Testing

- [x] `npm run test`
- [x] Manual verification completed: reviewed parser, mutation, count, and list-detail fetch paths in the diff.

## Visuals

- [ ] UI change with screenshots/video attached
- [x] No visual change
- [x] Visuals and text avoid sensitive external brand or partner names unless explicitly approved