### PR TITLE
perf(i18n): lazy-load inactive locale catalogs

### DIFF
--- a/src/lib/i18n/index.test.ts
+++ b/src/lib/i18n/index.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it } from 'vitest';
 import { LOCALE_STORAGE_KEY } from './config';
-import { createI18nInstance, initializeI18n } from './index';
+import { changeLanguage, createI18nInstance, initializeI18n } from './index';
 
 describe('i18n bootstrap', () => {
   beforeEach(() => {
@@ -87,5 +87,26 @@ describe('i18n bootstrap', () => {
 
     expect(i18n.language).toBe('ms');
     expect(i18n.t('nav.home')).toBe('Utama');
+  });
+
+  it('loads a lazy locale when changing language after english bootstrap', async () => {
+    const i18n = await initializeI18n({ force: true, languages: ['en-US'] });
+
+    await changeLanguage('ja');
+
+    expect(i18n.language).toBe('ja');
+    expect(i18n.t('nav.home')).toBe('ホーム');
+    expect(document.documentElement.lang).toBe('ja');
+  });
+
+  it('keeps lazy bundles available when switching away and back', async () => {
+    const i18n = await initializeI18n({ force: true, languages: ['en-US'] });
+
+    await changeLanguage('vi');
+    await changeLanguage('en');
+    await changeLanguage('vi');
+
+    expect(i18n.language).toBe('vi');
+    expect(i18n.t('nav.home')).toBe('Trang chủ');
   });
 });

--- a/src/lib/i18n/index.ts
+++ b/src/lib/i18n/index.ts
@@ -11,31 +11,109 @@ import {
 
 type LocaleResourceSet = Record<string, Record<string, unknown>>;
 
-const localeModules = import.meta.glob('./locales/*/*.json', {
+const localePathPattern = /^\.\/locales\/([^/]+)\/([^/]+)\.json$/;
+
+const englishModules = import.meta.glob('./locales/en/*.json', {
   eager: true,
   import: 'default',
 }) as Record<string, unknown>;
 
-const resources: Record<SupportedLocale, LocaleResourceSet> = SUPPORTED_LOCALES.reduce(
-  (accumulator, locale) => {
-    accumulator[locale] = {};
-    return accumulator;
-  },
-  {} as Record<SupportedLocale, LocaleResourceSet>,
-);
+const lazyLocaleModules = import.meta.glob(['./locales/*/*.json', '!./locales/en/*.json'], {
+  import: 'default',
+}) as Record<string, () => Promise<unknown>>;
 
-for (const [path, module] of Object.entries(localeModules)) {
-  const match = path.match(/\.\/locales\/([^/]+)\/([^/]+)\.json$/);
+function parseLocalePath(path: string): { locale: SupportedLocale; namespace: string } | null {
+  const match = path.match(localePathPattern);
   if (!match) {
-    continue;
+    return null;
   }
 
   const [, locale, namespace] = match;
   if (!SUPPORTED_LOCALES.includes(locale as SupportedLocale)) {
-    continue;
+    return null;
   }
 
-  resources[locale as SupportedLocale][namespace] = module as Record<string, unknown>;
+  return { locale: locale as SupportedLocale, namespace };
+}
+
+function collectLocaleResources(
+  locale: SupportedLocale,
+  modules: Record<string, unknown>,
+): LocaleResourceSet {
+  const resources: LocaleResourceSet = {};
+
+  for (const [path, module] of Object.entries(modules)) {
+    const parsed = parseLocalePath(path);
+    if (!parsed || parsed.locale !== locale) {
+      continue;
+    }
+
+    resources[parsed.namespace] = module as Record<string, unknown>;
+  }
+
+  return resources;
+}
+
+const englishResources = collectLocaleResources(DEFAULT_LOCALE, englishModules);
+const namespaces = Object.keys(englishResources);
+const localeResourcePromises = new Map<SupportedLocale, Promise<LocaleResourceSet>>();
+
+async function loadLocaleResources(locale: SupportedLocale): Promise<LocaleResourceSet> {
+  if (locale === DEFAULT_LOCALE) {
+    return englishResources;
+  }
+
+  const existingPromise = localeResourcePromises.get(locale);
+  if (existingPromise) {
+    return existingPromise;
+  }
+
+  const promise = Promise.all(
+    Object.entries(lazyLocaleModules)
+      .filter(([path]) => parseLocalePath(path)?.locale === locale)
+      .map(async ([path, load]) => {
+        const parsed = parseLocalePath(path);
+        const module = await load();
+        return parsed ? ([parsed.namespace, module] as const) : null;
+      }),
+  ).then((entries) =>
+    entries.reduce<LocaleResourceSet>((accumulator, entry) => {
+      if (!entry) {
+        return accumulator;
+      }
+
+      const [namespace, module] = entry;
+      accumulator[namespace] = module as Record<string, unknown>;
+      return accumulator;
+    }, {}),
+  ).catch((error: unknown) => {
+    localeResourcePromises.delete(locale);
+    throw error;
+  });
+
+  localeResourcePromises.set(locale, promise);
+  return promise;
+}
+
+function addLocaleResourceBundles(
+  instance: I18nInstance,
+  locale: SupportedLocale,
+  resources: LocaleResourceSet,
+): void {
+  for (const [namespace, catalog] of Object.entries(resources)) {
+    if (!instance.hasResourceBundle(locale, namespace)) {
+      instance.addResourceBundle(locale, namespace, catalog, true, true);
+    }
+  }
+}
+
+async function loadInitialLocale(locale: SupportedLocale): Promise<SupportedLocale> {
+  try {
+    await loadLocaleResources(locale);
+    return locale;
+  } catch {
+    return DEFAULT_LOCALE;
+  }
 }
 
 export interface InitializeI18nOptions {
@@ -56,11 +134,18 @@ function bindDocumentLocale(instance: I18nInstance): void {
 export async function createI18nInstance(
   options: InitializeI18nOptions = {},
 ): Promise<I18nInstance> {
-  const locale = resolveInitialLocale(options.languages ?? navigator.languages);
+  const detectedLanguages =
+    options.languages ?? (typeof navigator === 'undefined' ? undefined : navigator.languages);
+  const requestedLocale = resolveInitialLocale(detectedLanguages);
+  const locale = await loadInitialLocale(requestedLocale);
   const instance = i18next.createInstance();
-  const namespaces = Array.from(
-    new Set(Object.values(resources).flatMap((namespacesByLocale) => Object.keys(namespacesByLocale))),
-  );
+  const resources: Partial<Record<SupportedLocale, LocaleResourceSet>> = {
+    [DEFAULT_LOCALE]: englishResources,
+  };
+
+  if (locale !== DEFAULT_LOCALE) {
+    resources[locale] = await loadLocaleResources(locale);
+  }
 
   await instance.use(initReactI18next).init({
     defaultNS: 'common',
@@ -94,7 +179,11 @@ export async function initializeI18n(
 
 export async function changeLanguage(locale: SupportedLocale): Promise<void> {
   const instance = await initializeI18n();
-  await instance.changeLanguage(locale);
+  try {
+    const resources = await loadLocaleResources(locale);
+    addLocaleResourceBundles(instance, locale, resources);
+    await instance.changeLanguage(locale);
+  } catch {
+    await instance.changeLanguage(DEFAULT_LOCALE);
+  }
 }
-
-export { resources };

--- a/src/lib/i18n/locales.test.ts
+++ b/src/lib/i18n/locales.test.ts
@@ -1,5 +1,34 @@
 import { describe, expect, it } from 'vitest';
-import { resources } from './index';
+import { SUPPORTED_LOCALES, type SupportedLocale } from './config';
+
+type LocaleResourceSet = Record<string, Record<string, unknown>>;
+
+const localeModules = import.meta.glob('./locales/*/*.json', {
+  eager: true,
+  import: 'default',
+}) as Record<string, unknown>;
+
+const resources: Record<SupportedLocale, LocaleResourceSet> = SUPPORTED_LOCALES.reduce(
+  (accumulator, locale) => {
+    accumulator[locale] = {};
+    return accumulator;
+  },
+  {} as Record<SupportedLocale, LocaleResourceSet>,
+);
+
+for (const [path, module] of Object.entries(localeModules)) {
+  const match = path.match(/^\.\/locales\/([^/]+)\/([^/]+)\.json$/);
+  if (!match) {
+    continue;
+  }
+
+  const [, locale, namespace] = match;
+  if (!SUPPORTED_LOCALES.includes(locale as SupportedLocale)) {
+    continue;
+  }
+
+  resources[locale as SupportedLocale][namespace] = module as Record<string, unknown>;
+}
 
 const PLURAL_SUFFIXES = new Set(['zero', 'one', 'two', 'few', 'many', 'other']);
 const LOCALES_REQUIRING_FULL_PLURAL_COVERAGE = new Set(['ar']);

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -26,6 +26,7 @@ import { cleanupServiceWorkersAndCaches } from '@/lib/serviceWorkerCleanup';
 // Import polyfills first
 import './lib/polyfills.ts';
 
+// Start lazy locale loading early; React still waits for the same promise below.
 initializeI18n();
 
 // Initialize cookie consent listener (must be before analytics)

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -48,6 +48,21 @@ export default defineConfig(() => ({
   build: {
     // Enable source maps for better debugging
     sourcemap: false, // Disable in production for smaller builds
+    rollupOptions: {
+      output: {
+        manualChunks(id) {
+          const normalizedId = id.split(path.sep).join("/");
+          const localeMatch = normalizedId.match(/\/src\/lib\/i18n\/locales\/([^/]+)\//);
+          const locale = localeMatch?.[1];
+
+          if (!locale || locale === "en") {
+            return undefined;
+          }
+
+          return `locale-${locale}`;
+        },
+      },
+    },
     // Optimize dependencies
     commonjsOptions: {
       include: [/node_modules/]


### PR DESCRIPTION
## Summary

- Keep the English fallback catalog eagerly bundled, but lazy-load inactive non-English locale catalogs on bootstrap or language switch.
- Group each non-English locale into a single Rollup chunk and keep full-catalog guardrail tests out of the production i18n module export.
- Add regression coverage for lazy language switching and switching away/back.

> Avoid naming corporate partners, customers, or other sensitive external brands in this PR title or body. Use generic descriptors unless a maintainer explicitly approves the public reference.

## Motivation

- Every visitor currently downloads every locale catalog in the entry chunk even when only one locale can render.
- This preserves language switching, stored overrides, browser detection, English fallback behavior, and prerender support while moving inactive catalogs out of the entry.

Bundle measurement commands:
- Before: npm run build, then wc -c dist/assets/index-*.js and gzip -9 -c dist/assets/index-Dxo9AnxD.js | wc -c
- After: npm run build, then wc -c dist/assets/index-*.js and gzip -9 -c dist/assets/index-KEUGdzr_.js | wc -c

Bundle measurement:
- Before entry: 4,639,294 B raw / 1,347,610 B gzip -9
- After entry: 3,453,372 B raw / 980,182 B gzip -9
- Entry reduction: 1,185,922 B raw / 367,428 B gzip -9
- Emitted locale chunks: 19 non-English locale-*.js chunks, one per locale
- Spot check: Vietnamese "Trang chủ" and Urdu "تلاش" are present only in locale chunks, not in the entry chunk.

Trade-off: non-English visitors now fetch one locale chunk before first render. English visitors pay no extra request, and inactive catalogs no longer ship in the entry.

## Related Issue

- Closes #525

## Testing

- [x] npm run test
- [x] Manual verification completed
  - npx vitest run src/lib/i18n/index.test.ts src/lib/i18n/locales.test.ts
  - npm run build
  - wc/gzip bundle measurement commands above
  - rg -l "Trang chủ|تلاش" dist/assets/index-*.js dist/assets/locale-*.js

## Visuals

- [ ] UI change with screenshots/video attached
- [x] No visual change
- [x] Visuals and text avoid sensitive external brand or partner names unless explicitly approved