### PR TITLE
chore(i18n): translate paid partnership disclosure

### DIFF
--- a/src/lib/i18n/locales.test.ts
+++ b/src/lib/i18n/locales.test.ts
@@ -84,6 +84,7 @@ const MUST_BE_TRANSLATED_PREFIXES = [
   // docstring above excludes on purpose.
   'notificationsPage.errorTitle',
   'notificationsPage.errorFallback',
+  'discovery.paidPartnership',
   // Featured-navigation fallback copy. Same reasoning: full sentences, named
   // individually rather than widening to `videoPage.` so the short labels that
   // sit alongside them are not dragged in.

--- a/src/lib/i18n/locales/ar/common.json
+++ b/src/lib/i18n/locales/ar/common.json
@@ -70,6 +70,7 @@
     "hot": "رائج",
     "new": "جديد",
     "featured": "مميز",
+    "paidPartnership": "شراكة مدفوعة مع <bdi>{{sponsorName}}</bdi>",
     "tags": "الوسوم",
     "verifiedOnly": "من صنع البشر",
     "verifiedOnlyHint": "يتم عرض الفيديوهات التي تحتوي على تحقق ProofMode فقط",

--- a/src/lib/i18n/locales/de/common.json
+++ b/src/lib/i18n/locales/de/common.json
@@ -70,6 +70,7 @@
     "hot": "Heiss",
     "new": "Neu",
     "featured": "Empfohlen",
+    "paidPartnership": "Bezahlte Partnerschaft mit <bdi>{{sponsorName}}</bdi>",
     "tags": "Tags",
     "verifiedOnly": "Von Menschen gemacht",
     "verifiedOnlyHint": "Es werden nur Videos mit ProofMode-Verifizierung angezeigt",

--- a/src/lib/i18n/locales/en/common.json
+++ b/src/lib/i18n/locales/en/common.json
@@ -70,6 +70,7 @@
     "hot": "Hot",
     "new": "New",
     "featured": "Featured",
+    "paidPartnership": "In paid partnership with <bdi>{{sponsorName}}</bdi>",
     "tags": "Tags",
     "verifiedOnly": "Human Made",
     "verifiedOnlyHint": "Showing only videos with ProofMode verification",

--- a/src/lib/i18n/locales/es/common.json
+++ b/src/lib/i18n/locales/es/common.json
@@ -70,6 +70,7 @@
     "hot": "Popular",
     "new": "Nuevo",
     "featured": "Destacado",
+    "paidPartnership": "En colaboración pagada con <bdi>{{sponsorName}}</bdi>",
     "tags": "Etiquetas",
     "verifiedOnly": "Hecho por humanos",
     "verifiedOnlyHint": "Mostrando solo videos con verificacion ProofMode",

--- a/src/lib/i18n/locales/fil/common.json
+++ b/src/lib/i18n/locales/fil/common.json
@@ -70,6 +70,7 @@
     "hot": "Sikat",
     "new": "Bago",
     "featured": "Tampok",
+    "paidPartnership": "Bayad na partnership kasama ang <bdi>{{sponsorName}}</bdi>",
     "tags": "Mga Tag",
     "verifiedOnly": "Gawa ng Tao",
     "verifiedOnlyHint": "Mga video lang na may ProofMode verification.",

--- a/src/lib/i18n/locales/fr/common.json
+++ b/src/lib/i18n/locales/fr/common.json
@@ -70,6 +70,7 @@
     "hot": "Tendance",
     "new": "Nouveau",
     "featured": "A la une",
+    "paidPartnership": "Partenariat rémunéré avec <bdi>{{sponsorName}}</bdi>",
     "tags": "Tags",
     "verifiedOnly": "Cree par des humains",
     "verifiedOnlyHint": "Affiche uniquement les videos avec verification ProofMode",

--- a/src/lib/i18n/locales/id/common.json
+++ b/src/lib/i18n/locales/id/common.json
@@ -70,6 +70,7 @@
     "hot": "Populer",
     "new": "Baru",
     "featured": "Unggulan",
+    "paidPartnership": "Kemitraan berbayar dengan <bdi>{{sponsorName}}</bdi>",
     "tags": "Tag",
     "verifiedOnly": "Buatan manusia",
     "verifiedOnlyHint": "Hanya menampilkan video dengan verifikasi ProofMode",

--- a/src/lib/i18n/locales/it/common.json
+++ b/src/lib/i18n/locales/it/common.json
@@ -70,6 +70,7 @@
     "hot": "Caldo",
     "new": "Nuovo",
     "featured": "In evidenza",
+    "paidPartnership": "Partnership a pagamento con <bdi>{{sponsorName}}</bdi>",
     "tags": "Tag",
     "verifiedOnly": "Creato da umani",
     "verifiedOnlyHint": "Mostra solo video con verifica ProofMode",

--- a/src/lib/i18n/locales/ja/common.json
+++ b/src/lib/i18n/locales/ja/common.json
@@ -70,6 +70,7 @@
     "hot": "人気",
     "new": "新着",
     "featured": "注目",
+    "paidPartnership": "<bdi>{{sponsorName}}</bdi>との有料パートナーシップ",
     "tags": "タグ",
     "verifiedOnly": "人が作成",
     "verifiedOnlyHint": "ProofMode 検証済みの動画のみ表示しています",

--- a/src/lib/i18n/locales/ko/common.json
+++ b/src/lib/i18n/locales/ko/common.json
@@ -70,6 +70,7 @@
     "hot": "인기",
     "new": "신규",
     "featured": "추천",
+    "paidPartnership": "<bdi>{{sponsorName}}</bdi>와의 유료 파트너십",
     "tags": "태그",
     "verifiedOnly": "사람이 만든 콘텐츠",
     "verifiedOnlyHint": "ProofMode 검증이 있는 동영상만 표시합니다",

--- a/src/lib/i18n/locales/ms/common.json
+++ b/src/lib/i18n/locales/ms/common.json
@@ -70,6 +70,7 @@
     "hot": "Hangat",
     "new": "Baharu",
     "featured": "Pilihan",
+    "paidPartnership": "Perkongsian berbayar dengan <bdi>{{sponsorName}}</bdi>",
     "tags": "Tag",
     "verifiedOnly": "Buatan Manusia",
     "verifiedOnlyHint": "Menunjukkan hanya video dengan pengesahan ProofMode",

--- a/src/lib/i18n/locales/nl/common.json
+++ b/src/lib/i18n/locales/nl/common.json
@@ -70,6 +70,7 @@
     "hot": "Heet",
     "new": "Nieuw",
     "featured": "Uitgelicht",
+    "paidPartnership": "Betaald partnerschap met <bdi>{{sponsorName}}</bdi>",
     "tags": "Tags",
     "verifiedOnly": "Door mensen gemaakt",
     "verifiedOnlyHint": "Toont alleen video's met ProofMode-verificatie",

--- a/src/lib/i18n/locales/pl/common.json
+++ b/src/lib/i18n/locales/pl/common.json
@@ -70,6 +70,7 @@
     "hot": "Gorace",
     "new": "Nowe",
     "featured": "Polecane",
+    "paidPartnership": "Płatna współpraca z <bdi>{{sponsorName}}</bdi>",
     "tags": "Tagi",
     "verifiedOnly": "Stworzone przez ludzi",
     "verifiedOnlyHint": "Pokazuje tylko filmy z weryfikacja ProofMode",

--- a/src/lib/i18n/locales/pt/common.json
+++ b/src/lib/i18n/locales/pt/common.json
@@ -70,6 +70,7 @@
     "hot": "Em alta",
     "new": "Novo",
     "featured": "Destaque",
+    "paidPartnership": "Parceria paga com <bdi>{{sponsorName}}</bdi>",
     "tags": "Tags",
     "verifiedOnly": "Feito por humanos",
     "verifiedOnlyHint": "Mostrando apenas videos com verificacao ProofMode",

--- a/src/lib/i18n/locales/ro/common.json
+++ b/src/lib/i18n/locales/ro/common.json
@@ -70,6 +70,7 @@
     "hot": "Popular",
     "new": "Nou",
     "featured": "Recomandat",
+    "paidPartnership": "Parteneriat plătit cu <bdi>{{sponsorName}}</bdi>",
     "tags": "Etichete",
     "verifiedOnly": "Creat de oameni",
     "verifiedOnlyHint": "Afiseaza doar videoclipuri cu verificare ProofMode",

--- a/src/lib/i18n/locales/sv/common.json
+++ b/src/lib/i18n/locales/sv/common.json
@@ -70,6 +70,7 @@
     "hot": "Hett",
     "new": "Nytt",
     "featured": "Utvalt",
+    "paidPartnership": "Betalt partnerskap med <bdi>{{sponsorName}}</bdi>",
     "tags": "Taggar",
     "verifiedOnly": "Skapad av manniskor",
     "verifiedOnlyHint": "Visar endast videor med ProofMode-verifiering",

--- a/src/lib/i18n/locales/tr/common.json
+++ b/src/lib/i18n/locales/tr/common.json
@@ -70,6 +70,7 @@
     "hot": "Populer",
     "new": "Yeni",
     "featured": "Öne çıkan",
+    "paidPartnership": "<bdi>{{sponsorName}}</bdi> ile ücretli iş birliği",
     "tags": "Etiketler",
     "verifiedOnly": "Insan yapimi",
     "verifiedOnlyHint": "Yalnizca ProofMode dogrulamali videolar gosteriliyor",

--- a/src/lib/i18n/locales/ur/common.json
+++ b/src/lib/i18n/locales/ur/common.json
@@ -70,6 +70,7 @@
     "hot": "ہاٹ",
     "new": "نئے",
     "featured": "نمایاں",
+    "paidPartnership": "<bdi>{{sponsorName}}</bdi> کے ساتھ بامعاوضہ شراکت داری",
     "tags": "ٹیگز",
     "verifiedOnly": "انسان کا بنایا",
     "verifiedOnlyHint": "صرف ProofMode تصدیق شدہ ویڈیوز دکھائی جا رہی ہیں",

--- a/src/lib/i18n/locales/vi/common.json
+++ b/src/lib/i18n/locales/vi/common.json
@@ -70,6 +70,7 @@
     "hot": "Hot",
     "new": "Mới",
     "featured": "Nổi bật",
+    "paidPartnership": "Hợp tác trả phí với <bdi>{{sponsorName}}</bdi>",
     "tags": "Thẻ",
     "verifiedOnly": "Do con người tạo ra",
     "verifiedOnlyHint": "Chỉ hiển thị video có xác minh ProofMode",

--- a/src/lib/i18n/locales/zh/common.json
+++ b/src/lib/i18n/locales/zh/common.json
@@ -70,6 +70,7 @@
     "hot": "火爆",
     "new": "最新",
     "featured": "精选",
+    "paidPartnership": "与 <bdi>{{sponsorName}}</bdi> 的付费合作",
     "tags": "标签",
     "verifiedOnly": "真人创作",
     "verifiedOnlyHint": "只显示通过 ProofMode 验证的视频",

--- a/src/pages/DiscoveryPage.test.tsx
+++ b/src/pages/DiscoveryPage.test.tsx
@@ -8,6 +8,20 @@ import DiscoveryPage from './DiscoveryPage';
 import type { CategoryWithConfig } from '@/hooks/useCategories';
 import type { ResolvedFeaturedTab } from '@/types/featuredTabs';
 
+function getPartnershipDisclosure(text: string): HTMLElement {
+  return screen.getByText(
+    (_, element) => element?.textContent === text,
+    { selector: 'span' },
+  );
+}
+
+function queryPartnershipDisclosure(): HTMLElement | null {
+  return screen.queryByText(
+    (_, element) => element?.textContent?.includes('colaboración pagada') ?? false,
+    { selector: 'span' },
+  );
+}
+
 const {
   mockNavigate,
   mockCategories,
@@ -360,7 +374,9 @@ describe('DiscoveryPage', () => {
     );
 
     expect(screen.getByTestId('video-feed-featured')).toHaveAttribute('data-featured-tab-id', 'ft_1234abcd');
-    expect(screen.getByText('In paid partnership with Acme Bikes')).toBeInTheDocument();
+    const disclosure = getPartnershipDisclosure('En colaboración pagada con Acme Bikes');
+    expect(disclosure).toBeInTheDocument();
+    expect(disclosure.querySelector('bdi')).toHaveTextContent('Acme Bikes');
     expect(screen.getByRole('tab', { name: 'Destacado: Skate week' })).toHaveTextContent('Skate week');
     expect(screen.getAllByText(/Acme Bikes/)).toHaveLength(1);
   });
@@ -382,7 +398,7 @@ describe('DiscoveryPage', () => {
       </MemoryRouter>,
     );
 
-    expect(screen.queryByText(/In paid partnership with/)).not.toBeInTheDocument();
+    expect(queryPartnershipDisclosure()).not.toBeInTheDocument();
   });
 
   it.each(['empty', 'failed'] as const)(
@@ -405,10 +421,33 @@ describe('DiscoveryPage', () => {
         </MemoryRouter>,
       );
 
-      expect(screen.getByText('In paid partnership with Acme Bikes')).toBeInTheDocument();
+      expect(getPartnershipDisclosure('En colaboración pagada con Acme Bikes')).toBeInTheDocument();
       expect(screen.getByText(feedState)).toBeInTheDocument();
     },
   );
+
+  it('wraps the sponsor name with bdi for RTL disclosure copy', async () => {
+    window.localStorage.setItem(LOCALE_STORAGE_KEY, 'ar');
+    await initializeI18n({ force: true, languages: ['ar'] });
+    mockFeaturedTab.current = {
+      id: 'ft_1234abcd',
+      slug: 'seasonal-theme',
+      label: 'Especial',
+      pillLabel: null,
+      sponsorName: 'Acme Bikes',
+    };
+
+    render(
+      <MemoryRouter initialEntries={['/discovery/seasonal-theme']}>
+        <Routes>
+          <Route path="/discovery/:tab" element={<DiscoveryPage />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    const disclosure = getPartnershipDisclosure('شراكة مدفوعة مع Acme Bikes');
+    expect(disclosure.querySelector('bdi')).toHaveTextContent('Acme Bikes');
+  });
 
   it('names every tab trigger when labels are visually hidden on mobile', () => {
     mockFeaturedTab.current = {

--- a/src/pages/DiscoveryPage.tsx
+++ b/src/pages/DiscoveryPage.tsx
@@ -3,7 +3,7 @@
 // ABOUTME: For You tab shows personalized recommendations when user is logged in
 
 import { type ComponentType, useEffect, useMemo, useState } from 'react';
-import { useTranslation } from 'react-i18next';
+import { Trans, useTranslation } from 'react-i18next';
 import { useParams } from 'react-router-dom';
 import { useSubdomainNavigate } from '@/hooks/useSubdomainNavigate';
 import { VideoFeed } from '@/components/VideoFeed';
@@ -318,7 +318,12 @@ export function DiscoveryPage() {
               {activeTabItem.featuredTab.sponsorName && (
                 <div className="flex justify-center">
                   <span className="inline-flex max-w-full rounded-full border border-border bg-background px-3 py-1 text-center text-sm font-medium text-foreground">
-                    In paid partnership with {activeTabItem.featuredTab.sponsorName}
+                    {/* bdi keeps Latin sponsor names stable inside RTL disclosure copy. */}
+                    <Trans
+                      i18nKey="discovery.paidPartnership"
+                      values={{ sponsorName: activeTabItem.featuredTab.sponsorName }}
+                      components={{ bdi: <bdi /> }}
+                    />
                   </span>
                 </div>
               )}


### PR DESCRIPTION
## Summary

- Routes the featured-tab paid partnership disclosure through i18n with a whole-sentence key.
- Adds paid-disclosure copy for all supported locales and wraps the sponsor name in `bdi` for RTL rendering.
- Adds locale enforcement so non-English catalogs cannot silently keep the English disclosure.

> Avoid naming corporate partners, customers, or other sensitive external brands in this PR title or body. Use generic descriptors unless a maintainer explicitly approves the public reference.

## Motivation

- The disclosure was hardcoded English on Discovery, which leaves non-English users with an unreadable legal disclosure when a sponsored featured tab is shown.
- Issue #611 asks for the web client to translate this disclosure while preserving the sponsor name verbatim.
- Reviewer note: please verify the paid/commercial meaning of each localized disclosure string.

## Related Issue

- Closes #611

## Testing

- [x] `npm run test`
- [x] Manual verification completed: reviewed the rendered `Trans` path and locale catalog diff.

## Visuals

- [ ] UI change with screenshots/video attached
- [x] No visual layout change
- [x] Visuals and text avoid sensitive external brand or partner names unless explicitly approved