### PR TITLE
fix(discovery): hard-wire featured tab placement

### DIFF
--- a/src/hooks/useFeaturedTab.test.ts
+++ b/src/hooks/useFeaturedTab.test.ts
@@ -57,7 +57,6 @@ function makeResponse(overrides: Partial<FeaturedTabsResponse['featured_tabs'][n
         id: 'ft_1234abcd',
         slug: 'seasonal-theme',
         label: { default: 'Seasonal', es: 'Especial' },
-        position: { web: { after: 'hot' } },
         starts_at: '2026-08-01T00:00:00Z',
         ends_at: '2026-09-01T00:00:00Z',
         enabled: true,
@@ -122,7 +121,6 @@ describe('useFeaturedTab', () => {
       id: 'ft_1234abcd',
       slug: 'seasonal-theme',
       label: 'Especial',
-      position: { after: 'hot' },
       pillLabel: null,
       sponsorName: null,
     });

--- a/src/lib/featuredTabEligibility.test.ts
+++ b/src/lib/featuredTabEligibility.test.ts
@@ -8,7 +8,6 @@ function makeConfig(overrides: Partial<FeaturedTabConfigRaw> = {}): FeaturedTabC
     id: 'ft_1234abcd',
     slug: 'seasonal-theme',
     label: { default: 'Seasonal' },
-    position: { web: { after: 'hot' } },
     starts_at: '2026-08-01T00:00:00Z',
     ends_at: '2026-09-01T00:00:00Z',
     enabled: true,
@@ -83,7 +82,6 @@ describe('featured tab eligibility', () => {
       id: 'ft_eligible',
       slug: 'seasonal-theme',
       label: 'Especial',
-      position: { after: 'hot' },
       pillLabel: 'Skate week',
       sponsorName: 'Acme Bikes',
     });
@@ -106,7 +104,6 @@ describe('featured tab eligibility', () => {
       id: 'ft_eligible',
       slug: 'seasonal-theme',
       label: 'Seasonal',
-      position: { after: 'hot' },
       pillLabel: 'Skate week',
       sponsorName: null,
     });
@@ -144,7 +141,6 @@ describe('featured tab eligibility', () => {
       id: 'ft_eligible',
       slug: 'seasonal-theme',
       label: 'Especial',
-      position: { after: 'hot' },
       pillLabel: 'Skate week',
       sponsorName: 'Acme Bikes',
     });

--- a/src/lib/featuredTabEligibility.ts
+++ b/src/lib/featuredTabEligibility.ts
@@ -1,6 +1,5 @@
 import {
   parseFeaturedTabPillLabel,
-  parseFeaturedTabPosition,
   parseFeaturedTabSlug,
   parseFeaturedTabSponsorName,
   pickFeaturedTabLabel,
@@ -79,7 +78,6 @@ export function selectFeaturedTab(
       id,
       slug,
       label,
-      position: parseFeaturedTabPosition(config.position),
       pillLabel: parseFeaturedTabPillLabel(config.pill_label),
       sponsorName: parseFeaturedTabSponsorName(config.disclosure_label),
     };

--- a/src/lib/featuredTabsTransform.test.ts
+++ b/src/lib/featuredTabsTransform.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest';
 
 import {
   parseFeaturedTabPillLabel,
-  parseFeaturedTabPosition,
+  parseFeaturedTabSlug,
   parseFeaturedTabSponsorName,
   pickFeaturedTabLabel,
   transformFeaturedTabVideosResponse,
@@ -20,22 +20,16 @@ describe('featured tab transforms', () => {
     }, 'fr')).toBe('This label is unexpected');
   });
 
-  it('rejects hostile position payloads and unknown tab names', () => {
-    expect(parseFeaturedTabPosition('after-hot')).toBeNull();
-    expect(parseFeaturedTabPosition({ web: { after: 'rising' } })).toBeNull();
-    expect(parseFeaturedTabPosition({ mobile: { after: 'popular' } })).toBeNull();
+  it('rejects slugs that would shadow built-in discovery tabs', () => {
+    expect(parseFeaturedTabSlug('foryou')).toBeNull();
+    expect(parseFeaturedTabSlug('classics')).toBeNull();
+    expect(parseFeaturedTabSlug('hot')).toBeNull();
+    expect(parseFeaturedTabSlug('hashtags')).toBeNull();
+    expect(parseFeaturedTabSlug('top')).toBeNull();
   });
 
-  it('parses valid web position by tab name', () => {
-    expect(parseFeaturedTabPosition({ web: { after: 'hot' } })).toEqual({ after: 'hot' });
-    expect(parseFeaturedTabPosition({ web: { before: 'hashtags' } })).toEqual({ before: 'hashtags' });
-  });
-
-  it('keeps a single anchor when the backend sends both after and before', () => {
-    expect(parseFeaturedTabPosition({ web: { after: 'hot', before: 'hashtags' } }))
-      .toEqual({ after: 'hot' });
-    expect(parseFeaturedTabPosition({ web: { after: 'rising', before: 'hashtags' } }))
-      .toEqual({ before: 'hashtags' });
+  it('accepts routable featured tab slugs', () => {
+    expect(parseFeaturedTabSlug('seasonal-theme')).toBe('seasonal-theme');
   });
 
   it('only accepts string pill labels and keeps them readable', () => {

--- a/src/lib/featuredTabsTransform.ts
+++ b/src/lib/featuredTabsTransform.ts
@@ -2,7 +2,6 @@ import { DEFAULT_LOCALE, normalizeLocale } from '@/lib/i18n/config';
 import type { FunnelcakeResponse, FunnelcakeVideoRaw } from '@/types/funnelcake';
 import type {
   DiscoveryTabName,
-  FeaturedTabPosition,
   FeaturedTabVideosResponseRaw,
   FeaturedTabVideoRaw,
 } from '@/types/featuredTabs';
@@ -52,13 +51,6 @@ function cleanShortString(value: string, maxLength: number): string {
     .slice(0, maxLength);
 }
 
-function parseDiscoveryTabName(value: unknown): DiscoveryTabName | null {
-  if (typeof value !== 'string') return null;
-  return DISCOVERY_TAB_NAMES.has(value as DiscoveryTabName)
-    ? (value as DiscoveryTabName)
-    : null;
-}
-
 export function parseFeaturedTabSlug(value: unknown): string | null {
   if (typeof value !== 'string') return null;
 
@@ -85,24 +77,6 @@ export function pickFeaturedTabLabel(
   const cleaned = cleanShortString(localized, MAX_LABEL_LENGTH);
 
   return cleaned || null;
-}
-
-export function parseFeaturedTabPosition(value: unknown): FeaturedTabPosition | null {
-  if (typeof value !== 'object' || value === null || Array.isArray(value)) return null;
-
-  const web = (value as { web?: unknown }).web;
-  if (typeof web !== 'object' || web === null || Array.isArray(web)) return null;
-
-  const after = parseDiscoveryTabName((web as { after?: unknown }).after);
-  const before = parseDiscoveryTabName((web as { before?: unknown }).before);
-
-  // `after` and `before` are mutually exclusive anchors. Keeping both would let
-  // a placement contradict itself (anchor from one key, side from the other),
-  // so resolve the conflict here rather than in the insertion code.
-  if (after) return { after };
-  if (before) return { before };
-
-  return null;
 }
 
 export function parseFeaturedTabPillLabel(value: unknown): string | null {

--- a/src/pages/DiscoveryPage.test.tsx
+++ b/src/pages/DiscoveryPage.test.tsx
@@ -187,12 +187,11 @@ describe('DiscoveryPage', () => {
     });
   });
 
-  it('inserts an eligible featured tab after the configured tab and renders disclosure text', () => {
+  it('inserts an eligible featured tab after classics and before hot', () => {
     mockFeaturedTab.current = {
       id: 'ft_1234abcd',
       slug: 'seasonal-theme',
       label: 'Especial',
-      position: { after: 'hot' },
       pillLabel: 'Skate week',
       sponsorName: null,
     };
@@ -207,8 +206,35 @@ describe('DiscoveryPage', () => {
 
     expect(screen.getAllByRole('tab').map((tab) => tab.textContent)).toEqual([
       'Clasico',
-      'Popular',
       'DestacadoSkate week',
+      'Popular',
+      'Etiquetas',
+    ]);
+  });
+
+  it('keeps the featured tab after classics when foryou is visible', () => {
+    mockCurrentUser.current = { pubkey: 'viewer-pubkey' };
+    mockFeaturedTab.current = {
+      id: 'ft_1234abcd',
+      slug: 'seasonal-theme',
+      label: 'Especial',
+      pillLabel: null,
+      sponsorName: null,
+    };
+
+    render(
+      <MemoryRouter initialEntries={['/discovery/classics']}>
+        <Routes>
+          <Route path="/discovery/:tab" element={<DiscoveryPage />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    expect(screen.getAllByRole('tab').map((tab) => tab.textContent)).toEqual([
+      'Para ti',
+      'Clasico',
+      'Destacado',
+      'Popular',
       'Etiquetas',
     ]);
   });
@@ -218,7 +244,6 @@ describe('DiscoveryPage', () => {
       id: 'ft_1234abcd',
       slug: 'seasonal-theme',
       label: 'Especial',
-      position: { after: 'hot' },
       pillLabel: null,
       sponsorName: null,
     });
@@ -277,7 +302,6 @@ describe('DiscoveryPage', () => {
       id: 'ft_1234abcd',
       slug: 'seasonal-theme',
       label: 'Especial',
-      position: { after: 'hot' },
       pillLabel: null,
       sponsorName: null,
     };
@@ -323,7 +347,6 @@ describe('DiscoveryPage', () => {
       id: 'ft_1234abcd',
       slug: 'seasonal-theme',
       label: 'Especial',
-      position: { after: 'hot' },
       pillLabel: 'Skate week',
       sponsorName: 'Acme Bikes',
     };
@@ -347,7 +370,6 @@ describe('DiscoveryPage', () => {
       id: 'ft_1234abcd',
       slug: 'seasonal-theme',
       label: 'Especial',
-      position: { after: 'hot' },
       pillLabel: 'Skate week',
       sponsorName: null,
     };
@@ -371,7 +393,6 @@ describe('DiscoveryPage', () => {
         id: 'ft_1234abcd',
         slug: 'seasonal-theme',
         label: 'Especial',
-        position: { after: 'hot' },
         pillLabel: null,
         sponsorName: 'Acme Bikes',
       };
@@ -394,7 +415,6 @@ describe('DiscoveryPage', () => {
       id: 'ft_1234abcd',
       slug: 'seasonal-theme',
       label: 'Especial',
-      position: { after: 'hot' },
       pillLabel: 'Skate week',
       sponsorName: 'Acme Bikes',
     };
@@ -409,8 +429,8 @@ describe('DiscoveryPage', () => {
 
     expect(screen.getAllByRole('tab').map((tab) => tab.getAttribute('aria-label'))).toEqual([
       'Clasico',
-      'Popular',
       'Destacado: Skate week',
+      'Popular',
       'Etiquetas',
     ]);
   });

--- a/src/pages/DiscoveryPage.tsx
+++ b/src/pages/DiscoveryPage.tsx
@@ -45,17 +45,13 @@ function insertFeaturedTab(
     pillLabel: featuredTab.pillLabel,
     featuredTab,
   };
-  const position = featuredTab.position;
-  const target = position?.after ?? position?.before;
-  const targetIndex = target
-    ? tabs.findIndex((tab) => tab.value === target)
-    : -1;
+  const targetIndex = tabs.findIndex((tab) => tab.value === 'classics');
 
   if (targetIndex === -1) {
     return [...tabs, item];
   }
 
-  const insertAt = position?.before ? targetIndex : targetIndex + 1;
+  const insertAt = targetIndex + 1;
   return [
     ...tabs.slice(0, insertAt),
     item,

--- a/src/types/featuredTabs.ts
+++ b/src/types/featuredTabs.ts
@@ -9,7 +9,6 @@ export interface FeaturedTabConfigRaw {
   id: string;
   slug: string;
   label: Record<string, string>;
-  position: unknown;
   starts_at: string;
   ends_at: string;
   enabled: boolean;
@@ -19,16 +18,10 @@ export interface FeaturedTabConfigRaw {
   has_content: boolean;
 }
 
-export interface FeaturedTabPosition {
-  after?: DiscoveryTabName;
-  before?: DiscoveryTabName;
-}
-
 export interface ResolvedFeaturedTab {
   id: string;
   slug: string;
   label: string;
-  position: FeaturedTabPosition | null;
   pillLabel: string | null;
   sponsorName: string | null;
 }


### PR DESCRIPTION
## Summary

- Insert the Featured discovery tab immediately after Classics and before Hot by tab name instead of reading server placement config.
- Remove the resolved featured-tab position model and parser, while keeping built-in tab slugs reserved so featured configs cannot shadow existing tabs.
- Update focused tests for logged-out and logged-in tab ordering plus the removed position contract.

> Avoid naming corporate partners, customers, or other sensitive external brands in this PR title or body. Use generic descriptors unless a maintainer explicitly approves the public reference.

## Motivation

- Finishes the web-side featured tab placement work from #608 and keeps web aligned with the fixed client-side slot used by mobile.
- Avoids optional-tab index drift by inserting relative to the `classics` tab name rather than trusting a server-provided index or anchor.

## Related Issue

- Closes #608

## Testing

- [x] `npx vitest run src/lib/featuredTabsTransform.test.ts src/lib/featuredTabEligibility.test.ts src/hooks/useFeaturedTab.test.ts src/pages/DiscoveryPage.test.tsx`
- [x] `npm run test`
- [ ] Manual verification completed; production currently serves no live featured tabs to exercise manually.

## Visuals

- [x] UI change; no screenshot attached because production currently serves no live featured tabs.
- [x] Visuals and text avoid sensitive external brand or partner names unless explicitly approved
