### PR TITLE
test(a11y): check every audited route in dark mode as well as light

### DIFF
--- a/tests/visual/a11y.spec.ts
+++ b/tests/visual/a11y.spec.ts
@@ -17,12 +17,23 @@ const ROUTES = [
   '/__brand-preview',
 ];
 
-for (const route of ROUTES) {
-  test(`a11y: ${route} has no WCAG 2 A/AA violations`, async ({ page }) => {
+// Both schemes, because a contrast bug can exist in one and not the other.
+// The app's default theme is "system", so emulating the media preference is
+// what actually drives it — see the guard inside the test.
+const COLOR_SCHEMES = ['light', 'dark'] as const;
+
+for (const scheme of COLOR_SCHEMES) {
+  for (const route of ROUTES) {
+  test(`a11y (${scheme}): ${route} has no WCAG 2.1 A/AA violations`, async ({ page }) => {
     test.setTimeout(60_000); // discovery + search do a fair bit of fetching
+    await page.emulateMedia({ colorScheme: scheme });
     await page.goto(route, { waitUntil: 'domcontentloaded' });
     await expect(page.locator('body')).toBeVisible();
-    const builder = new AxeBuilder({ page }).withTags(['wcag2a', 'wcag2aa']);
+    // Without this the dark run silently degrades into a second light run the
+    // moment the default theme stops following the system preference, and the
+    // suite would report dark-mode coverage it no longer has.
+    await expect(page.locator('html')).toHaveClass(new RegExp(`\\b${scheme}\\b`));
+    const builder = new AxeBuilder({ page }).withTags(['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa']);
     // Color-swatch chips on the brand-preview page are reference tiles, not
     // content; their visible label is decorative. Axe's color-contrast rule
     // doesn't meaningfully apply — skip it on those elements only.
@@ -41,4 +52,5 @@ for (const route of ROUTES) {
     }
     expect(results.violations).toEqual([]);
   });
+}
 }

--- a/tests/visual/a11y.spec.ts
+++ b/tests/visual/a11y.spec.ts
@@ -24,33 +24,40 @@ const COLOR_SCHEMES = ['light', 'dark'] as const;
 
 for (const scheme of COLOR_SCHEMES) {
   for (const route of ROUTES) {
-  test(`a11y (${scheme}): ${route} has no WCAG 2.1 A/AA violations`, async ({ page }) => {
-    test.setTimeout(60_000); // discovery + search do a fair bit of fetching
-    await page.emulateMedia({ colorScheme: scheme });
-    await page.goto(route, { waitUntil: 'domcontentloaded' });
-    await expect(page.locator('body')).toBeVisible();
-    // Without this the dark run silently degrades into a second light run the
-    // moment the default theme stops following the system preference, and the
-    // suite would report dark-mode coverage it no longer has.
-    await expect(page.locator('html')).toHaveClass(new RegExp(`\\b${scheme}\\b`));
-    const builder = new AxeBuilder({ page }).withTags(['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa']);
-    // Color-swatch chips on the brand-preview page are reference tiles, not
-    // content; their visible label is decorative. Axe's color-contrast rule
-    // doesn't meaningfully apply — skip it on those elements only.
-    if (route === '/__brand-preview') {
-      builder.exclude('[data-axe-skip="color-contrast"]');
-    }
-    const results = await builder.analyze();
+    test(`a11y (${scheme}): ${route} has no WCAG 2.1 A/AA violations`, async ({ page }) => {
+      test.setTimeout(60_000); // discovery + search do a fair bit of fetching
+      await page.emulateMedia({ colorScheme: scheme });
+      await page.goto(route, { waitUntil: 'domcontentloaded' });
+      await expect(page.locator('body')).toBeVisible();
+      // Without this the dark run silently degrades into a second light run the
+      // moment the default theme stops following the system preference, and the
+      // suite would report dark-mode coverage it no longer has.
+      await expect(page.locator('html')).toHaveClass(new RegExp(`(^|\\s)${scheme}(\\s|$)`));
+      // The theme flip animates link colors, so axe could sample a transient
+      // color between the light and dark palettes. Snap to the final state.
+      await page.addStyleTag({
+        content: '*, *::before, *::after { transition: none !important; animation: none !important; }',
+      });
+      const builder = new AxeBuilder({ page })
+        .exclude('iframe[src*="youtube"]')
+        .withTags(['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa']);
+      // Color-swatch chips on the brand-preview page are reference tiles, not
+      // content; their visible label is decorative. Axe's color-contrast rule
+      // doesn't meaningfully apply — skip it on those elements only.
+      if (route === '/__brand-preview') {
+        builder.exclude('[data-axe-skip="color-contrast"]');
+      }
+      const results = await builder.analyze();
 
-    if (results.violations.length > 0) {
-      for (const v of results.violations) {
-        console.log(`[${v.impact?.toUpperCase() ?? '?'}] ${v.id}: ${v.description}`);
-        for (const n of v.nodes.slice(0, 3)) {
-          console.log(`   ${n.target.join(' > ')}`);
+      if (results.violations.length > 0) {
+        for (const v of results.violations) {
+          console.log(`[${v.impact?.toUpperCase() ?? '?'}] ${v.id}: ${v.description}`);
+          for (const n of v.nodes.slice(0, 3)) {
+            console.log(`   ${n.target.join(' > ')}`);
+          }
         }
       }
-    }
-    expect(results.violations).toEqual([]);
-  });
-}
+      expect(results.violations).toEqual([]);
+    });
+  }
 }


### PR DESCRIPTION
## Why

The accessibility sweep only ever ran in light mode. Dark mode is a complete second palette, so a contrast problem can exist in one theme and not the other, and the suite could not see it. That blind spot is not hypothetical — the dark-mode bug fixed in #624 made every sticker button in the app lose its outline, with the whole test suite green.

Each of the 12 audited routes now runs under both colour schemes: 24 checks instead of 12.

## Why the test needs stabilization

The app's default theme follows the system preference, so emulating the media query drives the switch. The test asserts the resulting class on `<html>` before running axe so a future default-theme change cannot silently turn the dark run into a second light run.

The theme flip happens after mount, while links have a 200 ms colour transition. Without test-only animation suppression, axe can sample a transient colour between the light and dark palettes and report a timing-dependent contrast violation. The audit now disables transitions and animations before analysis so it always inspects the final palette.

The family page also embeds a cross-origin third-party video player. Its document is outside this application's control and loads on its own schedule, so the audit excludes that iframe while continuing to check the surrounding Divine page.

The tags widen from WCAG 2.0 to 2.1 A/AA, which brings in the non-text-contrast rule (SC 1.4.11) covering UI component boundaries.

## What this deliberately does not do

This is test-only; it does not change the `/family` palette or any application behaviour. The final dark-mode `/family` colours meet contrast requirements. The failing sampled colours from review were intermediate values during the animated theme transition.

There is also no dark-mode screenshot baseline. Snapshot baselines are committed per-platform, and this suite does not run in CI, so a second baseline would add maintenance without adding a check anyone currently runs. Getting the accessibility suite into CI remains separate work.

## How it was verified

- `npx playwright test tests/visual/a11y.spec.ts --workers=1 --repeat-each=3` — 72 passed
- `npx playwright test tests/visual/a11y.spec.ts --workers=1 --repeat-each=5 -g 'a11y \\(dark\\)'` — 60 passed
- `npm run test` — type-check, lint, 282 test files / 2,289 tests, and production build passed

No visual or application behaviour change.
