### PR TITLE
fix(lists): avoid coordinate query truncation

### DIFF
--- a/src/components/PinnedVideosSection.tsx
+++ b/src/components/PinnedVideosSection.tsx
@@ -11,10 +11,9 @@ import { VideoGrid } from '@/components/VideoGrid';
 import { SectionHeader } from '@/components/brand/SectionHeader';
 import { Button } from '@/components/ui/button';
 import { useToast } from '@/hooks/useToast';
-import { parseVideoEvent, getVineId, getThumbnailUrl, getOriginalVineTimestamp, getLoopCount, getProofModeData, getOriginPlatform, isVineMigrated, getOriginalLikeCount, getOriginalRepostCount, getOriginalCommentCount } from '@/lib/videoParser';
-import { SHORT_VIDEO_KIND, VIDEO_KINDS } from '@/types/video';
-import type { ParsedVideoData } from '@/types/video';
-import type { NostrFilter } from '@nostrify/nostrify';
+import { buildPinnedVideoFilters, resolvePinnedVideosFromEvents } from '@/lib/pinnedVideoResolution';
+import { parseVideoCoordinate } from '@/lib/videoCoordinates';
+import { VIDEO_KINDS, type ParsedVideoData } from '@/types/video';
 
 interface PinnedVideosSectionProps {
   pubkey: string;
@@ -39,78 +38,11 @@ export function PinnedVideosSection({ pubkey, isOwnProfile }: PinnedVideosSectio
         AbortSignal.timeout(8000),
       ]);
 
-      // Parse coordinates into pubkey + d-tag groups
-      const pubkeyGroups = new Map<string, string[]>();
-      coordinates.forEach(coord => {
-        const [kind, pk, dTag] = coord.split(':');
-        const kindNum = parseInt(kind, 10);
-        if (VIDEO_KINDS.includes(kindNum) && pk && dTag) {
-          if (!pubkeyGroups.has(pk)) pubkeyGroups.set(pk, []);
-          pubkeyGroups.get(pk)!.push(dTag);
-        }
-      });
-
-      // Build filters grouped by pubkey
-      const filters: NostrFilter[] = [];
-      pubkeyGroups.forEach((dTags, pk) => {
-        filters.push({
-          kinds: VIDEO_KINDS,
-          authors: [pk],
-          '#d': dTags,
-          limit: dTags.length,
-        });
-      });
-
+      const filters = buildPinnedVideoFilters(coordinates);
       if (filters.length === 0) return [];
 
       const events = await nostr.query(filters, { signal });
-
-      // Parse events into a map keyed by pubkey:d-tag
-      const videoMap = new Map<string, ParsedVideoData>();
-      events.forEach(event => {
-        const vineId = getVineId(event);
-        if (!vineId) return;
-
-        const videoEvent = parseVideoEvent(event);
-        if (!videoEvent?.videoMetadata?.url) return;
-
-        const key = `${event.pubkey}:${vineId}`;
-        videoMap.set(key, {
-          id: event.id,
-          pubkey: event.pubkey,
-          kind: SHORT_VIDEO_KIND,
-          createdAt: event.created_at,
-          originalVineTimestamp: getOriginalVineTimestamp(event),
-          content: event.content,
-          videoUrl: videoEvent.videoMetadata.url,
-          fallbackVideoUrls: videoEvent.videoMetadata?.fallbackUrls,
-          hlsUrl: videoEvent.videoMetadata?.hlsUrl,
-          thumbnailUrl: getThumbnailUrl(videoEvent),
-          title: videoEvent.title,
-          duration: videoEvent.videoMetadata?.duration,
-          hashtags: videoEvent.hashtags || [],
-          vineId,
-          loopCount: getLoopCount(event),
-          likeCount: getOriginalLikeCount(event),
-          repostCount: getOriginalRepostCount(event),
-          commentCount: getOriginalCommentCount(event),
-          proofMode: getProofModeData(event),
-          origin: getOriginPlatform(event),
-          isVineMigrated: isVineMigrated(event),
-          reposts: [],
-        });
-      });
-
-      // Return in pin-list order, skipping unresolvable coordinates
-      const ordered: ParsedVideoData[] = [];
-      coordinates.forEach(coord => {
-        const parts = coord.split(':');
-        const key = `${parts[1]}:${parts[2]}`;
-        const video = videoMap.get(key);
-        if (video) ordered.push(video);
-      });
-
-      return ordered;
+      return resolvePinnedVideosFromEvents(coordinates, events);
     },
     enabled: coordinates.length > 0,
     staleTime: 60000,
@@ -121,9 +53,8 @@ export function PinnedVideosSection({ pubkey, isOwnProfile }: PinnedVideosSectio
   const coordinateForVideo = useMemo(() => {
     const map = new Map<string, string>();
     coordinates.forEach(coord => {
-      const parts = coord.split(':');
-      // Map vineId (d-tag) to full coordinate for unpin
-      map.set(parts[2], coord);
+      const coordinate = parseVideoCoordinate(coord, VIDEO_KINDS);
+      if (coordinate) map.set(coordinate.dTag, coord);
     });
     return map;
   }, [coordinates]);

--- a/src/lib/listVideos.test.ts
+++ b/src/lib/listVideos.test.ts
@@ -122,4 +122,27 @@ describe('fetchListVideos', () => {
     expect(videos.map(video => video.id)).toEqual([firstNew.id, second.id]);
     expect(videos[0]?.title).toBe('New first');
   });
+
+  it('breaks a same-timestamp revision tie by keeping the lowest event id', async () => {
+    const lowerId = videoEvent({
+      id: '4'.repeat(64),
+      created_at: 200,
+      tags: [['d', 'first'], ['title', 'Lower id']],
+    });
+    const higherId = videoEvent({
+      id: '7'.repeat(64),
+      created_at: 200,
+      tags: [['d', 'first'], ['title', 'Higher id']],
+    });
+    const members: VideoListMember[] = [
+      { type: 'a', value: `${SHORT_VIDEO_KIND}:${OWNER}:first` },
+    ];
+    // Return the higher id first so selection cannot depend on query order.
+    const query = vi.fn().mockResolvedValue([higherId, lowerId]);
+
+    const videos = await fetchListVideos({ query }, members, new AbortController().signal);
+
+    expect(videos.map(video => video.id)).toEqual([lowerId.id]);
+    expect(videos[0]?.title).toBe('Lower id');
+  });
 });

--- a/src/lib/listVideos.test.ts
+++ b/src/lib/listVideos.test.ts
@@ -11,17 +11,18 @@ const OWNER = 'a'.repeat(64);
 function videoEvent(overrides: Partial<NostrEvent> = {}): NostrEvent {
   const id = overrides.id ?? '1'.repeat(64);
   const dTag = overrides.tags?.find(tag => tag[0] === 'd')?.[1] ?? `d-${id[0]}`;
+  const title = overrides.tags?.find(tag => tag[0] === 'title')?.[1] ?? `Video ${dTag}`;
   return {
     ...overrides,
     id,
     pubkey: overrides.pubkey ?? OWNER,
     kind: overrides.kind ?? SHORT_VIDEO_KIND,
-    created_at: 1700,
+    created_at: overrides.created_at ?? 1700,
     tags: [
       ['d', dTag],
-      ['title', `Video ${dTag}`],
+      ['title', title],
       ['imeta', `url https://media.example/${dTag}.mp4`, 'm video/mp4'],
-      ...(overrides.tags?.filter(tag => tag[0] !== 'd') ?? []),
+      ...(overrides.tags?.filter(tag => tag[0] !== 'd' && tag[0] !== 'title') ?? []),
     ],
     content: '',
     sig: 's'.repeat(128),
@@ -38,8 +39,30 @@ describe('fetchListVideos', () => {
 
     const filters = query.mock.calls[0][0] as NostrFilter[];
     expect(filters).toHaveLength(2);
-    expect(filters[0]).toMatchObject({ kinds: LIST_VIDEO_KINDS, ids: ids.slice(0, 200), limit: 200 });
-    expect(filters[1]).toMatchObject({ kinds: LIST_VIDEO_KINDS, ids: ids.slice(200), limit: 1 });
+    expect(filters[0]).toMatchObject({ kinds: LIST_VIDEO_KINDS, ids: ids.slice(0, 200) });
+    expect(filters[1]).toMatchObject({ kinds: LIST_VIDEO_KINDS, ids: ids.slice(200) });
+    expect(filters[0]).not.toHaveProperty('limit');
+    expect(filters[1]).not.toHaveProperty('limit');
+  });
+
+  it('builds addressable filters without exact-count relay limits', async () => {
+    const members: VideoListMember[] = [
+      { type: 'a', value: `${SHORT_VIDEO_KIND}:${OWNER}:first` },
+      { type: 'a', value: `${SHORT_VIDEO_KIND}:${OWNER}:second` },
+      { type: 'a', value: `${SHORT_VIDEO_KIND}:${OWNER}:second` },
+    ];
+    const query = vi.fn().mockResolvedValue([]);
+
+    await fetchListVideos({ query }, members, new AbortController().signal);
+
+    const filters = query.mock.calls[0][0] as NostrFilter[];
+    expect(filters).toEqual([
+      {
+        kinds: LIST_VIDEO_KINDS,
+        authors: [OWNER],
+        '#d': ['first', 'second'],
+      },
+    ]);
   });
 
   it('merges e and a results, dedupes, and returns videos in member order', async () => {
@@ -70,5 +93,33 @@ describe('fetchListVideos', () => {
     const videos = await fetchListVideos({ query }, members, new AbortController().signal);
 
     expect(videos.map(video => video.id)).toEqual([eventId]);
+  });
+
+  it('keeps every resolvable coordinate and picks the newest revision', async () => {
+    const firstOld = videoEvent({
+      id: '4'.repeat(64),
+      created_at: 100,
+      tags: [['d', 'first'], ['title', 'Old first']],
+    });
+    const firstNew = videoEvent({
+      id: '5'.repeat(64),
+      created_at: 200,
+      tags: [['d', 'first'], ['title', 'New first']],
+    });
+    const second = videoEvent({
+      id: '6'.repeat(64),
+      created_at: 150,
+      tags: [['d', 'second']],
+    });
+    const members: VideoListMember[] = [
+      { type: 'a', value: `${SHORT_VIDEO_KIND}:${OWNER}:first` },
+      { type: 'a', value: `${SHORT_VIDEO_KIND}:${OWNER}:second` },
+    ];
+    const query = vi.fn().mockResolvedValue([firstNew, second, firstOld]);
+
+    const videos = await fetchListVideos({ query }, members, new AbortController().signal);
+
+    expect(videos.map(video => video.id)).toEqual([firstNew.id, second.id]);
+    expect(videos[0]?.title).toBe('New first');
   });
 });

--- a/src/lib/listVideos.ts
+++ b/src/lib/listVideos.ts
@@ -6,6 +6,8 @@ import {
   LIST_VIDEO_KINDS,
   type VideoListMember,
 } from '@/lib/parseVideoListFromEvent';
+import { isNewerParsedVideo } from '@/lib/parsedVideoSelection';
+import { parseVideoCoordinate, videoCoordinateKey } from '@/lib/videoCoordinates';
 import {
   getLoopCount,
   getOriginalCommentCount,
@@ -24,6 +26,7 @@ export interface ListVideoData extends ParsedVideoData {
   listMember: VideoListMember;
 }
 
+// Keep id filters comfortably below common relay request-size limits.
 const IDS_CHUNK_SIZE = 200;
 
 function chunk<T>(items: T[], size: number): T[][] {
@@ -36,9 +39,8 @@ function chunk<T>(items: T[], size: number): T[][] {
 
 function coordinateKey(member: VideoListMember): string | null {
   if (member.type !== 'a') return null;
-  const [kind, pubkey, dTag] = member.value.split(':');
-  if (!LIST_VIDEO_KINDS.includes(Number(kind)) || !pubkey || !dTag) return null;
-  return `${pubkey}:${dTag}`;
+  const coordinate = parseVideoCoordinate(member.value, LIST_VIDEO_KINDS);
+  return coordinate ? videoCoordinateKey(coordinate) : null;
 }
 
 function buildListVideoFilters(members: VideoListMember[]): NostrFilter[] {
@@ -51,24 +53,26 @@ function buildListVideoFilters(members: VideoListMember[]): NostrFilter[] {
     filters.push({
       kinds: LIST_VIDEO_KINDS,
       ids,
-      limit: ids.length,
     });
   }
 
   const pubkeyGroups = new Map<string, string[]>();
   for (const member of members) {
     if (member.type !== 'a') continue;
-    const [kind, pubkey, dTag] = member.value.split(':');
-    if (!LIST_VIDEO_KINDS.includes(Number(kind)) || !pubkey || !dTag) continue;
-    pubkeyGroups.set(pubkey, [...(pubkeyGroups.get(pubkey) ?? []), dTag]);
+    const coordinate = parseVideoCoordinate(member.value, LIST_VIDEO_KINDS);
+    if (!coordinate) continue;
+    pubkeyGroups.set(coordinate.pubkey, [
+      ...(pubkeyGroups.get(coordinate.pubkey) ?? []),
+      coordinate.dTag,
+    ]);
   }
 
   for (const [pubkey, dTags] of pubkeyGroups) {
+    const uniqueDTags = Array.from(new Set(dTags));
     filters.push({
       kinds: LIST_VIDEO_KINDS,
       authors: [pubkey],
-      '#d': Array.from(new Set(dTags)),
-      limit: dTags.length,
+      '#d': uniqueDTags,
     });
   }
 
@@ -127,7 +131,13 @@ export async function fetchListVideos(
     if (!video) continue;
 
     eventMap.set(event.id, video);
-    coordinateMap.set(`${event.pubkey}:${video.vineId}`, video);
+    if (!video.vineId) continue;
+
+    const key = videoCoordinateKey({ pubkey: event.pubkey, dTag: video.vineId });
+    const existing = coordinateMap.get(key);
+    if (!existing || isNewerParsedVideo(video, existing)) {
+      coordinateMap.set(key, video);
+    }
   }
 
   const orderedVideos: ListVideoData[] = [];

--- a/src/lib/listVideos.ts
+++ b/src/lib/listVideos.ts
@@ -1,26 +1,14 @@
 // ABOUTME: Resolves ordered video list members into parsed video grid data
 
 import type { NostrEvent, NostrFilter } from '@nostrify/nostrify';
-import { SHORT_VIDEO_KIND, type ParsedVideoData } from '@/types/video';
+import type { ParsedVideoData } from '@/types/video';
 import {
   LIST_VIDEO_KINDS,
   type VideoListMember,
 } from '@/lib/parseVideoListFromEvent';
+import { parseVideoDataFromEvent } from '@/lib/parsedVideoData';
 import { isNewerParsedVideo } from '@/lib/parsedVideoSelection';
 import { parseVideoCoordinate, videoCoordinateKey } from '@/lib/videoCoordinates';
-import {
-  getLoopCount,
-  getOriginalCommentCount,
-  getOriginalLikeCount,
-  getOriginalRepostCount,
-  getOriginalVineTimestamp,
-  getOriginPlatform,
-  getProofModeData,
-  getThumbnailUrl,
-  getVineId,
-  isVineMigrated,
-  parseVideoEvent,
-} from '@/lib/videoParser';
 
 export interface ListVideoData extends ParsedVideoData {
   listMember: VideoListMember;
@@ -79,39 +67,6 @@ function buildListVideoFilters(members: VideoListMember[]): NostrFilter[] {
   return filters;
 }
 
-function parseListVideoEvent(event: NostrEvent): ParsedVideoData | null {
-  const vineId = getVineId(event);
-  if (!vineId) return null;
-
-  const videoEvent = parseVideoEvent(event);
-  if (!videoEvent?.videoMetadata?.url) return null;
-
-  return {
-    id: event.id,
-    pubkey: event.pubkey,
-    kind: SHORT_VIDEO_KIND,
-    createdAt: event.created_at,
-    originalVineTimestamp: getOriginalVineTimestamp(event),
-    content: event.content,
-    videoUrl: videoEvent.videoMetadata.url,
-    fallbackVideoUrls: videoEvent.videoMetadata?.fallbackUrls,
-    hlsUrl: videoEvent.videoMetadata?.hlsUrl,
-    thumbnailUrl: getThumbnailUrl(videoEvent),
-    title: videoEvent.title,
-    duration: videoEvent.videoMetadata?.duration,
-    hashtags: videoEvent.hashtags || [],
-    vineId,
-    loopCount: getLoopCount(event),
-    likeCount: getOriginalLikeCount(event),
-    repostCount: getOriginalRepostCount(event),
-    commentCount: getOriginalCommentCount(event),
-    proofMode: getProofModeData(event),
-    origin: getOriginPlatform(event),
-    isVineMigrated: isVineMigrated(event),
-    reposts: [],
-  };
-}
-
 export async function fetchListVideos(
   nostr: { query: (filters: NostrFilter[], options: { signal: AbortSignal }) => Promise<NostrEvent[]> },
   members: VideoListMember[],
@@ -127,7 +82,7 @@ export async function fetchListVideos(
   const coordinateMap = new Map<string, ParsedVideoData>();
 
   for (const event of events) {
-    const video = parseListVideoEvent(event);
+    const video = parseVideoDataFromEvent(event);
     if (!video) continue;
 
     eventMap.set(event.id, video);

--- a/src/lib/parsedVideoData.ts
+++ b/src/lib/parsedVideoData.ts
@@ -1,0 +1,54 @@
+// ABOUTME: Maps a Nostr video event into ParsedVideoData grid rows
+
+import type { NostrEvent } from '@nostrify/nostrify';
+import { SHORT_VIDEO_KIND, type ParsedVideoData } from '@/types/video';
+import {
+  getLoopCount,
+  getOriginalCommentCount,
+  getOriginalLikeCount,
+  getOriginalRepostCount,
+  getOriginalVineTimestamp,
+  getOriginPlatform,
+  getProofModeData,
+  getThumbnailUrl,
+  getVineId,
+  isVineMigrated,
+  parseVideoEvent,
+} from '@/lib/videoParser';
+
+/**
+ * Parse a video event into the ParsedVideoData shape used by list and pinned
+ * grids. Returns null when the event has no d-tag or no playable media URL.
+ */
+export function parseVideoDataFromEvent(event: NostrEvent): ParsedVideoData | null {
+  const vineId = getVineId(event);
+  if (!vineId) return null;
+
+  const videoEvent = parseVideoEvent(event);
+  if (!videoEvent?.videoMetadata?.url) return null;
+
+  return {
+    id: event.id,
+    pubkey: event.pubkey,
+    kind: SHORT_VIDEO_KIND,
+    createdAt: event.created_at,
+    originalVineTimestamp: getOriginalVineTimestamp(event),
+    content: event.content,
+    videoUrl: videoEvent.videoMetadata.url,
+    fallbackVideoUrls: videoEvent.videoMetadata?.fallbackUrls,
+    hlsUrl: videoEvent.videoMetadata?.hlsUrl,
+    thumbnailUrl: getThumbnailUrl(videoEvent),
+    title: videoEvent.title,
+    duration: videoEvent.videoMetadata?.duration,
+    hashtags: videoEvent.hashtags || [],
+    vineId,
+    loopCount: getLoopCount(event),
+    likeCount: getOriginalLikeCount(event),
+    repostCount: getOriginalRepostCount(event),
+    commentCount: getOriginalCommentCount(event),
+    proofMode: getProofModeData(event),
+    origin: getOriginPlatform(event),
+    isVineMigrated: isVineMigrated(event),
+    reposts: [],
+  };
+}

--- a/src/lib/parsedVideoSelection.ts
+++ b/src/lib/parsedVideoSelection.ts
@@ -1,0 +1,8 @@
+// ABOUTME: Shared deterministic selection helpers for parsed video data
+
+import type { ParsedVideoData } from '@/types/video';
+
+export function isNewerParsedVideo(candidate: ParsedVideoData, existing: ParsedVideoData): boolean {
+  return candidate.createdAt > existing.createdAt ||
+    (candidate.createdAt === existing.createdAt && candidate.id < existing.id);
+}

--- a/src/lib/pinnedVideoResolution.test.ts
+++ b/src/lib/pinnedVideoResolution.test.ts
@@ -76,4 +76,26 @@ describe('resolvePinnedVideosFromEvents', () => {
     expect(videos.map(video => video.id)).toEqual([second.id, firstNew.id]);
     expect(videos[1]?.title).toBe('New first');
   });
+
+  it('breaks a same-timestamp revision tie by keeping the lowest event id', () => {
+    const lowerId = videoEvent({
+      id: '2'.repeat(64),
+      created_at: 200,
+      tags: [['d', 'first'], ['title', 'Lower id']],
+    });
+    const higherId = videoEvent({
+      id: '9'.repeat(64),
+      created_at: 200,
+      tags: [['d', 'first'], ['title', 'Higher id']],
+    });
+
+    // Return the higher id first so selection cannot depend on query order.
+    const videos = resolvePinnedVideosFromEvents(
+      [`${SHORT_VIDEO_KIND}:${OWNER}:first`],
+      [higherId, lowerId],
+    );
+
+    expect(videos.map(video => video.id)).toEqual([lowerId.id]);
+    expect(videos[0]?.title).toBe('Lower id');
+  });
 });

--- a/src/lib/pinnedVideoResolution.test.ts
+++ b/src/lib/pinnedVideoResolution.test.ts
@@ -1,0 +1,79 @@
+// ABOUTME: Unit tests for resolving pinned-video coordinates into video data
+
+import { describe, expect, it } from 'vitest';
+import type { NostrEvent } from '@nostrify/nostrify';
+import { SHORT_VIDEO_KIND, VIDEO_KINDS } from '@/types/video';
+import { buildPinnedVideoFilters, resolvePinnedVideosFromEvents } from './pinnedVideoResolution';
+
+const OWNER = 'b'.repeat(64);
+
+function videoEvent(overrides: Partial<NostrEvent> = {}): NostrEvent {
+  const id = overrides.id ?? '1'.repeat(64);
+  const dTag = overrides.tags?.find(tag => tag[0] === 'd')?.[1] ?? `d-${id[0]}`;
+  const title = overrides.tags?.find(tag => tag[0] === 'title')?.[1] ?? `Video ${dTag}`;
+  return {
+    ...overrides,
+    id,
+    pubkey: overrides.pubkey ?? OWNER,
+    kind: overrides.kind ?? SHORT_VIDEO_KIND,
+    created_at: overrides.created_at ?? 1700,
+    tags: [
+      ['d', dTag],
+      ['title', title],
+      ['imeta', `url https://media.example/${dTag}.mp4`, 'm video/mp4'],
+      ...(overrides.tags?.filter(tag => tag[0] !== 'd' && tag[0] !== 'title') ?? []),
+    ],
+    content: '',
+    sig: 's'.repeat(128),
+  };
+}
+
+describe('buildPinnedVideoFilters', () => {
+  it('groups coordinates without exact-count relay limits', () => {
+    const filters = buildPinnedVideoFilters([
+      `${SHORT_VIDEO_KIND}:${OWNER}:first`,
+      `${SHORT_VIDEO_KIND}:${OWNER}:second`,
+      `${SHORT_VIDEO_KIND}:${OWNER}:second`,
+      `1:${OWNER}:article`,
+    ]);
+
+    expect(filters).toEqual([
+      {
+        kinds: VIDEO_KINDS,
+        authors: [OWNER],
+        '#d': ['first', 'second'],
+      },
+    ]);
+  });
+});
+
+describe('resolvePinnedVideosFromEvents', () => {
+  it('keeps pin order and picks the newest revision per coordinate', () => {
+    const firstOld = videoEvent({
+      id: '2'.repeat(64),
+      created_at: 100,
+      tags: [['d', 'first'], ['title', 'Old first']],
+    });
+    const firstNew = videoEvent({
+      id: '3'.repeat(64),
+      created_at: 200,
+      tags: [['d', 'first'], ['title', 'New first']],
+    });
+    const second = videoEvent({
+      id: '4'.repeat(64),
+      created_at: 150,
+      tags: [['d', 'second']],
+    });
+
+    const videos = resolvePinnedVideosFromEvents(
+      [
+        `${SHORT_VIDEO_KIND}:${OWNER}:second`,
+        `${SHORT_VIDEO_KIND}:${OWNER}:first`,
+      ],
+      [firstNew, second, firstOld],
+    );
+
+    expect(videos.map(video => video.id)).toEqual([second.id, firstNew.id]);
+    expect(videos[1]?.title).toBe('New first');
+  });
+});

--- a/src/lib/pinnedVideoResolution.ts
+++ b/src/lib/pinnedVideoResolution.ts
@@ -1,0 +1,97 @@
+// ABOUTME: Resolves pinned-video coordinates into ordered parsed video data
+
+import type { NostrEvent, NostrFilter } from '@nostrify/nostrify';
+import { SHORT_VIDEO_KIND, VIDEO_KINDS, type ParsedVideoData } from '@/types/video';
+import { isNewerParsedVideo } from '@/lib/parsedVideoSelection';
+import { parseVideoCoordinate, videoCoordinateKey } from '@/lib/videoCoordinates';
+import {
+  getLoopCount,
+  getOriginalCommentCount,
+  getOriginalLikeCount,
+  getOriginalRepostCount,
+  getOriginalVineTimestamp,
+  getOriginPlatform,
+  getProofModeData,
+  getThumbnailUrl,
+  getVineId,
+  isVineMigrated,
+  parseVideoEvent,
+} from '@/lib/videoParser';
+
+export function buildPinnedVideoFilters(coordinates: string[]): NostrFilter[] {
+  const pubkeyGroups = new Map<string, string[]>();
+
+  for (const value of coordinates) {
+    const coordinate = parseVideoCoordinate(value, VIDEO_KINDS);
+    if (!coordinate) continue;
+    pubkeyGroups.set(coordinate.pubkey, [
+      ...(pubkeyGroups.get(coordinate.pubkey) ?? []),
+      coordinate.dTag,
+    ]);
+  }
+
+  return Array.from(pubkeyGroups.entries()).map(([pubkey, dTags]) => ({
+    kinds: VIDEO_KINDS,
+    authors: [pubkey],
+    '#d': Array.from(new Set(dTags)),
+  }));
+}
+
+function parsePinnedVideoEvent(event: NostrEvent): ParsedVideoData | null {
+  const vineId = getVineId(event);
+  if (!vineId) return null;
+
+  const videoEvent = parseVideoEvent(event);
+  if (!videoEvent?.videoMetadata?.url) return null;
+
+  return {
+    id: event.id,
+    pubkey: event.pubkey,
+    kind: SHORT_VIDEO_KIND,
+    createdAt: event.created_at,
+    originalVineTimestamp: getOriginalVineTimestamp(event),
+    content: event.content,
+    videoUrl: videoEvent.videoMetadata.url,
+    fallbackVideoUrls: videoEvent.videoMetadata?.fallbackUrls,
+    hlsUrl: videoEvent.videoMetadata?.hlsUrl,
+    thumbnailUrl: getThumbnailUrl(videoEvent),
+    title: videoEvent.title,
+    duration: videoEvent.videoMetadata?.duration,
+    hashtags: videoEvent.hashtags || [],
+    vineId,
+    loopCount: getLoopCount(event),
+    likeCount: getOriginalLikeCount(event),
+    repostCount: getOriginalRepostCount(event),
+    commentCount: getOriginalCommentCount(event),
+    proofMode: getProofModeData(event),
+    origin: getOriginPlatform(event),
+    isVineMigrated: isVineMigrated(event),
+    reposts: [],
+  };
+}
+
+export function resolvePinnedVideosFromEvents(
+  coordinates: string[],
+  events: NostrEvent[],
+): ParsedVideoData[] {
+  const videoMap = new Map<string, ParsedVideoData>();
+
+  for (const event of events) {
+    const video = parsePinnedVideoEvent(event);
+    if (!video?.vineId) continue;
+
+    const key = videoCoordinateKey({ pubkey: event.pubkey, dTag: video.vineId });
+    const existing = videoMap.get(key);
+    if (!existing || isNewerParsedVideo(video, existing)) {
+      videoMap.set(key, video);
+    }
+  }
+
+  return coordinates.flatMap((value) => {
+    const coordinate = parseVideoCoordinate(value, VIDEO_KINDS);
+    if (!coordinate) return [];
+
+    const video = videoMap.get(videoCoordinateKey(coordinate));
+    return video ? [video] : [];
+  });
+}

--- a/src/lib/pinnedVideoResolution.ts
+++ b/src/lib/pinnedVideoResolution.ts
@@ -1,22 +1,10 @@
 // ABOUTME: Resolves pinned-video coordinates into ordered parsed video data
 
 import type { NostrEvent, NostrFilter } from '@nostrify/nostrify';
-import { SHORT_VIDEO_KIND, VIDEO_KINDS, type ParsedVideoData } from '@/types/video';
+import { VIDEO_KINDS, type ParsedVideoData } from '@/types/video';
+import { parseVideoDataFromEvent } from '@/lib/parsedVideoData';
 import { isNewerParsedVideo } from '@/lib/parsedVideoSelection';
 import { parseVideoCoordinate, videoCoordinateKey } from '@/lib/videoCoordinates';
-import {
-  getLoopCount,
-  getOriginalCommentCount,
-  getOriginalLikeCount,
-  getOriginalRepostCount,
-  getOriginalVineTimestamp,
-  getOriginPlatform,
-  getProofModeData,
-  getThumbnailUrl,
-  getVineId,
-  isVineMigrated,
-  parseVideoEvent,
-} from '@/lib/videoParser';
 
 export function buildPinnedVideoFilters(coordinates: string[]): NostrFilter[] {
   const pubkeyGroups = new Map<string, string[]>();
@@ -37,39 +25,6 @@ export function buildPinnedVideoFilters(coordinates: string[]): NostrFilter[] {
   }));
 }
 
-function parsePinnedVideoEvent(event: NostrEvent): ParsedVideoData | null {
-  const vineId = getVineId(event);
-  if (!vineId) return null;
-
-  const videoEvent = parseVideoEvent(event);
-  if (!videoEvent?.videoMetadata?.url) return null;
-
-  return {
-    id: event.id,
-    pubkey: event.pubkey,
-    kind: SHORT_VIDEO_KIND,
-    createdAt: event.created_at,
-    originalVineTimestamp: getOriginalVineTimestamp(event),
-    content: event.content,
-    videoUrl: videoEvent.videoMetadata.url,
-    fallbackVideoUrls: videoEvent.videoMetadata?.fallbackUrls,
-    hlsUrl: videoEvent.videoMetadata?.hlsUrl,
-    thumbnailUrl: getThumbnailUrl(videoEvent),
-    title: videoEvent.title,
-    duration: videoEvent.videoMetadata?.duration,
-    hashtags: videoEvent.hashtags || [],
-    vineId,
-    loopCount: getLoopCount(event),
-    likeCount: getOriginalLikeCount(event),
-    repostCount: getOriginalRepostCount(event),
-    commentCount: getOriginalCommentCount(event),
-    proofMode: getProofModeData(event),
-    origin: getOriginPlatform(event),
-    isVineMigrated: isVineMigrated(event),
-    reposts: [],
-  };
-}
-
 export function resolvePinnedVideosFromEvents(
   coordinates: string[],
   events: NostrEvent[],
@@ -77,7 +32,7 @@ export function resolvePinnedVideosFromEvents(
   const videoMap = new Map<string, ParsedVideoData>();
 
   for (const event of events) {
-    const video = parsePinnedVideoEvent(event);
+    const video = parseVideoDataFromEvent(event);
     if (!video?.vineId) continue;
 
     const key = videoCoordinateKey({ pubkey: event.pubkey, dTag: video.vineId });

--- a/src/lib/videoCoordinates.ts
+++ b/src/lib/videoCoordinates.ts
@@ -1,0 +1,24 @@
+// ABOUTME: Shared parsing helpers for Nostr addressable video coordinates
+
+export interface VideoCoordinate {
+  kind: number;
+  pubkey: string;
+  dTag: string;
+}
+
+export function parseVideoCoordinate(value: string, allowedKinds: readonly number[]): VideoCoordinate | null {
+  const firstSeparator = value.indexOf(':');
+  const secondSeparator = value.indexOf(':', firstSeparator + 1);
+  if (firstSeparator < 0 || secondSeparator < 0) return null;
+
+  const kind = Number(value.slice(0, firstSeparator));
+  const pubkey = value.slice(firstSeparator + 1, secondSeparator);
+  const dTag = value.slice(secondSeparator + 1);
+
+  if (!allowedKinds.includes(kind) || !pubkey || !dTag) return null;
+  return { kind, pubkey, dTag };
+}
+
+export function videoCoordinateKey(coordinate: Pick<VideoCoordinate, 'pubkey' | 'dTag'>): string {
+  return `${coordinate.pubkey}:${coordinate.dTag}`;
+}


### PR DESCRIPTION
## Summary

- Remove exact-count relay limits from video-list and pinned-video coordinate resolution.
- Resolve duplicate/stale addressable video rows with deterministic newest-wins selection instead of query-order last-write-wins.
- Share coordinate parsing and add regression coverage for list and pinned-video resolvers.

> Avoid naming corporate partners, customers, or other sensitive external brands in this PR title or body. Use generic descriptors unless a maintainer explicitly approves the public reference.

## Motivation

- Follow-up to #605 after Rabble's post-merge review noted that `limit` sized to the exact member count can silently truncate list results when duplicate rows or addressable revisions consume relay result slots.
- Removing those limits also needs newest-wins coordinate selection so stale revisions cannot win by query return order.

## Related Issue

- Closes #606

## Testing

- [x] `npm run test`
- [x] Manual verification completed: no visual/browser flow change; resolver behavior covered by targeted unit tests and full suite.

## Visuals

- [ ] UI change with screenshots/video attached
- [x] No visual change
- [x] Visuals and text avoid sensitive external brand or partner names unless explicitly approved