### PR TITLE
fix(discovery): disclose featured tab sponsors

### DIFF
--- a/src/hooks/useFeaturedTab.test.ts
+++ b/src/hooks/useFeaturedTab.test.ts
@@ -62,6 +62,7 @@ function makeResponse(overrides: Partial<FeaturedTabsResponse['featured_tabs'][n
         ends_at: '2026-09-01T00:00:00Z',
         enabled: true,
         visible_to_minors: true,
+        pill_label: null,
         disclosure_label: null,
         has_content: true,
         ...overrides,
@@ -122,7 +123,8 @@ describe('useFeaturedTab', () => {
       slug: 'seasonal-theme',
       label: 'Especial',
       position: { after: 'hot' },
-      disclosureLabel: null,
+      pillLabel: null,
+      sponsorName: null,
     });
   });
 

--- a/src/lib/featuredTabEligibility.test.ts
+++ b/src/lib/featuredTabEligibility.test.ts
@@ -13,6 +13,7 @@ function makeConfig(overrides: Partial<FeaturedTabConfigRaw> = {}): FeaturedTabC
     ends_at: '2026-09-01T00:00:00Z',
     enabled: true,
     visible_to_minors: true,
+    pill_label: null,
     disclosure_label: null,
     has_content: true,
     ...overrides,
@@ -69,7 +70,8 @@ describe('featured tab eligibility', () => {
       makeConfig({
         id: 'ft_eligible',
         label: { default: 'Default', es: 'Especial' },
-        disclosure_label: 'Featured',
+        pill_label: 'Skate week',
+        disclosure_label: 'Acme Bikes',
       }),
     ], {
       now,
@@ -82,7 +84,31 @@ describe('featured tab eligibility', () => {
       slug: 'seasonal-theme',
       label: 'Especial',
       position: { after: 'hot' },
-      disclosureLabel: 'Featured',
+      pillLabel: 'Skate week',
+      sponsorName: 'Acme Bikes',
+    });
+  });
+
+  it('resolves empty sponsor names as unsponsored', () => {
+    const selected = selectFeaturedTab([
+      makeConfig({
+        id: 'ft_eligible',
+        pill_label: 'Skate week',
+        disclosure_label: '   ',
+      }),
+    ], {
+      now,
+      minorState: 'not_protected',
+      locale: 'en',
+    });
+
+    expect(selected).toEqual({
+      id: 'ft_eligible',
+      slug: 'seasonal-theme',
+      label: 'Seasonal',
+      position: { after: 'hot' },
+      pillLabel: 'Skate week',
+      sponsorName: null,
     });
   });
 
@@ -102,7 +128,12 @@ describe('featured tab eligibility', () => {
   it('falls through to the next eligible configuration when a slug is unusable', () => {
     const selected = selectFeaturedTab([
       makeConfig({ id: 'ft_bad_slug', slug: 'hashtags' }),
-      makeConfig({ id: 'ft_eligible', label: { default: 'Default', es: 'Especial' }, disclosure_label: 'Featured' }),
+      makeConfig({
+        id: 'ft_eligible',
+        label: { default: 'Default', es: 'Especial' },
+        pill_label: 'Skate week',
+        disclosure_label: 'Acme Bikes',
+      }),
     ], {
       now,
       minorState: 'not_protected',
@@ -114,7 +145,8 @@ describe('featured tab eligibility', () => {
       slug: 'seasonal-theme',
       label: 'Especial',
       position: { after: 'hot' },
-      disclosureLabel: 'Featured',
+      pillLabel: 'Skate week',
+      sponsorName: 'Acme Bikes',
     });
   });
 });

--- a/src/lib/featuredTabEligibility.ts
+++ b/src/lib/featuredTabEligibility.ts
@@ -1,7 +1,8 @@
 import {
-  parseFeaturedTabDisclosure,
+  parseFeaturedTabPillLabel,
   parseFeaturedTabPosition,
   parseFeaturedTabSlug,
+  parseFeaturedTabSponsorName,
   pickFeaturedTabLabel,
 } from '@/lib/featuredTabsTransform';
 import { isFeaturedTabMinorRestricted, type ProtectedMinorState } from '@/lib/protectedMinor';
@@ -79,7 +80,8 @@ export function selectFeaturedTab(
       slug,
       label,
       position: parseFeaturedTabPosition(config.position),
-      disclosureLabel: parseFeaturedTabDisclosure(config.disclosure_label),
+      pillLabel: parseFeaturedTabPillLabel(config.pill_label),
+      sponsorName: parseFeaturedTabSponsorName(config.disclosure_label),
     };
   }
 

--- a/src/lib/featuredTabsTransform.test.ts
+++ b/src/lib/featuredTabsTransform.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it } from 'vitest';
 
-import { parseFeaturedTabDisclosure, parseFeaturedTabPosition, pickFeaturedTabLabel, transformFeaturedTabVideosResponse } from './featuredTabsTransform';
+import {
+  parseFeaturedTabPillLabel,
+  parseFeaturedTabPosition,
+  parseFeaturedTabSponsorName,
+  pickFeaturedTabLabel,
+  transformFeaturedTabVideosResponse,
+} from './featuredTabsTransform';
 
 describe('featured tab transforms', () => {
   it('picks a locale label and falls back to default with a length cap', () => {
@@ -32,17 +38,27 @@ describe('featured tab transforms', () => {
       .toEqual({ before: 'hashtags' });
   });
 
-  it('only accepts string disclosure labels and keeps the phrase readable', () => {
-    expect(parseFeaturedTabDisclosure({ text: 'Ad' })).toBeNull();
-    expect(parseFeaturedTabDisclosure(' Sponsored collection ')).toBe('Sponsored collection');
-    expect(parseFeaturedTabDisclosure('Paid partnership')).toBe('Paid partnership');
+  it('only accepts string pill labels and keeps them readable', () => {
+    expect(parseFeaturedTabPillLabel({ text: 'Launch' })).toBeNull();
+    expect(parseFeaturedTabPillLabel(' Skate week ')).toBe('Skate week');
+    expect(parseFeaturedTabPillLabel('This pill label is unexpectedly long'))
+      .toBe('This pill label is unexp');
+  });
+
+  it('only accepts string sponsor names and keeps them readable', () => {
+    expect(parseFeaturedTabSponsorName({ text: 'Acme Bikes' })).toBeNull();
+    expect(parseFeaturedTabSponsorName(' Acme Bikes ')).toBe('Acme Bikes');
+    expect(parseFeaturedTabSponsorName('')).toBeNull();
+    expect(parseFeaturedTabSponsorName('This sponsor name is unexpectedly long'))
+      .toBe('This sponsor name is une');
   });
 
   it('strips invisible formatting from server-supplied strings', () => {
     // A bidi override could otherwise reorder the tab bar around the label.
     expect(pickFeaturedTabLabel({ default: 'Sea\u202esonal' }, 'en')).toBe('Seasonal');
-    expect(parseFeaturedTabDisclosure('Spon\u200bsored')).toBe('Sponsored');
-    expect(parseFeaturedTabDisclosure('\u200b\u202e')).toBeNull();
+    expect(parseFeaturedTabPillLabel('Ska\u200bte')).toBe('Skate');
+    expect(parseFeaturedTabSponsorName('Acme\u200b Bikes')).toBe('Acme Bikes');
+    expect(parseFeaturedTabSponsorName('\u200b\u202e')).toBeNull();
   });
 
   it('maps featured video envelopes without reordering server data', () => {

--- a/src/lib/featuredTabsTransform.ts
+++ b/src/lib/featuredTabsTransform.ts
@@ -8,10 +8,8 @@ import type {
 } from '@/types/featuredTabs';
 
 const MAX_LABEL_LENGTH = 24;
-// A disclosure is the one server-supplied string here whose meaning is legal
-// rather than decorative — "Sponsored", "Paid partnership". Room for the phrases
-// that matter, and the tab renders it in full rather than clipping it again.
-const MAX_DISCLOSURE_LENGTH = 24;
+const MAX_PILL_LABEL_LENGTH = 24;
+const MAX_SPONSOR_NAME_LENGTH = 24;
 const DISCOVERY_TAB_NAMES = new Set<DiscoveryTabName>(['foryou', 'classics', 'hot', 'hashtags']);
 // The slug is both the `/discovery/:tab` route segment and the Radix Tabs value.
 // The route comparison lowercases `params.tab`, so anything outside this shape
@@ -107,10 +105,17 @@ export function parseFeaturedTabPosition(value: unknown): FeaturedTabPosition | 
   return null;
 }
 
-export function parseFeaturedTabDisclosure(value: unknown): string | null {
+export function parseFeaturedTabPillLabel(value: unknown): string | null {
   if (typeof value !== 'string') return null;
 
-  const cleaned = cleanShortString(value, MAX_DISCLOSURE_LENGTH);
+  const cleaned = cleanShortString(value, MAX_PILL_LABEL_LENGTH);
+  return cleaned || null;
+}
+
+export function parseFeaturedTabSponsorName(value: unknown): string | null {
+  if (typeof value !== 'string') return null;
+
+  const cleaned = cleanShortString(value, MAX_SPONSOR_NAME_LENGTH);
   return cleaned || null;
 }
 

--- a/src/lib/i18n/locales/ar/common.json
+++ b/src/lib/i18n/locales/ar/common.json
@@ -69,6 +69,7 @@
     "classic": "كلاسيكي",
     "hot": "رائج",
     "new": "جديد",
+    "featured": "مميز",
     "tags": "الوسوم",
     "verifiedOnly": "من صنع البشر",
     "verifiedOnlyHint": "يتم عرض الفيديوهات التي تحتوي على تحقق ProofMode فقط",

--- a/src/lib/i18n/locales/de/common.json
+++ b/src/lib/i18n/locales/de/common.json
@@ -69,6 +69,7 @@
     "classic": "Klassisch",
     "hot": "Heiss",
     "new": "Neu",
+    "featured": "Empfohlen",
     "tags": "Tags",
     "verifiedOnly": "Von Menschen gemacht",
     "verifiedOnlyHint": "Es werden nur Videos mit ProofMode-Verifizierung angezeigt",

--- a/src/lib/i18n/locales/en/common.json
+++ b/src/lib/i18n/locales/en/common.json
@@ -69,6 +69,7 @@
     "classic": "Classic",
     "hot": "Hot",
     "new": "New",
+    "featured": "Featured",
     "tags": "Tags",
     "verifiedOnly": "Human Made",
     "verifiedOnlyHint": "Showing only videos with ProofMode verification",

--- a/src/lib/i18n/locales/es/common.json
+++ b/src/lib/i18n/locales/es/common.json
@@ -69,6 +69,7 @@
     "classic": "Clasico",
     "hot": "Popular",
     "new": "Nuevo",
+    "featured": "Destacado",
     "tags": "Etiquetas",
     "verifiedOnly": "Hecho por humanos",
     "verifiedOnlyHint": "Mostrando solo videos con verificacion ProofMode",

--- a/src/lib/i18n/locales/fil/common.json
+++ b/src/lib/i18n/locales/fil/common.json
@@ -69,6 +69,7 @@
     "classic": "Klasiko",
     "hot": "Sikat",
     "new": "Bago",
+    "featured": "Tampok",
     "tags": "Mga Tag",
     "verifiedOnly": "Gawa ng Tao",
     "verifiedOnlyHint": "Mga video lang na may ProofMode verification.",

--- a/src/lib/i18n/locales/fr/common.json
+++ b/src/lib/i18n/locales/fr/common.json
@@ -69,6 +69,7 @@
     "classic": "Classique",
     "hot": "Tendance",
     "new": "Nouveau",
+    "featured": "A la une",
     "tags": "Tags",
     "verifiedOnly": "Cree par des humains",
     "verifiedOnlyHint": "Affiche uniquement les videos avec verification ProofMode",

--- a/src/lib/i18n/locales/id/common.json
+++ b/src/lib/i18n/locales/id/common.json
@@ -69,6 +69,7 @@
     "classic": "Klasik",
     "hot": "Populer",
     "new": "Baru",
+    "featured": "Unggulan",
     "tags": "Tag",
     "verifiedOnly": "Buatan manusia",
     "verifiedOnlyHint": "Hanya menampilkan video dengan verifikasi ProofMode",

--- a/src/lib/i18n/locales/it/common.json
+++ b/src/lib/i18n/locales/it/common.json
@@ -69,6 +69,7 @@
     "classic": "Classico",
     "hot": "Caldo",
     "new": "Nuovo",
+    "featured": "In evidenza",
     "tags": "Tag",
     "verifiedOnly": "Creato da umani",
     "verifiedOnlyHint": "Mostra solo video con verifica ProofMode",

--- a/src/lib/i18n/locales/ja/common.json
+++ b/src/lib/i18n/locales/ja/common.json
@@ -69,6 +69,7 @@
     "classic": "クラシック",
     "hot": "人気",
     "new": "新着",
+    "featured": "注目",
     "tags": "タグ",
     "verifiedOnly": "人が作成",
     "verifiedOnlyHint": "ProofMode 検証済みの動画のみ表示しています",

--- a/src/lib/i18n/locales/ko/common.json
+++ b/src/lib/i18n/locales/ko/common.json
@@ -69,6 +69,7 @@
     "classic": "클래식",
     "hot": "인기",
     "new": "신규",
+    "featured": "추천",
     "tags": "태그",
     "verifiedOnly": "사람이 만든 콘텐츠",
     "verifiedOnlyHint": "ProofMode 검증이 있는 동영상만 표시합니다",

--- a/src/lib/i18n/locales/ms/common.json
+++ b/src/lib/i18n/locales/ms/common.json
@@ -69,6 +69,7 @@
     "classic": "Klasik",
     "hot": "Hangat",
     "new": "Baharu",
+    "featured": "Pilihan",
     "tags": "Tag",
     "verifiedOnly": "Buatan Manusia",
     "verifiedOnlyHint": "Menunjukkan hanya video dengan pengesahan ProofMode",

--- a/src/lib/i18n/locales/nl/common.json
+++ b/src/lib/i18n/locales/nl/common.json
@@ -69,6 +69,7 @@
     "classic": "Klassiek",
     "hot": "Heet",
     "new": "Nieuw",
+    "featured": "Uitgelicht",
     "tags": "Tags",
     "verifiedOnly": "Door mensen gemaakt",
     "verifiedOnlyHint": "Toont alleen video's met ProofMode-verificatie",

--- a/src/lib/i18n/locales/pl/common.json
+++ b/src/lib/i18n/locales/pl/common.json
@@ -69,6 +69,7 @@
     "classic": "Klasyczne",
     "hot": "Gorace",
     "new": "Nowe",
+    "featured": "Polecane",
     "tags": "Tagi",
     "verifiedOnly": "Stworzone przez ludzi",
     "verifiedOnlyHint": "Pokazuje tylko filmy z weryfikacja ProofMode",

--- a/src/lib/i18n/locales/pt/common.json
+++ b/src/lib/i18n/locales/pt/common.json
@@ -69,6 +69,7 @@
     "classic": "Classico",
     "hot": "Em alta",
     "new": "Novo",
+    "featured": "Destaque",
     "tags": "Tags",
     "verifiedOnly": "Feito por humanos",
     "verifiedOnlyHint": "Mostrando apenas videos com verificacao ProofMode",

--- a/src/lib/i18n/locales/ro/common.json
+++ b/src/lib/i18n/locales/ro/common.json
@@ -69,6 +69,7 @@
     "classic": "Clasic",
     "hot": "Popular",
     "new": "Nou",
+    "featured": "Recomandat",
     "tags": "Etichete",
     "verifiedOnly": "Creat de oameni",
     "verifiedOnlyHint": "Afiseaza doar videoclipuri cu verificare ProofMode",

--- a/src/lib/i18n/locales/sv/common.json
+++ b/src/lib/i18n/locales/sv/common.json
@@ -69,6 +69,7 @@
     "classic": "Klassiskt",
     "hot": "Hett",
     "new": "Nytt",
+    "featured": "Utvalt",
     "tags": "Taggar",
     "verifiedOnly": "Skapad av manniskor",
     "verifiedOnlyHint": "Visar endast videor med ProofMode-verifiering",

--- a/src/lib/i18n/locales/tr/common.json
+++ b/src/lib/i18n/locales/tr/common.json
@@ -69,6 +69,7 @@
     "classic": "Klasik",
     "hot": "Populer",
     "new": "Yeni",
+    "featured": "Öne çıkan",
     "tags": "Etiketler",
     "verifiedOnly": "Insan yapimi",
     "verifiedOnlyHint": "Yalnizca ProofMode dogrulamali videolar gosteriliyor",

--- a/src/lib/i18n/locales/ur/common.json
+++ b/src/lib/i18n/locales/ur/common.json
@@ -69,6 +69,7 @@
     "classic": "کلاسک",
     "hot": "ہاٹ",
     "new": "نئے",
+    "featured": "نمایاں",
     "tags": "ٹیگز",
     "verifiedOnly": "انسان کا بنایا",
     "verifiedOnlyHint": "صرف ProofMode تصدیق شدہ ویڈیوز دکھائی جا رہی ہیں",

--- a/src/lib/i18n/locales/vi/common.json
+++ b/src/lib/i18n/locales/vi/common.json
@@ -69,6 +69,7 @@
     "classic": "Kinh điển",
     "hot": "Hot",
     "new": "Mới",
+    "featured": "Nổi bật",
     "tags": "Thẻ",
     "verifiedOnly": "Do con người tạo ra",
     "verifiedOnlyHint": "Chỉ hiển thị video có xác minh ProofMode",

--- a/src/lib/i18n/locales/zh/common.json
+++ b/src/lib/i18n/locales/zh/common.json
@@ -69,6 +69,7 @@
     "classic": "经典",
     "hot": "火爆",
     "new": "最新",
+    "featured": "精选",
     "tags": "标签",
     "verifiedOnly": "真人创作",
     "verifiedOnlyHint": "只显示通过 ProofMode 验证的视频",

--- a/src/pages/DiscoveryPage.test.tsx
+++ b/src/pages/DiscoveryPage.test.tsx
@@ -17,6 +17,7 @@ const {
   mockFeaturedResolved,
   mockResolvingJwt,
   mockFeaturedApiUrl,
+  mockFeaturedFeedState,
   mockUseFeaturedTabArgs,
 } = vi.hoisted(() => ({
   mockNavigate: vi.fn(),
@@ -27,6 +28,7 @@ const {
   mockCurrentUser: { current: null as { pubkey: string } | null },
   mockResolvingJwt: { current: false },
   mockFeaturedApiUrl: { current: 'https://api.divine.video' },
+  mockFeaturedFeedState: { current: 'normal' as 'normal' | 'empty' | 'failed' },
   mockUseFeaturedTabArgs: [] as Array<{ apiUrl?: string } | undefined>,
 }));
 
@@ -68,9 +70,17 @@ vi.mock('@/lib/analytics', () => ({
 }));
 
 vi.mock('@/components/VideoFeed', () => ({
-  VideoFeed: ({ feedType, featuredTabId }: { feedType: string; featuredTabId?: string }) => (
-    <div data-testid={`video-feed-${feedType}`} data-featured-tab-id={featuredTabId} />
-  ),
+  VideoFeed: ({ feedType, featuredTabId }: { feedType: string; featuredTabId?: string }) => {
+    const message = feedType === 'featured' && mockFeaturedFeedState.current !== 'normal'
+      ? mockFeaturedFeedState.current
+      : null;
+
+    return (
+      <div data-testid={`video-feed-${feedType}`} data-featured-tab-id={featuredTabId}>
+        {message}
+      </div>
+    );
+  },
 }));
 
 vi.mock('@/components/HashtagExplorer', () => ({
@@ -106,6 +116,7 @@ describe('DiscoveryPage', () => {
     mockResolvingJwt.current = false;
     mockCurrentUser.current = null;
     mockFeaturedApiUrl.current = 'https://api.divine.video';
+    mockFeaturedFeedState.current = 'normal';
     mockUseFeaturedTabArgs.length = 0;
   });
 
@@ -182,7 +193,8 @@ describe('DiscoveryPage', () => {
       slug: 'seasonal-theme',
       label: 'Especial',
       position: { after: 'hot' },
-      disclosureLabel: 'New',
+      pillLabel: 'Skate week',
+      sponsorName: null,
     };
 
     render(
@@ -196,7 +208,7 @@ describe('DiscoveryPage', () => {
     expect(screen.getAllByRole('tab').map((tab) => tab.textContent)).toEqual([
       'Clasico',
       'Popular',
-      'EspecialNew',
+      'DestacadoSkate week',
       'Etiquetas',
     ]);
   });
@@ -207,7 +219,8 @@ describe('DiscoveryPage', () => {
       slug: 'seasonal-theme',
       label: 'Especial',
       position: { after: 'hot' },
-      disclosureLabel: null,
+      pillLabel: null,
+      sponsorName: null,
     });
     mockFeaturedTab.current = config();
 
@@ -265,7 +278,8 @@ describe('DiscoveryPage', () => {
       slug: 'seasonal-theme',
       label: 'Especial',
       position: { after: 'hot' },
-      disclosureLabel: null,
+      pillLabel: null,
+      sponsorName: null,
     };
 
     const tree = () => (
@@ -310,7 +324,8 @@ describe('DiscoveryPage', () => {
       slug: 'seasonal-theme',
       label: 'Especial',
       position: { after: 'hot' },
-      disclosureLabel: 'Sponsored',
+      pillLabel: 'Skate week',
+      sponsorName: 'Acme Bikes',
     };
 
     render(
@@ -322,8 +337,57 @@ describe('DiscoveryPage', () => {
     );
 
     expect(screen.getByTestId('video-feed-featured')).toHaveAttribute('data-featured-tab-id', 'ft_1234abcd');
-    expect(screen.getAllByText('Sponsored')).not.toHaveLength(0);
+    expect(screen.getByText('In paid partnership with Acme Bikes')).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: 'Destacado' })).toHaveTextContent('Skate week');
+    expect(screen.getAllByText(/Acme Bikes/)).toHaveLength(1);
   });
+
+  it('does not render partnership copy for an unsponsored featured tab', () => {
+    mockFeaturedTab.current = {
+      id: 'ft_1234abcd',
+      slug: 'seasonal-theme',
+      label: 'Especial',
+      position: { after: 'hot' },
+      pillLabel: 'Skate week',
+      sponsorName: null,
+    };
+
+    render(
+      <MemoryRouter initialEntries={['/discovery/seasonal-theme']}>
+        <Routes>
+          <Route path="/discovery/:tab" element={<DiscoveryPage />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    expect(screen.queryByText(/In paid partnership with/)).not.toBeInTheDocument();
+  });
+
+  it.each(['empty', 'failed'] as const)(
+    'keeps partnership copy visible when the featured feed is %s',
+    (feedState) => {
+      mockFeaturedFeedState.current = feedState;
+      mockFeaturedTab.current = {
+        id: 'ft_1234abcd',
+        slug: 'seasonal-theme',
+        label: 'Especial',
+        position: { after: 'hot' },
+        pillLabel: null,
+        sponsorName: 'Acme Bikes',
+      };
+
+      render(
+        <MemoryRouter initialEntries={['/discovery/seasonal-theme']}>
+          <Routes>
+            <Route path="/discovery/:tab" element={<DiscoveryPage />} />
+          </Routes>
+        </MemoryRouter>,
+      );
+
+      expect(screen.getByText('In paid partnership with Acme Bikes')).toBeInTheDocument();
+      expect(screen.getByText(feedState)).toBeInTheDocument();
+    },
+  );
 
   it('names every tab trigger when labels are visually hidden on mobile', () => {
     mockFeaturedTab.current = {
@@ -331,7 +395,8 @@ describe('DiscoveryPage', () => {
       slug: 'seasonal-theme',
       label: 'Especial',
       position: { after: 'hot' },
-      disclosureLabel: 'Sponsored',
+      pillLabel: 'Skate week',
+      sponsorName: 'Acme Bikes',
     };
 
     render(
@@ -345,7 +410,7 @@ describe('DiscoveryPage', () => {
     expect(screen.getAllByRole('tab').map((tab) => tab.getAttribute('aria-label'))).toEqual([
       'Clasico',
       'Popular',
-      'Especial: Sponsored',
+      'Destacado',
       'Etiquetas',
     ]);
   });

--- a/src/pages/DiscoveryPage.test.tsx
+++ b/src/pages/DiscoveryPage.test.tsx
@@ -338,7 +338,7 @@ describe('DiscoveryPage', () => {
 
     expect(screen.getByTestId('video-feed-featured')).toHaveAttribute('data-featured-tab-id', 'ft_1234abcd');
     expect(screen.getByText('In paid partnership with Acme Bikes')).toBeInTheDocument();
-    expect(screen.getByRole('tab', { name: 'Destacado' })).toHaveTextContent('Skate week');
+    expect(screen.getByRole('tab', { name: 'Destacado: Skate week' })).toHaveTextContent('Skate week');
     expect(screen.getAllByText(/Acme Bikes/)).toHaveLength(1);
   });
 
@@ -410,7 +410,7 @@ describe('DiscoveryPage', () => {
     expect(screen.getAllByRole('tab').map((tab) => tab.getAttribute('aria-label'))).toEqual([
       'Clasico',
       'Popular',
-      'Destacado',
+      'Destacado: Skate week',
       'Etiquetas',
     ]);
   });

--- a/src/pages/DiscoveryPage.tsx
+++ b/src/pages/DiscoveryPage.tsx
@@ -258,7 +258,7 @@ export function DiscoveryPage() {
                 key={value}
                 value={value}
                 className="min-w-0 gap-1.5 px-2 sm:gap-2 sm:px-4"
-                aria-label={label}
+                aria-label={pillLabel ? `${label}: ${pillLabel}` : label}
               >
                 <Icon className="h-4 w-4 shrink-0" />
                 <span className="hidden min-w-0 truncate sm:inline" title={label}>{label}</span>

--- a/src/pages/DiscoveryPage.tsx
+++ b/src/pages/DiscoveryPage.tsx
@@ -24,24 +24,25 @@ interface DiscoveryTabItem {
   value: string;
   label: string;
   Icon: ComponentType<{ className?: string }>;
-  disclosureLabel?: string | null;
+  pillLabel?: string | null;
   featuredTab?: ResolvedFeaturedTab;
 }
 
 function insertFeaturedTab(
   tabs: DiscoveryTabItem[],
-  featuredTab: ResolvedFeaturedTab | null
+  featuredTab: ResolvedFeaturedTab | null,
+  featuredLabel: string
 ): DiscoveryTabItem[] {
   if (!featuredTab) return tabs;
 
   const item: DiscoveryTabItem = {
     value: featuredTab.slug,
-    label: featuredTab.label,
+    label: featuredLabel,
     // Not Hash: the hashtags tab already owns that glyph, and below `sm` the
     // labels are hidden, so a second Hash would make the editorial tab
     // indistinguishable from it on mobile.
     Icon: Confetti,
-    disclosureLabel: featuredTab.disclosureLabel,
+    pillLabel: featuredTab.pillLabel,
     featuredTab,
   };
   const position = featuredTab.position;
@@ -106,8 +107,8 @@ export function DiscoveryPage() {
   }, [isLoggedIn, t]);
 
   const tabItems = useMemo(
-    () => insertFeaturedTab(baseTabs, featuredTab),
-    [baseTabs, featuredTab]
+    () => insertFeaturedTab(baseTabs, featuredTab, t('discovery.featured')),
+    [baseTabs, featuredTab, t]
   );
 
   const allowedTabs = useMemo(() => {
@@ -252,21 +253,21 @@ export function DiscoveryPage() {
             className="grid w-full gap-1"
             style={{ gridTemplateColumns: `repeat(${tabItems.length}, minmax(0, 1fr))` }}
           >
-            {tabItems.map(({ value, label, Icon, disclosureLabel }) => (
+            {tabItems.map(({ value, label, Icon, pillLabel }) => (
               <TabsTrigger
                 key={value}
                 value={value}
                 className="min-w-0 gap-1.5 px-2 sm:gap-2 sm:px-4"
-                aria-label={disclosureLabel ? `${label}: ${disclosureLabel}` : label}
+                aria-label={label}
               >
                 <Icon className="h-4 w-4 shrink-0" />
                 <span className="hidden min-w-0 truncate sm:inline" title={label}>{label}</span>
-                {disclosureLabel && (
+                {pillLabel && (
                   <span
                     className="hidden max-w-[7rem] shrink truncate rounded-full bg-background/80 px-1.5 py-0.5 text-[10px] leading-none text-foreground sm:inline"
-                    title={disclosureLabel}
+                    title={pillLabel}
                   >
-                    {disclosureLabel}
+                    {pillLabel}
                   </span>
                 )}
               </TabsTrigger>
@@ -318,10 +319,10 @@ export function DiscoveryPage() {
 
           {activeTabItem?.featuredTab && (
             <TabsContent value={activeTabItem.featuredTab.slug} className="mt-0 space-y-6">
-              {activeTabItem.featuredTab.disclosureLabel && (
+              {activeTabItem.featuredTab.sponsorName && (
                 <div className="flex justify-center">
-                  <span className="inline-flex max-w-full rounded-full border border-border bg-background px-3 py-1 text-sm font-medium text-foreground">
-                    {activeTabItem.featuredTab.disclosureLabel}
+                  <span className="inline-flex max-w-full rounded-full border border-border bg-background px-3 py-1 text-center text-sm font-medium text-foreground">
+                    In paid partnership with {activeTabItem.featuredTab.sponsorName}
                   </span>
                 </div>
               )}

--- a/src/types/featuredTabs.ts
+++ b/src/types/featuredTabs.ts
@@ -14,6 +14,7 @@ export interface FeaturedTabConfigRaw {
   ends_at: string;
   enabled: boolean;
   visible_to_minors: boolean;
+  pill_label: unknown;
   disclosure_label: unknown;
   has_content: boolean;
 }
@@ -28,7 +29,8 @@ export interface ResolvedFeaturedTab {
   slug: string;
   label: string;
   position: FeaturedTabPosition | null;
-  disclosureLabel: string | null;
+  pillLabel: string | null;
+  sponsorName: string | null;
 }
 
 export interface FeaturedTabVideoRaw extends Omit<FunnelcakeVideoRaw, 'created_at'> {


### PR DESCRIPTION
## Summary

- Parse featured tab `pill_label` separately from sponsor disclosure, and resolve `disclosure_label` as `sponsorName` instead of tab chrome copy.
- Render the Featured tab label from local i18n, show the collection pill from `pill_label`, and show the exact paid-partnership disclosure above the featured feed when a sponsor is present.
- Add locale coverage and focused regression tests for parsing, eligibility, tab rendering, sponsor non-duplication, and empty/failed feed states.

> Avoid naming corporate partners, customers, or other sensitive external brands in this PR title or body. Use generic descriptors unless a maintainer explicitly approves the public reference.

## Motivation

- Keeps web aligned with the upcoming featured-tab sponsorship contract so a sponsor name does not replace the collection pill or get read as generic disclosure copy.
- Leaves placement hard-wiring for a separate PR so this change stays scoped to sponsorship semantics.

## Related Issue

- Refs #608

## Testing

- [x] `npm run test`
- [ ] Manual verification completed; production currently serves no live featured tabs to exercise manually.

## Visuals

- [x] UI change; no screenshot attached because production currently serves no live featured tabs.
- [x] Visuals and text avoid sensitive external brand or partner names unless explicitly approved
