### PR TITLE
fix(pwa): stop the install prompt clipping its own button labels

### DIFF
--- a/src/components/PWAInstallPrompt.test.tsx
+++ b/src/components/PWAInstallPrompt.test.tsx
@@ -107,6 +107,25 @@ describe('PWAInstallPrompt', () => {
     expect(await screen.findByRole('link', { name: 'Download Divine on the App Store' })).toBeVisible();
   });
 
+  // The store actions are `flex-1` inside a `flex-wrap` row, and the button
+  // base class sets `whitespace-nowrap`. `min-w-0` removes each item's
+  // min-content floor, so instead of the row wrapping when the labels no longer
+  // fit, the items shrink under their own text and the label spills outside the
+  // pill. jsdom performs no layout, so only the absence of the floor-removal is
+  // checkable here.
+  it('lets the store actions keep their content width so the row wraps instead of clipping', async () => {
+    setNavigator({
+      userAgent: 'Mozilla/5.0 (iPhone; CPU iPhone OS 18_0 like Mac OS X) AppleWebKit/605.1.15 Version/18.0 Mobile/15E148 Safari/604.1',
+      languages: ['en-NZ'],
+    });
+
+    renderPrompt();
+
+    const appStore = await screen.findByRole('link', { name: 'Download Divine on the App Store' });
+    expect(appStore).not.toHaveClass('min-w-0');
+    expect(appStore.parentElement?.className ?? '').toContain('flex-wrap');
+  });
+
   it('does not inject a third-party lookup script', async () => {
     setNavigator({
       userAgent: 'Mozilla/5.0 (iPhone; CPU iPhone OS 18_0 like Mac OS X) AppleWebKit/605.1.15 Version/18.0 Mobile/15E148 Safari/604.1',

--- a/src/components/PWAInstallPrompt.test.tsx
+++ b/src/components/PWAInstallPrompt.test.tsx
@@ -113,17 +113,26 @@ describe('PWAInstallPrompt', () => {
   // fit, the items shrink under their own text and the label spills outside the
   // pill. jsdom performs no layout, so only the absence of the floor-removal is
   // checkable here.
-  it('lets the store actions keep their content width so the row wraps instead of clipping', async () => {
+  //
+  // A user agent that is neither iOS nor Android is the case in the bug report:
+  // it renders both store actions, which is the widest the row ever gets. Each
+  // action has to be checked on its own, because an Android visitor only ever
+  // sees the Google Play one and an iOS visitor only the App Store one.
+  it('lets both store actions keep their content width so the row wraps instead of clipping', async () => {
     setNavigator({
-      userAgent: 'Mozilla/5.0 (iPhone; CPU iPhone OS 18_0 like Mac OS X) AppleWebKit/605.1.15 Version/18.0 Mobile/15E148 Safari/604.1',
-      languages: ['en-NZ'],
+      userAgent:
+        'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36',
+      languages: ['en-US'],
     });
 
     renderPrompt();
 
     const appStore = await screen.findByRole('link', { name: 'Download Divine on the App Store' });
+    const googlePlay = screen.getByRole('link', { name: 'Get Divine on Google Play' });
+
     expect(appStore).not.toHaveClass('min-w-0');
-    expect(appStore.parentElement?.className ?? '').toContain('flex-wrap');
+    expect(googlePlay).not.toHaveClass('min-w-0');
+    expect(appStore.parentElement).toHaveClass('flex-wrap');
   });
 
   it('does not inject a third-party lookup script', async () => {

--- a/src/components/PWAInstallPrompt.tsx
+++ b/src/components/PWAInstallPrompt.tsx
@@ -126,9 +126,15 @@ export function PWAInstallPrompt({ delayMs = 10000 }: { delayMs?: number } = {})
             {t('pwaInstallPrompt.descriptionNative')}
           </p>
 
+          {/*
+            flex-1 without min-w-0: the buttons share the row when the labels
+            fit and the row wraps when they do not. With min-w-0 they shrank
+            under their own `whitespace-nowrap` text instead, spilling the label
+            outside the pill.
+          */}
           <div className="flex flex-wrap gap-2">
             {showAppStore && (
-              <Button asChild size="sm" className="flex-1 min-w-0">
+              <Button asChild size="sm" className="flex-1">
                 <a href={APP_STORE_URL} target="_blank" rel="noopener noreferrer" aria-label={t('pwaInstallPrompt.appStoreAria')}>
                   <Download className="h-4 w-4 mr-2" />
                   {t('pwaInstallPrompt.appStore')}
@@ -136,7 +142,7 @@ export function PWAInstallPrompt({ delayMs = 10000 }: { delayMs?: number } = {})
               </Button>
             )}
             {showGooglePlay && (
-              <Button asChild size="sm" className="flex-1 min-w-0">
+              <Button asChild size="sm" className="flex-1">
                 <a href={PLAY_STORE_URL} target="_blank" rel="noopener noreferrer" aria-label={t('pwaInstallPrompt.googlePlayAria')}>
                   <Download className="h-4 w-4 mr-2" />
                   {t('pwaInstallPrompt.googlePlay')}


### PR DESCRIPTION
## The problem

On a narrow screen, the prompt inviting people to install the app renders its own buttons with the labels spilling outside the pills — "App Sto re" and "Google Pla" with the text running past the rounded edge. It's shown to every mobile visitor ten seconds after they leave the landing page, so it's a fairly visible bit of breakage.

## Why it happens

The two store actions are `flex-1 min-w-0` inside a `flex-wrap` row, and the shared button base class sets `whitespace-nowrap`.

`min-w-0` removes each flex item's automatic min-content floor. Without that floor, `flex-1` shrinks the buttons past the width of their own text — and because the text can't wrap, it overflows the pill instead. The `flex-wrap` on the container could never help: wrapping only kicks in when items *can't* shrink further, and `min-w-0` said they always can.

Dropping `min-w-0` restores the floor. The buttons still share a row when they fit, and now wrap onto a second line when they don't, which is what `flex-wrap` was there for in the first place. `flex-1` stays, so the row still fills nicely in the common case.

## What this deliberately does not change

The button sizing, copy, and platform logic are untouched. Note that a real phone only ever shows two buttons — iOS gets App Store, Android gets Google Play, and both get "Not now". The three-button case is a non-mobile user agent on a narrow screen, which is the worst case for width and the one in the screenshot.

## How it was verified

`npm run test` passes end to end: 282 files, 2289 tests, plus type-check, lint, and build.

Measured in a browser at a 390px viewport, before and after. Every button now reports `scrollWidth <= clientWidth` (no overflow), and the row wraps as intended: "App Store" on the first line, "Google Play" and "Not now" sharing the second.

jsdom performs no layout, so the added test can only assert the absence of the floor-removal and that the row can still wrap — the same limitation that let this ship in the first place. The rendered result was checked by hand.