### PR TITLE
fix(discovery): stop the featured tab pill from clipping

### DIFF
--- a/src/pages/DiscoveryPage.test.tsx
+++ b/src/pages/DiscoveryPage.test.tsx
@@ -434,4 +434,71 @@ describe('DiscoveryPage', () => {
       'Etiquetas',
     ]);
   });
+
+  describe('featured tab pill layout', () => {
+    const FEATURED: ResolvedFeaturedTab = {
+      id: 'ft_1234abcd',
+      slug: 'seasonal-theme',
+      label: 'Especial',
+      pillLabel: 'Skate week',
+      sponsorName: null,
+    };
+
+    function renderAt(route: string) {
+      mockFeaturedTab.current = FEATURED;
+      return render(
+        <MemoryRouter initialEntries={[route]}>
+          <Routes>
+            <Route path="/discovery/:tab" element={<DiscoveryPage />} />
+          </Routes>
+        </MemoryRouter>,
+      );
+    }
+
+    // The pill used to clip because every trigger shared an equal `1fr` grid
+    // column while only the featured one carried a third child. The featured
+    // trigger now sizes to its content and the rest split what is left.
+    it('sizes the featured trigger to its content and lets the others share the rest', () => {
+      renderAt('/discovery/seasonal-theme');
+
+      const featured = screen.getByRole('tab', { name: 'Destacado: Skate week' });
+      expect(featured).toHaveClass('shrink-0');
+      expect(featured).not.toHaveClass('flex-1');
+
+      for (const name of ['Clasico', 'Popular', 'Etiquetas']) {
+        const trigger = screen.getByRole('tab', { name });
+        expect(trigger).toHaveClass('flex-1', 'min-w-0');
+      }
+    });
+
+    it('renders the pill label in full rather than a clipped copy', () => {
+      renderAt('/discovery/seasonal-theme');
+
+      const pill = screen.getByTestId('featured-tab-pill');
+      expect(pill).toHaveTextContent('Skate week');
+      expect(pill).toHaveAttribute('title', 'Skate week');
+    });
+
+    // Between `sm` and `md` the pill shows only for the active tab, so the
+    // other four triggers keep their labels when the user is somewhere else.
+    it('reveals the pill on the active tab and at md and up', () => {
+      renderAt('/discovery/seasonal-theme');
+
+      const pill = screen.getByTestId('featured-tab-pill');
+      expect(pill).toHaveClass('hidden');
+      expect(pill).toHaveClass('sm:group-data-[state=active]:inline-block');
+      expect(pill).toHaveClass('md:inline-block');
+      expect(
+        screen.getByRole('tab', { name: 'Destacado: Skate week' }),
+      ).toHaveClass('group');
+    });
+
+    it('gives the pill an opaque sticker fill so it reads on both tab states', () => {
+      renderAt('/discovery/classics');
+
+      const pill = screen.getByTestId('featured-tab-pill');
+      expect(pill).toHaveClass('bg-brand-yellow', 'text-brand-dark-green');
+      expect(pill).not.toHaveClass('bg-background/80');
+    });
+  });
 });

--- a/src/pages/DiscoveryPage.tsx
+++ b/src/pages/DiscoveryPage.tsx
@@ -17,6 +17,7 @@ import { useCategories } from '@/hooks/useCategories';
 import { useFeaturedTab } from '@/hooks/useFeaturedTab';
 import { useFunnelcakeSupport } from '@/hooks/useVideoProvider';
 import { getTranslatedCategoryLabel } from '@/lib/constants/categories';
+import { cn } from '@/lib/utils';
 import { trackEvent } from '@/lib/analytics';
 import type { ResolvedFeaturedTab } from '@/types/featuredTabs';
 
@@ -245,22 +246,48 @@ export function DiscoveryPage() {
           }}
           className="space-y-6"
         >
-          <TabsList
-            className="grid w-full gap-1"
-            style={{ gridTemplateColumns: `repeat(${tabItems.length}, minmax(0, 1fr))` }}
-          >
-            {tabItems.map(({ value, label, Icon, pillLabel }) => (
+          {/*
+            Equal `1fr` columns used to clip the featured pill: only the
+            featured trigger carries a third child, so it needed more room than
+            the average column it was allotted and the pill was the child that
+            gave. The featured trigger now sizes to its content and the rest
+            share what is left.
+          */}
+          <TabsList className="flex w-full gap-1">
+            {tabItems.map(({ value, label, Icon, pillLabel, featuredTab: featuredConfig }) => (
               <TabsTrigger
                 key={value}
                 value={value}
-                className="min-w-0 gap-1.5 px-2 sm:gap-2 sm:px-4"
+                className={cn(
+                  'min-w-0 gap-1.5 px-2 sm:gap-2 sm:px-4',
+                  featuredConfig ? 'group shrink-0' : 'flex-1'
+                )}
                 aria-label={pillLabel ? `${label}: ${pillLabel}` : label}
               >
                 <Icon className="h-4 w-4 shrink-0" />
                 <span className="hidden min-w-0 truncate sm:inline" title={label}>{label}</span>
                 {pillLabel && (
+                  /*
+                    A sticker rather than a chip: the old `bg-background/80` sat
+                    on the muted tab bar with almost no separation. Opaque brand
+                    yellow with dark-green ink clears AA against both the muted
+                    bar and the green active trigger, and needs no dark-mode
+                    variant because both tokens are theme-invariant.
+
+                    Between `sm` and `md` the pill shows only on the active
+                    trigger: measured at a 640px viewport, keeping it open there
+                    truncates the "For You" and "Classic" labels. From `md` up
+                    there is room for it to simply stay open. The toggle is
+                    `display` rather than an animated `max-width` because
+                    `max-w-0` cannot crush the border and padding below ~16px,
+                    which left a yellow sliver on the furled pill.
+
+                    `max-w-[9rem]` is a backstop, not the usual case: pill labels
+                    are capped at 24 characters by parseFeaturedTabPillLabel.
+                  */
                   <span
-                    className="hidden max-w-[7rem] shrink truncate rounded-full bg-background/80 px-1.5 py-0.5 text-[10px] leading-none text-foreground sm:inline"
+                    data-testid="featured-tab-pill"
+                    className="hidden max-w-[9rem] shrink-0 truncate rounded-full border-2 border-brand-dark-green bg-brand-yellow px-1.5 py-0.5 text-[10px] font-semibold leading-none text-brand-dark-green sm:group-data-[state=active]:inline-block md:inline-block"
                     title={pillLabel}
                   >
                     {pillLabel}


### PR DESCRIPTION
## What

The Discovery tab bar laid its triggers out as a grid of equal `1fr` columns. Only the featured trigger carries a third child (icon + label + pill), so it needed more room than the average column it was allotted — and the pill was the child that gave. The live pill label renders as `#…` beside a `Fe…` tab label.

Note the live label is short (three emoji glyphs); the clipping is not caused by a long string. Three emoji measure ~40px, which is enough to blow the column on its own.

## How

- Lay the bar out as flex rather than a rigid equal-column grid. The featured trigger gets `shrink-0` and sizes to its content; the rest get `flex-1` and share what is left.
- Replace the pill's `bg-background/80`, which sat on the muted tab bar with almost no separation and read as a smudge even when it was not clipped. Opaque brand yellow with dark-green ink clears AA (~14.4:1) against both the muted bar and the green active trigger, and needs no dark-mode variant because both tokens are theme-invariant.
- Between `sm` and `md` the pill shows only on the active trigger. Measured at a 640px viewport, keeping it open there truncates the "For You" and "Classic" labels; at 740px it can stay open with no truncation.

## Notes for review

A couple of things worth knowing, since both were wrong on the first pass and only surfaced by running the app:

- I first suspected the emoji were clipping *vertically* inside `leading-none` + `overflow: hidden`. They are not — forcing `overflow: visible` produced pixel-identical glyphs. The cause is purely the horizontal column squeeze.
- The reveal was originally an animated `max-width` unfurl. `max-w-0` cannot crush `border-2` + `px-1.5` below ~16px under border-box sizing, which left a yellow sliver on the collapsed pill. It is a plain `display` toggle now. That trades away the animation, but the animation only ever played in a ~60px viewport band (640–700px) for logged-in users, so it was not paying for the artifact.

## Testing

- `npm run test` — 280 files / 2264 tests pass, 0 lint errors, type-check and build clean.
- Four new tests in `DiscoveryPage.test.tsx` cover trigger sizing, full pill text + `title`, the reveal variants, and the opaque fill.
- Verified manually against the live featured tab at 640px, 740px, and desktop width, active and inactive. jsdom has no layout, so the unit tests assert classes; I also grepped the built CSS to confirm `sm:group-data-[state=active]:inline-block` and `md:inline-block` actually emit inside the right media queries — a silently-dropped arbitrary variant would pass tests and break in the browser.
