### PR TITLE
feat(discovery): show a taco on the featured tab in mobile browsers

### DIFF
--- a/src/components/PWAInstallPrompt.tsx
+++ b/src/components/PWAInstallPrompt.tsx
@@ -4,6 +4,7 @@ import { useLocation } from 'react-router-dom';
 import { DownloadSimple as Download, X } from '@phosphor-icons/react';
 import { Button } from '@/components/ui/button';
 import { APP_STORE_URL, PLAY_STORE_URL } from '@/lib/mobileStoreLinks';
+import { isMobileUserAgent } from '@/lib/isMobileUserAgent';
 
 interface NavigatorWithStandalone extends Navigator {
   standalone?: boolean;
@@ -32,10 +33,8 @@ export function PWAInstallPrompt({ delayMs = 10000 }: { delayMs?: number } = {})
   useEffect(() => {
     // Check if mobile device
     const checkMobile = () => {
-      const userAgent = window.navigator.userAgent.toLowerCase();
-      const isMobileDevice = /iphone|ipad|ipod|android|mobile/.test(userAgent);
       const isSmallScreen = window.innerWidth < 768; // md breakpoint
-      setIsMobile(isMobileDevice || isSmallScreen);
+      setIsMobile(isMobileUserAgent(window.navigator.userAgent) || isSmallScreen);
     };
 
     checkMobile();

--- a/src/hooks/useIsMobileDevice.test.tsx
+++ b/src/hooks/useIsMobileDevice.test.tsx
@@ -1,0 +1,51 @@
+import { renderHook } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+import { useIsMobileDevice } from './useIsMobileDevice';
+
+const ORIGINAL_USER_AGENT = window.navigator.userAgent;
+
+function setUserAgent(userAgent: string) {
+  Object.defineProperty(window.navigator, 'userAgent', {
+    configurable: true,
+    value: userAgent,
+  });
+}
+
+describe('useIsMobileDevice', () => {
+  afterEach(() => {
+    setUserAgent(ORIGINAL_USER_AGENT);
+  });
+
+  it('reports true for a phone user agent', () => {
+    setUserAgent('Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) Mobile/15E148 Safari/604.1');
+
+    const { result } = renderHook(() => useIsMobileDevice());
+
+    expect(result.current).toBe(true);
+  });
+
+  it('reports false for a desktop user agent', () => {
+    setUserAgent('Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 Chrome/120.0.0.0 Safari/537.36');
+
+    const { result } = renderHook(() => useIsMobileDevice());
+
+    expect(result.current).toBe(false);
+  });
+
+  // The user agent is only readable in the browser. Reporting mobile during the
+  // first render would make prerendered markup disagree with hydration, so the
+  // answer only arrives once the effect has run.
+  it('does not claim mobile before the effect reads the user agent', () => {
+    setUserAgent('Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) Mobile/15E148 Safari/604.1');
+
+    const renders: boolean[] = [];
+    renderHook(() => {
+      const value = useIsMobileDevice();
+      renders.push(value);
+      return value;
+    });
+
+    expect(renders[0]).toBe(false);
+    expect(renders.at(-1)).toBe(true);
+  });
+});

--- a/src/hooks/useIsMobileDevice.ts
+++ b/src/hooks/useIsMobileDevice.ts
@@ -1,0 +1,23 @@
+// ABOUTME: Reports whether the page is being viewed in a mobile browser, by user agent
+// ABOUTME: Not useIsMobile — that one measures viewport width, which a narrow desktop window also passes
+
+import { useEffect, useState } from 'react';
+import { isMobileUserAgent } from '@/lib/isMobileUserAgent';
+
+/**
+ * True on a phone or tablet browser.
+ *
+ * Starts false and only settles after the effect runs. The user agent is
+ * readable in the browser alone, so answering during the first render would
+ * make prerendered markup disagree with what hydration produces. Callers must
+ * therefore treat the desktop branch as the safe default, not as a fact.
+ */
+export function useIsMobileDevice(): boolean {
+  const [isMobileDevice, setIsMobileDevice] = useState(false);
+
+  useEffect(() => {
+    setIsMobileDevice(isMobileUserAgent(window.navigator.userAgent));
+  }, []);
+
+  return isMobileDevice;
+}

--- a/src/lib/isMobileUserAgent.test.ts
+++ b/src/lib/isMobileUserAgent.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+import { isMobileUserAgent } from './isMobileUserAgent';
+
+describe('isMobileUserAgent', () => {
+  it('matches phone and tablet browsers', () => {
+    const agents = [
+      'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1',
+      'Mozilla/5.0 (iPad; CPU OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1',
+      'Mozilla/5.0 (iPod touch; CPU iPhone OS 16_6 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148',
+      'Mozilla/5.0 (Linux; Android 14; Pixel 8) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Mobile Safari/537.36',
+      'Mozilla/5.0 (Android 13; Mobile; rv:120.0) Gecko/120.0 Firefox/120.0',
+    ];
+
+    for (const agent of agents) {
+      expect(isMobileUserAgent(agent), agent).toBe(true);
+    }
+  });
+
+  it('does not match desktop browsers', () => {
+    const agents = [
+      'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
+      'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
+      'Mozilla/5.0 (X11; Linux x86_64; rv:120.0) Gecko/20100101 Firefox/120.0',
+    ];
+
+    for (const agent of agents) {
+      expect(isMobileUserAgent(agent), agent).toBe(false);
+    }
+  });
+
+  it('is case insensitive', () => {
+    expect(isMobileUserAgent('SOME-BROWSER/1.0 (IPHONE)')).toBe(true);
+  });
+
+  // Prerender and non-browser callers have no navigator to read, and a thrown
+  // TypeError there would take down a render that only wanted to pick a glyph.
+  it('treats a missing user agent as not mobile', () => {
+    expect(isMobileUserAgent(undefined)).toBe(false);
+    expect(isMobileUserAgent(null)).toBe(false);
+    expect(isMobileUserAgent('')).toBe(false);
+  });
+});

--- a/src/lib/isMobileUserAgent.ts
+++ b/src/lib/isMobileUserAgent.ts
@@ -1,0 +1,18 @@
+// ABOUTME: User-agent predicate for "is this browser running on a phone or tablet"
+// ABOUTME: Deliberately about the device, not the viewport — see useIsMobile for width
+
+// Kept in one place so the featured tab glyph and the app install prompt can
+// never disagree about what counts as a mobile browser.
+const MOBILE_USER_AGENT = /iphone|ipad|ipod|android|mobile/;
+
+/**
+ * Whether a user-agent string belongs to a mobile browser.
+ *
+ * Tolerates a missing agent rather than throwing: prerender and test callers
+ * have no navigator to read, and a render that only wanted to pick a glyph
+ * should not be the thing that takes the page down.
+ */
+export function isMobileUserAgent(userAgent: string | null | undefined): boolean {
+  if (!userAgent) return false;
+  return MOBILE_USER_AGENT.test(userAgent.toLowerCase());
+}

--- a/src/pages/DiscoveryPage.test.tsx
+++ b/src/pages/DiscoveryPage.test.tsx
@@ -22,6 +22,22 @@ function queryPartnershipDisclosure(): HTMLElement | null {
   );
 }
 
+const TACO = '🌮';
+
+const ORIGINAL_USER_AGENT = window.navigator.userAgent;
+
+const IPHONE_USER_AGENT =
+  'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1';
+const DESKTOP_USER_AGENT =
+  'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36';
+
+function setUserAgent(userAgent: string) {
+  Object.defineProperty(window.navigator, 'userAgent', {
+    configurable: true,
+    value: userAgent,
+  });
+}
+
 const {
   mockNavigate,
   mockCategories,
@@ -132,6 +148,7 @@ describe('DiscoveryPage', () => {
     mockFeaturedApiUrl.current = 'https://api.divine.video';
     mockFeaturedFeedState.current = 'normal';
     mockUseFeaturedTabArgs.length = 0;
+    setUserAgent(ORIGINAL_USER_AGENT);
   });
 
   it('renders localized discovery copy and category pills', () => {
@@ -538,6 +555,73 @@ describe('DiscoveryPage', () => {
       const pill = screen.getByTestId('featured-tab-pill');
       expect(pill).toHaveClass('bg-brand-yellow', 'text-brand-dark-green');
       expect(pill).not.toHaveClass('bg-background/80');
+    });
+  });
+
+  describe('featured tab glyph', () => {
+    const FEATURED: ResolvedFeaturedTab = {
+      id: 'ft_1234abcd',
+      slug: 'seasonal-theme',
+      label: 'Especial',
+      pillLabel: null,
+      sponsorName: null,
+    };
+
+    function renderFeatured() {
+      mockFeaturedTab.current = FEATURED;
+      return render(
+        <MemoryRouter initialEntries={['/discovery/classics']}>
+          <Routes>
+            <Route path="/discovery/:tab" element={<DiscoveryPage />} />
+          </Routes>
+        </MemoryRouter>,
+      );
+    }
+
+    it('wears a taco in a mobile browser', () => {
+      setUserAgent(IPHONE_USER_AGENT);
+
+      renderFeatured();
+
+      const featured = screen.getByRole('tab', { name: 'Destacado' });
+      expect(featured).toHaveTextContent(TACO);
+      expect(featured.querySelector('svg')).toBeNull();
+    });
+
+    it('keeps the confetti icon in a desktop browser', () => {
+      setUserAgent(DESKTOP_USER_AGENT);
+
+      renderFeatured();
+
+      const featured = screen.getByRole('tab', { name: 'Destacado' });
+      expect(featured.textContent).not.toContain(TACO);
+      expect(featured.querySelector('svg')).not.toBeNull();
+    });
+
+    // The glyph is decoration on top of the trigger's own aria-label, so it
+    // must not leak into the accessible name or the tab's text.
+    it('hides the taco from assistive technology and from the tab label', () => {
+      setUserAgent(IPHONE_USER_AGENT);
+
+      renderFeatured();
+
+      const featured = screen.getByRole('tab', { name: 'Destacado' });
+      const taco = featured.querySelector('[aria-hidden="true"]');
+      expect(taco).not.toBeNull();
+      expect(taco).toHaveTextContent(TACO);
+      expect(featured).toHaveAttribute('aria-label', 'Destacado');
+    });
+
+    it('leaves the non-featured tabs on their own icons', () => {
+      setUserAgent(IPHONE_USER_AGENT);
+
+      renderFeatured();
+
+      for (const name of ['Clasico', 'Popular', 'Etiquetas']) {
+        const trigger = screen.getByRole('tab', { name });
+        expect(trigger.querySelector('svg')).not.toBeNull();
+        expect(trigger.textContent).not.toContain(TACO);
+      }
     });
   });
 });

--- a/src/pages/DiscoveryPage.tsx
+++ b/src/pages/DiscoveryPage.tsx
@@ -15,6 +15,7 @@ import { Star, Hash, Flame, Sparkle as Sparkles, Confetti } from '@phosphor-icon
 import { useCurrentUser } from '@/hooks/useCurrentUser';
 import { useCategories } from '@/hooks/useCategories';
 import { useFeaturedTab } from '@/hooks/useFeaturedTab';
+import { useIsMobileDevice } from '@/hooks/useIsMobileDevice';
 import { useFunnelcakeSupport } from '@/hooks/useVideoProvider';
 import { getTranslatedCategoryLabel } from '@/lib/constants/categories';
 import { cn } from '@/lib/utils';
@@ -29,20 +30,36 @@ interface DiscoveryTabItem {
   featuredTab?: ResolvedFeaturedTab;
 }
 
+// The featured tab's mobile glyph. Below `sm` every trigger is icon-only, so
+// on a phone this emoji is the entire tab — it carries the editorial identity
+// that the hidden label would otherwise. `aria-hidden` because the trigger
+// already names itself through `aria-label`; without it a screen reader would
+// announce the emoji's own description alongside that name.
+function TacoIcon({ className }: { className?: string }) {
+  return (
+    <span
+      className={cn('inline-flex items-center justify-center text-base leading-none', className)}
+      aria-hidden="true"
+    >
+      🌮
+    </span>
+  );
+}
+
 function insertFeaturedTab(
   tabs: DiscoveryTabItem[],
   featuredTab: ResolvedFeaturedTab | null,
-  featuredLabel: string
+  featuredLabel: string,
+  // Passed in rather than chosen here so this stays a pure list transform: the
+  // glyph depends on the device, which only the component knows about.
+  Icon: ComponentType<{ className?: string }>
 ): DiscoveryTabItem[] {
   if (!featuredTab) return tabs;
 
   const item: DiscoveryTabItem = {
     value: featuredTab.slug,
     label: featuredLabel,
-    // Not Hash: the hashtags tab already owns that glyph, and below `sm` the
-    // labels are hidden, so a second Hash would make the editorial tab
-    // indistinguishable from it on mobile.
-    Icon: Confetti,
+    Icon,
     pillLabel: featuredTab.pillLabel,
     featuredTab,
   };
@@ -71,6 +88,7 @@ export function DiscoveryPage() {
   const { tab: featuredTab, isResolved: isFeaturedConfigResolved } = useFeaturedTab({
     apiUrl: featuredApiUrl,
   });
+  const isMobileDevice = useIsMobileDevice();
 
   const baseTabs = useMemo<DiscoveryTabItem[]>(() => {
     const tabs: DiscoveryTabItem[] = [
@@ -103,9 +121,13 @@ export function DiscoveryPage() {
       : tabs;
   }, [isLoggedIn, t]);
 
+  // Confetti is the desktop glyph and the pre-hydration default. Not Hash: the
+  // hashtags tab already owns that one, and below `sm` the labels are hidden,
+  // so a second Hash would make the editorial tab indistinguishable from it.
+  const featuredIcon = isMobileDevice ? TacoIcon : Confetti;
   const tabItems = useMemo(
-    () => insertFeaturedTab(baseTabs, featuredTab, t('discovery.featured')),
-    [baseTabs, featuredTab, t]
+    () => insertFeaturedTab(baseTabs, featuredTab, t('discovery.featured'), featuredIcon),
+    [baseTabs, featuredTab, t, featuredIcon]
   );
 
   const allowedTabs = useMemo(() => {


### PR DESCRIPTION
## What this changes

On a phone, the Discovery tab bar is icon-only — the text labels are hidden below the `sm` breakpoint to fit five tabs across a 390px screen. That means the featured tab's icon *is* the whole tab, and it was showing the same generic confetti glyph it shows on desktop, where the label is right there next to it doing the explaining.

On a mobile browser that glyph is now a taco. Desktop is unchanged.

## Why it's gated this way

The swap keys off the browser's user agent, not the window width. A narrow desktop window keeps confetti — that was a deliberate choice, since the intent is "someone on a phone", not "someone with a small window".

The user agent is only readable in the browser, so the check starts as "not mobile" and settles once the component mounts. Prerendered markup and hydration therefore agree, and a phone shows confetti for one frame before the taco lands. Getting this backwards would mean a hydration mismatch on every prerendered page.

The same user-agent regex was already sitting inlined in the app-install prompt. Both now call one shared helper, so a future edit to one can't silently disagree with the other. That refactor is behaviour-identical — same pattern, same casing, same `|| isSmallScreen` fallback in the prompt.

## What this deliberately leaves alone

- **Desktop and narrow desktop windows.** Still confetti, by design.
- **The tab's accessible name.** The taco is `aria-hidden`; the trigger already names itself through `aria-label`, so screen readers hear exactly what they heard before. There's a test pinning this.
- **The glyph's source.** It's hard-coded in the frontend. The durable version is an emoji field on the featured-tab config from Funnelcake, which doesn't send one today — that would be a server change, not a web one.

## How it was verified

`npm run test` passes end to end on this branch: 283 files, 2292 tests, plus type-check, lint, and build.

Checked in a real browser at a 390px viewport under a spoofed iPhone user agent: the featured trigger renders the taco and drops its `<svg>`, the other four tabs keep their Phosphor icons, and the accessible name is untouched. New coverage: 4 cases on the user-agent predicate, 3 on the hook (including that it does not claim mobile before the effect runs), and 4 on the tab itself.

**Screenshot to be attached** — the reviewer should see the mobile tab bar; I can't upload images from the CLI, so it's coming in a follow-up comment.