### PR TITLE
fix(discovery): restore the missing space before the sponsor name

### DIFF
--- a/src/pages/DiscoveryPage.test.tsx
+++ b/src/pages/DiscoveryPage.test.tsx
@@ -381,6 +381,34 @@ describe('DiscoveryPage', () => {
     expect(screen.getAllByText(/Acme Bikes/)).toHaveLength(1);
   });
 
+  // The disclosure renders as a text node followed by a <bdi> element. In a
+  // flex container those become two separate flex items, and flex layout drops
+  // the trailing whitespace of the anonymous text item — so the sponsor name
+  // renders welded to the word before it. jsdom does no layout, so textContent
+  // still reports the space and cannot catch this; the layout mode is the only
+  // thing a unit test can pin.
+  it('lays the disclosure out inline so the space before the sponsor survives', async () => {
+    mockFeaturedTab.current = {
+      id: 'ft_1234abcd',
+      slug: 'seasonal-theme',
+      label: 'Especial',
+      pillLabel: null,
+      sponsorName: 'Acme Bikes',
+    };
+
+    render(
+      <MemoryRouter initialEntries={['/discovery/seasonal-theme']}>
+        <Routes>
+          <Route path="/discovery/:tab" element={<DiscoveryPage />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    const disclosure = getPartnershipDisclosure('En colaboración pagada con Acme Bikes');
+    expect(disclosure).toHaveClass('inline-block');
+    expect(disclosure.className).not.toMatch(/(^|\s)(inline-)?flex(\s|$)/);
+  });
+
   it('does not render partnership copy for an unsponsored featured tab', () => {
     mockFeaturedTab.current = {
       id: 'ft_1234abcd',

--- a/src/pages/DiscoveryPage.tsx
+++ b/src/pages/DiscoveryPage.tsx
@@ -344,7 +344,14 @@ export function DiscoveryPage() {
             <TabsContent value={activeTabItem.featuredTab.slug} className="mt-0 space-y-6">
               {activeTabItem.featuredTab.sponsorName && (
                 <div className="flex justify-center">
-                  <span className="inline-flex max-w-full rounded-full border border-border bg-background px-3 py-1 text-center text-sm font-medium text-foreground">
+                  {/*
+                    inline-block, not inline-flex: the copy below renders as a
+                    text node next to a <bdi> element, and a flex container
+                    would make those two flex items and discard the trailing
+                    space of the text one — welding the sponsor name onto the
+                    word before it. Nothing here needs flex.
+                  */}
+                  <span className="inline-block max-w-full rounded-full border border-border bg-background px-3 py-1 text-center text-sm font-medium text-foreground">
                     {/* bdi keeps Latin sponsor names stable inside RTL disclosure copy. */}
                     <Trans
                       i18nKey="discovery.paidPartnership"


### PR DESCRIPTION
## The problem

The paid-partnership disclosure on a featured Discovery tab is rendering **on production** with the sponsor name welded onto the word before it — "In paid partnership withAcme Bikes" instead of "In paid partnership with Acme Bikes". It reads as a typo in a legally-meaningful disclosure line. The mobile app is unaffected; this is web only.

The copy is not the problem. The translation string carries the space in every locale, and the DOM text node still contains it — you can select it, and `textContent` reports it.

## Why it happens

The pill is `inline-flex`. The disclosure renders as a text node followed by a `<bdi>` element, so flex layout treats those as two separate flex items and discards the trailing whitespace of the anonymous text item. The space exists in the DOM and is thrown away at layout time.

This only became reachable when the sponsor name gained its `<bdi>` wrapper for RTL locales. Before that it was a plain `{sponsorName}` interpolation — text sitting beside text, one anonymous item, space preserved. `inline-flex` was harmless until an element landed next to the text.

Nothing in that pill needs flex. It lays out `inline-block` now; `max-w-full`, `text-center`, the padding and the pill radius all behave identically.

## What this deliberately does not change

- **The translation strings.** All 20 locales already have the space and are untouched.
- **The `<bdi>` wrapper.** It is doing its job for RTL locales; it just needed a container that does not eat whitespace.
- **The centering wrapper.** Still `flex justify-center`. That makes the pill a flex *item*, which blockifies its outer display — but blockification does not change the inline formatting context inside it, so the space is safe.

## How it was verified

Isolated the mechanism first, in a standalone page with identical DOM: `inline-flex` renders "withAcme Bikes" at 261.3px, `inline-block` renders "with Acme Bikes" at 265.5px, `textContent` identical in both. The 4.2px delta is the space.

Then confirmed the actual fix in the running app on a real featured route, reading the computed style and the rendered pill — the disclosure reads correctly again.

`npm run test` passes end to end: 281 files, 2282 tests, plus type-check, lint, and build.

**Note on test coverage:** jsdom performs no layout, so `textContent` assertions pass on a page that renders wrong — that is exactly why the existing tests were green while production was broken. The added test pins the layout mode instead, which is the one part of this a unit test can actually see. Catching the rendered output would need a browser-based visual test.