### PR TITLE
fix(brand): keep sticker buttons from going shapeless in dark mode

### DIFF
--- a/src/styles/brand-utilities.css
+++ b/src/styles/brand-utilities.css
@@ -34,6 +34,28 @@
     box-shadow: 2px 2px 0 0 hsl(var(--brand-dark-green));
   }
 
+  /*
+    Dark mode redraws the sticker's ink in off-white. `--background`, `--card`
+    and the landing page's dark sections all resolve to the same 158 67% 8% as
+    `--brand-dark-green`, so the border and the offset shadow above were being
+    painted in the exact colour of the surface behind them: both disappeared and
+    the button flattened into a plain green rectangle with no sticker read at
+    all. Off-white is the ink `--foreground` already switches to in dark mode.
+
+    Every offset state is restated, not just the resting one — fixing the border
+    alone would leave a hover and press nobody can see.
+  */
+  .dark .brand-sticker {
+    border-color: hsl(var(--brand-off-white));
+    box-shadow: 4px 4px 0 0 hsl(var(--brand-off-white));
+  }
+  .dark .brand-sticker:hover {
+    box-shadow: 6px 6px 0 0 hsl(var(--brand-off-white));
+  }
+  .dark .brand-sticker:active {
+    box-shadow: 2px 2px 0 0 hsl(var(--brand-off-white));
+  }
+
   /* Card: thick border + optional accent shadow via composition */
   .brand-card {
     border: 2px solid hsl(var(--brand-dark-green));

--- a/tests/brand/sticker-dark-mode.test.ts
+++ b/tests/brand/sticker-dark-mode.test.ts
@@ -1,0 +1,42 @@
+import { readFileSync } from 'node:fs';
+import { describe, it, expect } from 'vitest';
+
+// In dark mode `--background`, `--card`, and the landing page's dark sections
+// all resolve to the same `158 67% 8%` as `--brand-dark-green`, which is the
+// ink `.brand-sticker` draws its border and offset shadow in. Left alone, both
+// render dark-green on dark-green and vanish: the sticker flattens into a plain
+// coloured rectangle and loses the treatment entirely. The dark-mode override
+// has to restate BOTH the border colour and every offset-shadow state, because
+// a rule that fixes only the border leaves a shadow nobody can see.
+const CSS = readFileSync('src/styles/brand-utilities.css', 'utf8');
+
+const DARK_INK = 'hsl(var(--brand-off-white))';
+
+describe('brand rule: the sticker keeps its shape in dark mode', () => {
+  it('redraws the sticker border in dark mode', () => {
+    const rule = CSS.match(/\.dark \.brand-sticker\s*\{([^}]*)\}/);
+    expect(rule, '.dark .brand-sticker rule is missing').not.toBeNull();
+    expect(rule![1]).toContain('border-color');
+    expect(rule![1]).toContain(DARK_INK);
+  });
+
+  it('redraws the sticker offset shadow in dark mode, including hover and active', () => {
+    for (const state of ['', ':hover', ':active']) {
+      const pattern = new RegExp(`\\.dark \\.brand-sticker${state}\\s*\\{([^}]*)\\}`);
+      const rule = CSS.match(pattern);
+      expect(rule, `.dark .brand-sticker${state} rule is missing`).not.toBeNull();
+      expect(rule![1], `.dark .brand-sticker${state} shadow`).toContain('box-shadow');
+      expect(rule![1], `.dark .brand-sticker${state} ink`).toContain(DARK_INK);
+    }
+  });
+
+  it('never paints dark-mode sticker ink in the colour of the dark-mode surface', () => {
+    const darkRules = CSS.match(/\.dark \.brand-sticker[^{]*\{[^}]*\}/g) ?? [];
+    expect(darkRules.length).toBeGreaterThan(0);
+    for (const rule of darkRules) {
+      expect(rule, 'dark sticker ink must not be brand-dark-green').not.toContain(
+        'hsl(var(--brand-dark-green))',
+      );
+    }
+  });
+});


### PR DESCRIPTION
## What this fixes

In dark mode, the chunky "sticker" buttons — Log in, the landing page CTAs, Merch, Save/Follow — lose the thick outline and offset shadow that make them look like stickers. They flatten into plain green rectangles. It's most obvious on the landing page's top nav button on a phone, which is where it was reported, but it affects every sticker button on every page in dark mode.

## Why it happens, and why this is the right fix

The sticker treatment draws its 2px border and its 4px offset shadow in `--brand-dark-green`. In dark mode the page background, cards, and the landing page's dark sections *all* resolve to `158 67% 8%` — the identical value. So both the border and the shadow were being painted in exactly the colour of the surface sitting behind them. Nothing was broken geometrically; the shape was there the whole time, drawn in invisible ink.

The fix is to give dark mode its own ink: off-white, which is already what the foreground token switches to in dark mode, so it's a colour the theme has committed to rather than a new one. Against the dark-green surface it separates from, that reads at about 15:1.

All three offset states — resting, hover, active — are restated. Fixing the border alone would have left a hover and a press that still nobody could see.

## Blast radius

**This is the shared brand utility, so it changes every `variant="sticker"` button and every `.brand-sticker` composition in dark mode.** That's intended — the defect was app-wide, not local to one button. I checked each current usage: none sits on a hardcoded light surface in dark mode, so they all gain the outline rather than losing one.

**The Playwright visual baseline in `tests/visual/brand-primitives.spec.ts` will need regenerating**, since the dark-mode sticker snapshots legitimately change.

## What this deliberately leaves alone

The same class of bug exists in **light** mode on the landing hero: the sticker CTAs there sit on `bg-brand-dark-green` sections, so their dark-green border and shadow are invisible regardless of theme. That's a different fix — it needs the ink to follow the surface, not the theme — and it isn't in scope here.

## How it was verified

`npm run test` passes end to end: 282 files, 2284 tests, plus type-check, lint, and build.

Confirmed in a real browser rather than by reading the cascade: with the app in dark mode, the button's computed `border-color` and `box-shadow` both resolve to `rgb(249, 247, 246)` and the sticker shape reads clearly again. A new guardrail test fails if the dark override is removed or ever reverts to dark-green ink.

The rendered before/after is visible on the deploy preview linked below — any sticker button in dark mode (Log in, the landing CTAs, Merch) now keeps its outline and offset shadow instead of flattening.
