### PR TITLE
docs: disclose Shorebird update telemetry

### DIFF
--- a/scripts/prerender-content/privacy-content.html
+++ b/scripts/prerender-content/privacy-content.html
@@ -37,6 +37,14 @@
         <li>Public video content</li>
         <li>Followers/Following lists</li>
       </ul>
+      <p style="color:#374151;margin-top:1rem;">
+        Divine uses Shorebird to check for and deliver app updates. When the app checks for an update,
+        Shorebird receives a random identifier unique to that app installation, the app, release, and patch
+        versions, update channel, platform, device architecture, and patch download or installation status.
+        This information is used to deliver updates, diagnose update failures, and produce aggregated update
+        and active-install analytics. The installation identifier is not an advertising identifier and is not
+        used for advertising or cross-app tracking.
+      </p>
     </div>
     <div>
       <h3 style="font-weight:600;margin-bottom:0.5rem;">What We Don't Collect</h3>

--- a/src/pages/PrivacyPage.tsx
+++ b/src/pages/PrivacyPage.tsx
@@ -12,7 +12,7 @@ export function PrivacyPage() {
       <div className="container mx-auto px-4 py-8 max-w-4xl">
         <ZendeskWidget />
         <h1 className="text-4xl font-extrabold mb-4">{t('privacyPage.title')}</h1>
-        <p className="text-muted-foreground mb-8">{t('privacyPage.lastUpdated', { date: 'March 30, 2026' })}</p>
+        <p className="text-muted-foreground mb-8">{t('privacyPage.lastUpdated', { date: 'August 17, 2026' })}</p>
 
         <div className="space-y-8 text-muted-foreground leading-relaxed">
           {/* 1. Overview */}
@@ -116,6 +116,14 @@ export function PrivacyPage() {
               We collect information automatically when you use the Service, including device and browser
               information, IP address, approximate location derived from network signals, and logs relating to
               interactions with Divine-controlled infrastructure.
+            </p>
+            <p className="mb-3">
+              Divine uses Shorebird to check for and deliver app updates. When the app checks for an update,
+              Shorebird receives a random identifier unique to that app installation, the app, release, and patch
+              versions, update channel, platform, device architecture, and patch download or installation status.
+              This information is used to deliver updates, diagnose update failures, and produce aggregated update
+              and active-install analytics. The installation identifier is not an advertising identifier and is
+              not used for advertising or cross-app tracking.
             </p>
             <p className="mb-3">
               We may also collect and generate information for safety and moderation purposes, including reports,

--- a/src/pages/static-pages-i18n.test.tsx
+++ b/src/pages/static-pages-i18n.test.tsx
@@ -80,6 +80,8 @@ describe('static pages i18n', () => {
     );
 
     expect(screen.getByRole('heading', { name: 'Política de privacidad' })).toBeInTheDocument();
+    expect(screen.getByText(/Divine uses Shorebird to check for and deliver app updates/)).toBeInTheDocument();
+    expect(screen.getByText(/not used for advertising or cross-app tracking/)).toBeInTheDocument();
   });
 
   it('renders safety copy in spanish', () => {

--- a/tests/privacy-prerender-content.test.ts
+++ b/tests/privacy-prerender-content.test.ts
@@ -1,0 +1,39 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const REPO_ROOT = resolve(__dirname, '..');
+
+function readPrerenderedPrivacy(): string {
+  return readFileSync(resolve(REPO_ROOT, 'scripts/prerender-content/privacy-content.html'), 'utf8')
+    .replace(/\s+/g, ' ');
+}
+
+describe('prerendered privacy policy', () => {
+  it('keeps the Shorebird update-telemetry disclosure in the prerendered copy', () => {
+    const source = readPrerenderedPrivacy();
+
+    expect(source).toContain('Divine uses Shorebird to check for and deliver app updates.');
+    expect(source).toContain(
+      'The installation identifier is not an advertising identifier and is not used for advertising or cross-app tracking.',
+    );
+  });
+
+  it('keeps the prerendered Shorebird disclosure aligned with the React privacy page', () => {
+    const prerendered = readPrerenderedPrivacy();
+    const page = readFileSync(resolve(REPO_ROOT, 'src/pages/PrivacyPage.tsx'), 'utf8')
+      .replace(/\s+/g, ' ');
+
+    const disclosureSentences = [
+      'Divine uses Shorebird to check for and deliver app updates.',
+      'Shorebird receives a random identifier unique to that app installation, the app, release, and patch versions, update channel, platform, device architecture, and patch download or installation status.',
+      'This information is used to deliver updates, diagnose update failures, and produce aggregated update and active-install analytics.',
+      'The installation identifier is not an advertising identifier and is not used for advertising or cross-app tracking.',
+    ];
+
+    for (const sentence of disclosureSentences) {
+      expect(prerendered, `prerendered copy must contain: ${sentence}`).toContain(sentence);
+      expect(page, `PrivacyPage copy must contain: ${sentence}`).toContain(sentence);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- disclose the update-check and patch-event data sent to Shorebird
- state its operational, diagnostic, and aggregated analytics purposes
- keep the JavaScript and prerendered legal copies aligned
- update the policy date and pin the disclosure with a rendering test

## Motivation

- Divine mobile PR #7202 enables Shorebird code push for store builds, so the public policy needs to describe the resulting automatic collection

## Related Issue

- Related: divinevideo/divine-mobile#7202

## Testing

- [x] `npm run test`
- [ ] Manual verification completed

## Visuals

- [x] No visual change
- [x] Visuals and text avoid sensitive external brand or partner names unless explicitly approved