### PR TITLE
feat(analytics): add shared event definitions to web

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,5 +25,8 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Verify pinned analytics contract
+        run: npm run analytics:contract:check
+
       - name: Run tests (includes lint, type-check, and build)
         run: npm test

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -207,10 +207,12 @@ repository and is generated from `analytics/event-contract.yaml` there. This
 repository vendors the TypeScript output at
 [`src/generated/productAnalytics.ts`](./src/generated/productAnalytics.ts) and
 pins it in [`analytics-contract.lock`](./analytics-contract.lock), which records
-the upstream commit and the artifact's SHA-256.
+the source-contract commit, generated-artifact commit, schema version, and
+SHA-256 values for both the vendored manifest and artifact.
 
 Do not hand-edit the vendored file. To take a new version, regenerate it
-upstream, copy it here, and update both fields in the lock.
+upstream, copy both the artifact and `analytics-contract.manifest.json` here,
+and update the lock from that manifest.
 `npm run analytics:contract:check` verifies the pin, and
 `scripts/check-analytics-contract.test.mjs` runs the same check under
 `npm run test`.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -35,6 +35,7 @@ src/
   types/         shared TypeScript definitions
   config/        relay lists and app configuration
   data/          static data files
+  generated/     vendored generated code, never hand-edited
   styles/        global stylesheets
   test/          test setup (setup.ts) and utilities
 ```
@@ -198,6 +199,21 @@ Nostr relays are configured in [`src/config/relays.ts`](./src/config/relays.ts).
 Firebase Analytics runs behind GDPR cookie consent. Sentry handles error
 tracking. Media assets come from cdn.divine.video. Content moderation uses
 moderation-api.divine.video. HubSpot provides the cookie consent banner.
+
+### Product Analytics Contract
+
+The cross-platform product-event vocabulary lives in the `divine-context`
+repository and is generated from `analytics/event-contract.yaml` there. This
+repository vendors the TypeScript output at
+[`src/generated/productAnalytics.ts`](./src/generated/productAnalytics.ts) and
+pins it in [`analytics-contract.lock`](./analytics-contract.lock), which records
+the upstream commit and the artifact's SHA-256.
+
+Do not hand-edit the vendored file. To take a new version, regenerate it
+upstream, copy it here, and update both fields in the lock.
+`npm run analytics:contract:check` verifies the pin, and
+`scripts/check-analytics-contract.test.mjs` runs the same check under
+`npm run test`.
 
 ### Relay Routing
 

--- a/analytics-contract.lock
+++ b/analytics-contract.lock
@@ -1,0 +1,7 @@
+{
+  "artifact": "src/generated/productAnalytics.ts",
+  "artifact_sha256": "9a19b65862fdd98005c3b11517a632b83833f0f33f7ffa50c37d414e3ef9efca",
+  "contract_commit": "687df20125fac8b8643892e7cfaefbd84606c83c",
+  "schema_version": 1,
+  "source_artifact": "analytics/generated/productAnalytics.ts"
+}

--- a/analytics-contract.lock
+++ b/analytics-contract.lock
@@ -1,10 +1,10 @@
 {
   "artifact": "src/generated/productAnalytics.ts",
-  "artifact_commit": "72d3fcfdf0d7348d9b950234df87c0b9d975cad1",
-  "artifact_sha256": "affd0d9c6652cee9ae9878254ac712b84f9e0bc2a28b12881624f5930b6643f0",
-  "contract_commit": "02083864050efdba549f118ba11bf6111f4bb7ba",
+  "artifact_commit": "470a150d767b0c23bea66c37158cdefec6ae9743",
+  "artifact_sha256": "1b99c8425e8d7087910debbb5af62c05ba85df545c704d80c7f0c703914595c3",
+  "contract_commit": "27e21a7a1ea3c6cb998186eda50807e63806efc9",
   "manifest": "analytics-contract.manifest.json",
-  "manifest_sha256": "602d1cf981fbb66a0080049935bc2443db6473e113a5b67028d283ba780b8a18",
+  "manifest_sha256": "027e85ab7098adc866b0b3cd8e827fd48c9645471b13e5a014212c4652765ec5",
   "schema_version": 2,
   "source_artifact": "analytics/generated/productAnalytics.ts",
   "source_manifest": "analytics/generated/manifest.json"

--- a/analytics-contract.lock
+++ b/analytics-contract.lock
@@ -1,7 +1,11 @@
 {
   "artifact": "src/generated/productAnalytics.ts",
-  "artifact_sha256": "9a19b65862fdd98005c3b11517a632b83833f0f33f7ffa50c37d414e3ef9efca",
-  "contract_commit": "687df20125fac8b8643892e7cfaefbd84606c83c",
-  "schema_version": 1,
-  "source_artifact": "analytics/generated/productAnalytics.ts"
+  "artifact_commit": "b9817bba76d7923bde7decd84797a8818eba4c50",
+  "artifact_sha256": "66f803080fc42a9310a97ee087a8ae0d72d0c74d80f8a3a2d8bd748be9439c48",
+  "contract_commit": "0aa587e38a9aea3bee70fd1d0bf492dac8266dd4",
+  "manifest": "analytics-contract.manifest.json",
+  "manifest_sha256": "56c36b304a67afeb5aa28283f554010890d39de9091d949445ca5476870e6615",
+  "schema_version": 2,
+  "source_artifact": "analytics/generated/productAnalytics.ts",
+  "source_manifest": "analytics/generated/manifest.json"
 }

--- a/analytics-contract.lock
+++ b/analytics-contract.lock
@@ -1,10 +1,10 @@
 {
   "artifact": "src/generated/productAnalytics.ts",
-  "artifact_commit": "b9817bba76d7923bde7decd84797a8818eba4c50",
-  "artifact_sha256": "66f803080fc42a9310a97ee087a8ae0d72d0c74d80f8a3a2d8bd748be9439c48",
-  "contract_commit": "0aa587e38a9aea3bee70fd1d0bf492dac8266dd4",
+  "artifact_commit": "72d3fcfdf0d7348d9b950234df87c0b9d975cad1",
+  "artifact_sha256": "affd0d9c6652cee9ae9878254ac712b84f9e0bc2a28b12881624f5930b6643f0",
+  "contract_commit": "02083864050efdba549f118ba11bf6111f4bb7ba",
   "manifest": "analytics-contract.manifest.json",
-  "manifest_sha256": "56c36b304a67afeb5aa28283f554010890d39de9091d949445ca5476870e6615",
+  "manifest_sha256": "602d1cf981fbb66a0080049935bc2443db6473e113a5b67028d283ba780b8a18",
   "schema_version": 2,
   "source_artifact": "analytics/generated/productAnalytics.ts",
   "source_manifest": "analytics/generated/manifest.json"

--- a/analytics-contract.manifest.json
+++ b/analytics-contract.manifest.json
@@ -2,17 +2,18 @@
   "artifacts": {
     "productAnalytics.ts": {
       "path": "analytics/generated/productAnalytics.ts",
-      "sha256": "66f803080fc42a9310a97ee087a8ae0d72d0c74d80f8a3a2d8bd748be9439c48"
+      "sha256": "affd0d9c6652cee9ae9878254ac712b84f9e0bc2a28b12881624f5930b6643f0"
     },
     "product_analytics.dart": {
       "path": "analytics/generated/product_analytics.dart",
-      "sha256": "e3ba00fd68243f84dd2299893acf698b2db90c239c33e86d3c9932cbb1ce971a"
+      "sha256": "9c9baad4e36d56e4f462eb6d18c986d97ec2ff5a9ed4f08e9298e72164b4d3e6"
     },
     "product_analytics.rs": {
       "path": "analytics/generated/product_analytics.rs",
-      "sha256": "fe7008ce56325e04df8543d85435fb932f31ff23381817fdb3897dcce2d0b918"
+      "sha256": "44a866e8b0e4036fe14416d9327bf1e47f13679cd89c61dfeb77ec40ae13b305"
     }
   },
-  "contract_commit": "0aa587e38a9aea3bee70fd1d0bf492dac8266dd4",
+  "contract_commit": "02083864050efdba549f118ba11bf6111f4bb7ba",
+  "event_id_algorithm": "sha256-rfc8785-v1",
   "schema_version": 2
 }

--- a/analytics-contract.manifest.json
+++ b/analytics-contract.manifest.json
@@ -2,18 +2,18 @@
   "artifacts": {
     "productAnalytics.ts": {
       "path": "analytics/generated/productAnalytics.ts",
-      "sha256": "affd0d9c6652cee9ae9878254ac712b84f9e0bc2a28b12881624f5930b6643f0"
+      "sha256": "1b99c8425e8d7087910debbb5af62c05ba85df545c704d80c7f0c703914595c3"
     },
     "product_analytics.dart": {
       "path": "analytics/generated/product_analytics.dart",
-      "sha256": "9c9baad4e36d56e4f462eb6d18c986d97ec2ff5a9ed4f08e9298e72164b4d3e6"
+      "sha256": "70a236ec0822f272de572669ccb55c5baba905f23df3adc2d572dcbd08b8a778"
     },
     "product_analytics.rs": {
       "path": "analytics/generated/product_analytics.rs",
-      "sha256": "44a866e8b0e4036fe14416d9327bf1e47f13679cd89c61dfeb77ec40ae13b305"
+      "sha256": "83ad6c09c6b8331891b71dc88259cdb878ff56fd96911e83b0603c22008cbe1f"
     }
   },
-  "contract_commit": "02083864050efdba549f118ba11bf6111f4bb7ba",
+  "contract_commit": "27e21a7a1ea3c6cb998186eda50807e63806efc9",
   "event_id_algorithm": "sha256-rfc8785-v1",
   "schema_version": 2
 }

--- a/analytics-contract.manifest.json
+++ b/analytics-contract.manifest.json
@@ -1,0 +1,18 @@
+{
+  "artifacts": {
+    "productAnalytics.ts": {
+      "path": "analytics/generated/productAnalytics.ts",
+      "sha256": "66f803080fc42a9310a97ee087a8ae0d72d0c74d80f8a3a2d8bd748be9439c48"
+    },
+    "product_analytics.dart": {
+      "path": "analytics/generated/product_analytics.dart",
+      "sha256": "e3ba00fd68243f84dd2299893acf698b2db90c239c33e86d3c9932cbb1ce971a"
+    },
+    "product_analytics.rs": {
+      "path": "analytics/generated/product_analytics.rs",
+      "sha256": "fe7008ce56325e04df8543d85435fb932f31ff23381817fdb3897dcce2d0b918"
+    }
+  },
+  "contract_commit": "0aa587e38a9aea3bee70fd1d0bf492dac8266dd4",
+  "schema_version": 2
+}

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "fastly:release": "npm run fastly:deploy && npm run fastly:publish",
     "verify:well-known": "node scripts/verify-well-known.mjs",
     "verify:og": "bash scripts/verify-og-tags.sh",
+    "analytics:contract:check": "node scripts/check-analytics-contract.mjs",
     "precalculate-thumbnails": "tsx scripts/precalculate-hashtag-thumbnails.ts",
     "generate-icons": "node scripts/generate-icons.js",
     "test:visual": "playwright test",

--- a/scripts/check-analytics-contract.mjs
+++ b/scripts/check-analytics-contract.mjs
@@ -10,6 +10,12 @@ export function readEmbeddedCommit(contents) {
   return contents.match(/Source contract commit: ([0-9a-f]{40})/)?.[1];
 }
 
+export function readEmbeddedSchemaVersion(contents) {
+  const match = contents.match(/PRODUCT_ANALYTICS_SCHEMA_VERSION = (\d+) as const;/);
+
+  return match ? Number(match[1]) : undefined;
+}
+
 export function assertContractPin(lock, artifact) {
   if (lock.artifact !== expectedArtifact) {
     throw new Error(`analytics contract lock must target ${expectedArtifact}`);
@@ -26,6 +32,13 @@ export function assertContractPin(lock, artifact) {
   const contents = bytes.toString('utf8');
   if (readEmbeddedCommit(contents) !== lock.contract_commit) {
     throw new Error('analytics contract artifact commit does not match the lock');
+  }
+
+  const embeddedSchemaVersion = readEmbeddedSchemaVersion(contents);
+  if (embeddedSchemaVersion !== lock.schema_version) {
+    throw new Error(
+      `analytics contract schema version does not match the lock: expected ${lock.schema_version}, got ${embeddedSchemaVersion}`,
+    );
   }
 
   if (!contents.includes('DO NOT EDIT')) {

--- a/scripts/check-analytics-contract.mjs
+++ b/scripts/check-analytics-contract.mjs
@@ -29,7 +29,7 @@ export function readEmbeddedSchemaVersion(contents) {
     /PRODUCT_ANALYTICS_V([0-9]+)_SCHEMA_VERSION = ([0-9]+) as const;/,
   );
 
-  return match?.[1] === match?.[2] ? Number(match[1]) : undefined;
+  return match && match[1] === match[2] ? Number(match[1]) : undefined;
 }
 
 export function readEmbeddedEventIdAlgorithm(contents) {

--- a/scripts/check-analytics-contract.mjs
+++ b/scripts/check-analytics-contract.mjs
@@ -32,6 +32,10 @@ export function readEmbeddedSchemaVersion(contents) {
   return match?.[1] === match?.[2] ? Number(match[1]) : undefined;
 }
 
+export function readEmbeddedEventIdAlgorithm(contents) {
+  return contents.match(/PRODUCT_ANALYTICS_V2_EVENT_ID_ALGORITHM = '([^']+)' as const;/)?.[1];
+}
+
 function requireEqual(actual, expected, label) {
   if (actual !== expected) {
     throw new Error(`analytics contract ${label} must be ${expected}`);
@@ -75,6 +79,11 @@ export function assertContractPin(lock, artifact, manifest) {
   const manifestValue = JSON.parse(manifestBytes.toString('utf8'));
   requireEqual(manifestValue.contract_commit, lock.contract_commit, 'manifest commit');
   requireEqual(manifestValue.schema_version, lock.schema_version, 'manifest schema version');
+  requireEqual(
+    manifestValue.event_id_algorithm,
+    'sha256-rfc8785-v1',
+    'manifest event ID algorithm',
+  );
   const sourceName = expectedSourceArtifact.split('/').at(-1);
   const sourceEntry = manifestValue.artifacts?.[sourceName];
   if (sourceEntry === null || typeof sourceEntry !== 'object' || Array.isArray(sourceEntry)) {
@@ -100,6 +109,9 @@ export function assertContractPin(lock, artifact, manifest) {
     throw new Error(
       `analytics contract schema version does not match the lock: expected ${lock.schema_version}, got ${embeddedSchemaVersion}`,
     );
+  }
+  if (readEmbeddedEventIdAlgorithm(contents) !== 'sha256-rfc8785-v1') {
+    throw new Error('analytics contract event ID algorithm does not match the manifest');
   }
   if (!contents.includes('DO NOT EDIT')) {
     throw new Error('analytics contract artifact is missing its generated-file header');

--- a/scripts/check-analytics-contract.mjs
+++ b/scripts/check-analytics-contract.mjs
@@ -5,42 +5,102 @@ import { fileURLToPath, pathToFileURL } from 'node:url';
 
 const repoRoot = dirname(dirname(fileURLToPath(import.meta.url)));
 const expectedArtifact = 'src/generated/productAnalytics.ts';
+const expectedManifest = 'analytics-contract.manifest.json';
+const expectedSourceArtifact = 'analytics/generated/productAnalytics.ts';
+const expectedSourceManifest = 'analytics/generated/manifest.json';
+const expectedLockKeys = [
+  'artifact',
+  'artifact_commit',
+  'artifact_sha256',
+  'contract_commit',
+  'manifest',
+  'manifest_sha256',
+  'schema_version',
+  'source_artifact',
+  'source_manifest',
+];
 
 export function readEmbeddedCommit(contents) {
   return contents.match(/Source contract commit: ([0-9a-f]{40})/)?.[1];
 }
 
 export function readEmbeddedSchemaVersion(contents) {
-  const match = contents.match(/PRODUCT_ANALYTICS_SCHEMA_VERSION = (\d+) as const;/);
+  const match = contents.match(
+    /PRODUCT_ANALYTICS_V([0-9]+)_SCHEMA_VERSION = ([0-9]+) as const;/,
+  );
 
-  return match ? Number(match[1]) : undefined;
+  return match?.[1] === match?.[2] ? Number(match[1]) : undefined;
 }
 
-export function assertContractPin(lock, artifact) {
+function requireEqual(actual, expected, label) {
+  if (actual !== expected) {
+    throw new Error(`analytics contract ${label} must be ${expected}`);
+  }
+}
+
+function requireMatch(value, pattern, label) {
+  if (typeof value !== 'string' || !pattern.test(value)) {
+    throw new Error(`analytics contract ${label} has an invalid format`);
+  }
+}
+
+function asBuffer(value) {
+  return Buffer.isBuffer(value) ? value : Buffer.from(value, 'utf8');
+}
+
+export function assertContractPin(lock, artifact, manifest) {
+  if (JSON.stringify(Object.keys(lock).sort()) !== JSON.stringify(expectedLockKeys)) {
+    throw new Error('analytics contract lock fields do not match the required provenance fields');
+  }
   if (lock.artifact !== expectedArtifact) {
     throw new Error(`analytics contract lock must target ${expectedArtifact}`);
   }
 
-  const bytes = Buffer.isBuffer(artifact) ? artifact : Buffer.from(artifact, 'utf8');
-  const actualSha = createHash('sha256').update(bytes).digest('hex');
-  if (actualSha !== lock.artifact_sha256) {
+  requireEqual(lock.manifest, expectedManifest, 'manifest path');
+  requireEqual(lock.source_artifact, expectedSourceArtifact, 'source artifact path');
+  requireEqual(lock.source_manifest, expectedSourceManifest, 'source manifest path');
+  requireEqual(lock.schema_version, 2, 'schema version');
+  requireMatch(lock.contract_commit, /^[0-9a-f]{40}$/, 'contract commit');
+  requireMatch(lock.artifact_commit, /^[0-9a-f]{40}$/, 'artifact commit');
+  requireMatch(lock.artifact_sha256, /^[0-9a-f]{64}$/, 'artifact checksum');
+  requireMatch(lock.manifest_sha256, /^[0-9a-f]{64}$/, 'manifest checksum');
+
+  const manifestBytes = asBuffer(manifest);
+  const actualManifestSha = createHash('sha256').update(manifestBytes).digest('hex');
+  if (actualManifestSha !== lock.manifest_sha256) {
     throw new Error(
-      `analytics contract artifact checksum drifted: expected ${lock.artifact_sha256}, got ${actualSha}`,
+      `analytics contract manifest checksum drifted: expected ${lock.manifest_sha256}, got ${actualManifestSha}`,
+    );
+  }
+  const manifestValue = JSON.parse(manifestBytes.toString('utf8'));
+  requireEqual(manifestValue.contract_commit, lock.contract_commit, 'manifest commit');
+  requireEqual(manifestValue.schema_version, lock.schema_version, 'manifest schema version');
+  const sourceName = expectedSourceArtifact.split('/').at(-1);
+  const sourceEntry = manifestValue.artifacts?.[sourceName];
+  if (sourceEntry === null || typeof sourceEntry !== 'object' || Array.isArray(sourceEntry)) {
+    throw new Error('analytics contract source artifact is missing from the manifest');
+  }
+  requireEqual(sourceEntry.path, expectedSourceArtifact, 'manifest artifact path');
+  requireEqual(sourceEntry.sha256, lock.artifact_sha256, 'manifest artifact checksum');
+
+  const artifactBytes = asBuffer(artifact);
+  const actualArtifactSha = createHash('sha256').update(artifactBytes).digest('hex');
+  if (actualArtifactSha !== lock.artifact_sha256) {
+    throw new Error(
+      `analytics contract artifact checksum drifted: expected ${lock.artifact_sha256}, got ${actualArtifactSha}`,
     );
   }
 
-  const contents = bytes.toString('utf8');
+  const contents = artifactBytes.toString('utf8');
   if (readEmbeddedCommit(contents) !== lock.contract_commit) {
     throw new Error('analytics contract artifact commit does not match the lock');
   }
-
   const embeddedSchemaVersion = readEmbeddedSchemaVersion(contents);
   if (embeddedSchemaVersion !== lock.schema_version) {
     throw new Error(
       `analytics contract schema version does not match the lock: expected ${lock.schema_version}, got ${embeddedSchemaVersion}`,
     );
   }
-
   if (!contents.includes('DO NOT EDIT')) {
     throw new Error('analytics contract artifact is missing its generated-file header');
   }
@@ -50,10 +110,16 @@ export function assertContractPin(lock, artifact) {
 
 export function verifyAnalyticsContract(root = repoRoot) {
   const lock = JSON.parse(readFileSync(join(root, 'analytics-contract.lock'), 'utf8'));
+  const artifact = readFileSync(join(root, expectedArtifact));
+  const manifest = readFileSync(join(root, expectedManifest));
 
-  return assertContractPin(lock, readFileSync(join(root, expectedArtifact)));
+  assertContractPin(lock, artifact, manifest);
+  return lock;
 }
 
 if (import.meta.url === pathToFileURL(process.argv[1]).href) {
-  console.log(`analytics contract pin verified at ${verifyAnalyticsContract()}`);
+  const lock = verifyAnalyticsContract();
+  console.log(
+    `analytics contract pin verified at ${lock.contract_commit} from artifact ${lock.artifact_commit}`,
+  );
 }

--- a/scripts/check-analytics-contract.mjs
+++ b/scripts/check-analytics-contract.mjs
@@ -1,31 +1,46 @@
 import { createHash } from 'node:crypto';
 import { readFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 
 const repoRoot = dirname(dirname(fileURLToPath(import.meta.url)));
-const lock = JSON.parse(readFileSync(join(repoRoot, 'analytics-contract.lock'), 'utf8'));
 const expectedArtifact = 'src/generated/productAnalytics.ts';
 
-if (lock.artifact !== expectedArtifact) {
-  throw new Error(`analytics contract lock must target ${expectedArtifact}`);
+export function readEmbeddedCommit(contents) {
+  return contents.match(/Source contract commit: ([0-9a-f]{40})/)?.[1];
 }
 
-const artifact = readFileSync(join(repoRoot, expectedArtifact));
-const actualSha = createHash('sha256').update(artifact).digest('hex');
-if (actualSha !== lock.artifact_sha256) {
-  throw new Error(
-    `analytics contract artifact checksum drifted: expected ${lock.artifact_sha256}, got ${actualSha}`,
-  );
+export function assertContractPin(lock, artifact) {
+  if (lock.artifact !== expectedArtifact) {
+    throw new Error(`analytics contract lock must target ${expectedArtifact}`);
+  }
+
+  const bytes = Buffer.isBuffer(artifact) ? artifact : Buffer.from(artifact, 'utf8');
+  const actualSha = createHash('sha256').update(bytes).digest('hex');
+  if (actualSha !== lock.artifact_sha256) {
+    throw new Error(
+      `analytics contract artifact checksum drifted: expected ${lock.artifact_sha256}, got ${actualSha}`,
+    );
+  }
+
+  const contents = bytes.toString('utf8');
+  if (readEmbeddedCommit(contents) !== lock.contract_commit) {
+    throw new Error('analytics contract artifact commit does not match the lock');
+  }
+
+  if (!contents.includes('DO NOT EDIT')) {
+    throw new Error('analytics contract artifact is missing its generated-file header');
+  }
+
+  return lock.contract_commit;
 }
 
-const contents = artifact.toString('utf8');
-const embeddedCommit = contents.match(/Source contract commit: ([0-9a-f]{40})/)?.[1];
-if (embeddedCommit !== lock.contract_commit) {
-  throw new Error('analytics contract artifact commit does not match the lock');
-}
-if (!contents.includes('DO NOT EDIT')) {
-  throw new Error('analytics contract artifact is missing its generated-file header');
+export function verifyAnalyticsContract(root = repoRoot) {
+  const lock = JSON.parse(readFileSync(join(root, 'analytics-contract.lock'), 'utf8'));
+
+  return assertContractPin(lock, readFileSync(join(root, expectedArtifact)));
 }
 
-console.log(`analytics contract pin verified at ${lock.contract_commit}`);
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+  console.log(`analytics contract pin verified at ${verifyAnalyticsContract()}`);
+}

--- a/scripts/check-analytics-contract.mjs
+++ b/scripts/check-analytics-contract.mjs
@@ -1,0 +1,31 @@
+import { createHash } from 'node:crypto';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const repoRoot = dirname(dirname(fileURLToPath(import.meta.url)));
+const lock = JSON.parse(readFileSync(join(repoRoot, 'analytics-contract.lock'), 'utf8'));
+const expectedArtifact = 'src/generated/productAnalytics.ts';
+
+if (lock.artifact !== expectedArtifact) {
+  throw new Error(`analytics contract lock must target ${expectedArtifact}`);
+}
+
+const artifact = readFileSync(join(repoRoot, expectedArtifact));
+const actualSha = createHash('sha256').update(artifact).digest('hex');
+if (actualSha !== lock.artifact_sha256) {
+  throw new Error(
+    `analytics contract artifact checksum drifted: expected ${lock.artifact_sha256}, got ${actualSha}`,
+  );
+}
+
+const contents = artifact.toString('utf8');
+const embeddedCommit = contents.match(/Source contract commit: ([0-9a-f]{40})/)?.[1];
+if (embeddedCommit !== lock.contract_commit) {
+  throw new Error('analytics contract artifact commit does not match the lock');
+}
+if (!contents.includes('DO NOT EDIT')) {
+  throw new Error('analytics contract artifact is missing its generated-file header');
+}
+
+console.log(`analytics contract pin verified at ${lock.contract_commit}`);

--- a/scripts/check-analytics-contract.test.mjs
+++ b/scripts/check-analytics-contract.test.mjs
@@ -119,6 +119,19 @@ describe('analytics contract pin', () => {
       .toThrow(/required provenance fields/);
   });
 
+  it('rejects an artifact whose schema version constant was renamed', () => {
+    const renamed = Buffer.from(
+      artifact
+        .toString('utf8')
+        .replace('PRODUCT_ANALYTICS_V2_SCHEMA_VERSION', 'PRODUCT_ANALYTICS_SCHEMA_REVISION'),
+      'utf8',
+    );
+    const repinned = repinArtifact(renamed);
+
+    expect(() => assertContractPin(repinned.lock, renamed, repinned.manifest))
+      .toThrow(/schema version does not match the lock/);
+  });
+
   it('rejects an artifact missing its generated-file header', () => {
     const stripped = Buffer.from(artifact.toString('utf8').replace('// DO NOT EDIT.', '//'), 'utf8');
     const repinned = repinArtifact(stripped);

--- a/scripts/check-analytics-contract.test.mjs
+++ b/scripts/check-analytics-contract.test.mjs
@@ -8,6 +8,7 @@ import { describe, expect, it } from 'vitest';
 import {
   assertContractPin,
   readEmbeddedCommit,
+  readEmbeddedSchemaVersion,
   verifyAnalyticsContract,
 } from './check-analytics-contract.mjs';
 
@@ -20,10 +21,11 @@ describe('analytics contract pin', () => {
     expect(verifyAnalyticsContract()).toBe(lock.contract_commit);
   });
 
-  it('reads the commit the generator embedded', () => {
+  it('reads the commit and schema version the generator embedded', () => {
     const contents = artifact.toString('utf8');
 
     expect(readEmbeddedCommit(contents)).toBe(lock.contract_commit);
+    expect(readEmbeddedSchemaVersion(contents)).toBe(lock.schema_version);
     expect(contents).toContain('DO NOT EDIT');
   });
 
@@ -41,6 +43,11 @@ describe('analytics contract pin', () => {
   it('rejects a re-pin that forgot to update the contract commit', () => {
     expect(() => assertContractPin({ ...lock, contract_commit: 'a'.repeat(40) }, artifact))
       .toThrow(/commit does not match/);
+  });
+
+  it('rejects a re-pin that forgot to update the schema version', () => {
+    expect(() => assertContractPin({ ...lock, schema_version: 2 }, artifact))
+      .toThrow(/schema version does not match/);
   });
 
   it('rejects an artifact missing its generated-file header', () => {

--- a/scripts/check-analytics-contract.test.mjs
+++ b/scripts/check-analytics-contract.test.mjs
@@ -1,0 +1,55 @@
+import { createHash } from 'node:crypto';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  assertContractPin,
+  readEmbeddedCommit,
+  verifyAnalyticsContract,
+} from './check-analytics-contract.mjs';
+
+const repoRoot = dirname(dirname(fileURLToPath(import.meta.url)));
+const lock = JSON.parse(readFileSync(join(repoRoot, 'analytics-contract.lock'), 'utf8'));
+const artifact = readFileSync(join(repoRoot, 'src/generated/productAnalytics.ts'));
+
+describe('analytics contract pin', () => {
+  it('accepts the checked-in artifact and lock', () => {
+    expect(verifyAnalyticsContract()).toBe(lock.contract_commit);
+  });
+
+  it('reads the commit the generator embedded', () => {
+    const contents = artifact.toString('utf8');
+
+    expect(readEmbeddedCommit(contents)).toBe(lock.contract_commit);
+    expect(contents).toContain('DO NOT EDIT');
+  });
+
+  it('rejects a lock that points at another file', () => {
+    expect(() => assertContractPin({ ...lock, artifact: 'src/generated/other.ts' }, artifact))
+      .toThrow(/must target/);
+  });
+
+  it('rejects an artifact edited after it was pinned', () => {
+    const edited = Buffer.concat([artifact, Buffer.from('\nexport const SNUCK_IN = 1;\n')]);
+
+    expect(() => assertContractPin(lock, edited)).toThrow(/checksum drifted/);
+  });
+
+  it('rejects a re-pin that forgot to update the contract commit', () => {
+    expect(() => assertContractPin({ ...lock, contract_commit: 'a'.repeat(40) }, artifact))
+      .toThrow(/commit does not match/);
+  });
+
+  it('rejects an artifact missing its generated-file header', () => {
+    const stripped = Buffer.from(artifact.toString('utf8').replace('// DO NOT EDIT.', '//'), 'utf8');
+    const repinned = {
+      ...lock,
+      artifact_sha256: createHash('sha256').update(stripped).digest('hex'),
+    };
+
+    expect(() => assertContractPin(repinned, stripped)).toThrow(/generated-file header/);
+  });
+});

--- a/scripts/check-analytics-contract.test.mjs
+++ b/scripts/check-analytics-contract.test.mjs
@@ -15,10 +15,34 @@ import {
 const repoRoot = dirname(dirname(fileURLToPath(import.meta.url)));
 const lock = JSON.parse(readFileSync(join(repoRoot, 'analytics-contract.lock'), 'utf8'));
 const artifact = readFileSync(join(repoRoot, 'src/generated/productAnalytics.ts'));
+const manifest = readFileSync(join(repoRoot, 'analytics-contract.manifest.json'));
+
+function sha256(bytes) {
+  return createHash('sha256').update(bytes).digest('hex');
+}
+
+function repinManifest(manifestValue, lockOverrides = {}) {
+  const repinnedManifest = Buffer.from(`${JSON.stringify(manifestValue, null, 2)}\n`);
+  return {
+    lock: {
+      ...lock,
+      ...lockOverrides,
+      manifest_sha256: sha256(repinnedManifest),
+    },
+    manifest: repinnedManifest,
+  };
+}
+
+function repinArtifact(repinnedArtifact) {
+  const artifactSha = sha256(repinnedArtifact);
+  const manifestValue = JSON.parse(manifest.toString('utf8'));
+  manifestValue.artifacts['productAnalytics.ts'].sha256 = artifactSha;
+  return repinManifest(manifestValue, { artifact_sha256: artifactSha });
+}
 
 describe('analytics contract pin', () => {
   it('accepts the checked-in artifact and lock', () => {
-    expect(verifyAnalyticsContract()).toBe(lock.contract_commit);
+    expect(verifyAnalyticsContract()).toEqual(lock);
   });
 
   it('reads the commit and schema version the generator embedded', () => {
@@ -30,33 +54,54 @@ describe('analytics contract pin', () => {
   });
 
   it('rejects a lock that points at another file', () => {
-    expect(() => assertContractPin({ ...lock, artifact: 'src/generated/other.ts' }, artifact))
+    expect(() =>
+      assertContractPin({ ...lock, artifact: 'src/generated/other.ts' }, artifact, manifest),
+    )
       .toThrow(/must target/);
   });
 
   it('rejects an artifact edited after it was pinned', () => {
     const edited = Buffer.concat([artifact, Buffer.from('\nexport const SNUCK_IN = 1;\n')]);
 
-    expect(() => assertContractPin(lock, edited)).toThrow(/checksum drifted/);
+    expect(() => assertContractPin(lock, edited, manifest)).toThrow(/checksum drifted/);
   });
 
   it('rejects a re-pin that forgot to update the contract commit', () => {
-    expect(() => assertContractPin({ ...lock, contract_commit: 'a'.repeat(40) }, artifact))
-      .toThrow(/commit does not match/);
+    const contractCommit = 'a'.repeat(40);
+    const manifestValue = JSON.parse(manifest.toString('utf8'));
+    manifestValue.contract_commit = contractCommit;
+    const repinned = repinManifest(manifestValue, { contract_commit: contractCommit });
+
+    expect(() => assertContractPin(repinned.lock, artifact, repinned.manifest))
+      .toThrow(/artifact commit does not match/);
   });
 
   it('rejects a re-pin that forgot to update the schema version', () => {
-    expect(() => assertContractPin({ ...lock, schema_version: 2 }, artifact))
-      .toThrow(/schema version does not match/);
+    expect(() => assertContractPin({ ...lock, schema_version: 1 }, artifact, manifest))
+      .toThrow(/schema version/);
+  });
+
+  it('rejects a modified upstream manifest', () => {
+    const edited = Buffer.concat([manifest, Buffer.from('\n')]);
+
+    expect(() => assertContractPin(lock, artifact, edited)).toThrow(/manifest checksum drifted/);
+  });
+
+  it('rejects an artifact commit that is not a full Git commit', () => {
+    expect(() => assertContractPin({ ...lock, artifact_commit: 'branch-name' }, artifact, manifest))
+      .toThrow(/artifact commit has an invalid format/);
+  });
+
+  it('rejects unvalidated lock fields', () => {
+    expect(() => assertContractPin({ ...lock, unused: true }, artifact, manifest))
+      .toThrow(/required provenance fields/);
   });
 
   it('rejects an artifact missing its generated-file header', () => {
     const stripped = Buffer.from(artifact.toString('utf8').replace('// DO NOT EDIT.', '//'), 'utf8');
-    const repinned = {
-      ...lock,
-      artifact_sha256: createHash('sha256').update(stripped).digest('hex'),
-    };
+    const repinned = repinArtifact(stripped);
 
-    expect(() => assertContractPin(repinned, stripped)).toThrow(/generated-file header/);
+    expect(() => assertContractPin(repinned.lock, stripped, repinned.manifest))
+      .toThrow(/generated-file header/);
   });
 });

--- a/scripts/check-analytics-contract.test.mjs
+++ b/scripts/check-analytics-contract.test.mjs
@@ -8,6 +8,7 @@ import { describe, expect, it } from 'vitest';
 import {
   assertContractPin,
   readEmbeddedCommit,
+  readEmbeddedEventIdAlgorithm,
   readEmbeddedSchemaVersion,
   verifyAnalyticsContract,
 } from './check-analytics-contract.mjs';
@@ -45,11 +46,12 @@ describe('analytics contract pin', () => {
     expect(verifyAnalyticsContract()).toEqual(lock);
   });
 
-  it('reads the commit and schema version the generator embedded', () => {
+  it('reads the commit, schema version, and ID algorithm the generator embedded', () => {
     const contents = artifact.toString('utf8');
 
     expect(readEmbeddedCommit(contents)).toBe(lock.contract_commit);
     expect(readEmbeddedSchemaVersion(contents)).toBe(lock.schema_version);
+    expect(readEmbeddedEventIdAlgorithm(contents)).toBe('sha256-rfc8785-v1');
     expect(contents).toContain('DO NOT EDIT');
   });
 
@@ -85,6 +87,26 @@ describe('analytics contract pin', () => {
     const edited = Buffer.concat([manifest, Buffer.from('\n')]);
 
     expect(() => assertContractPin(lock, artifact, edited)).toThrow(/manifest checksum drifted/);
+  });
+
+  it('rejects a manifest with another event ID algorithm', () => {
+    const manifestValue = JSON.parse(manifest.toString('utf8'));
+    manifestValue.event_id_algorithm = 'random-uuid';
+    const repinned = repinManifest(manifestValue);
+
+    expect(() => assertContractPin(repinned.lock, artifact, repinned.manifest))
+      .toThrow(/event ID algorithm/);
+  });
+
+  it('rejects an artifact with another event ID algorithm', () => {
+    const edited = Buffer.from(
+      artifact.toString('utf8').replace('sha256-rfc8785-v1', 'random-uuid'),
+      'utf8',
+    );
+    const repinned = repinArtifact(edited);
+
+    expect(() => assertContractPin(repinned.lock, edited, repinned.manifest))
+      .toThrow(/event ID algorithm/);
   });
 
   it('rejects an artifact commit that is not a full Git commit', () => {

--- a/src/generated/productAnalytics.ts
+++ b/src/generated/productAnalytics.ts
@@ -1,0 +1,125 @@
+// @generated from analytics/event-contract.yaml.
+// Source contract commit: 687df20125fac8b8643892e7cfaefbd84606c83c
+// DO NOT EDIT. Update the contract and run analytics/codegen/generate.py.
+export const PRODUCT_ANALYTICS_CONTRACT_COMMIT = '687df20125fac8b8643892e7cfaefbd84606c83c' as const;
+export const PRODUCT_ANALYTICS_SCHEMA_VERSION = 1 as const;
+export const PRODUCT_ANALYTICS_CONSENT_DEFAULT_ENABLED: boolean | null = null;
+
+export type ProductAnalyticsSource = 'mobile' | 'web';
+
+export type ProductAnalyticsPlatform = 'ios' | 'android' | 'web';
+
+export type ProductAnalyticsConsentCategory = 'product_analytics';
+
+export type ProductAnalyticsSurface = 'feed' | 'following' | 'discovery' | 'profile' | 'search_results' | 'onboarding' | 'registration' | 'landing' | 'notifications' | 'settings' | 'unknown';
+
+export type ProductAnalyticsPlaybackEndReason = 'ended' | 'paused' | 'navigation' | 'backgrounded' | 'error' | 'unknown';
+
+export type ProductAnalyticsNavigationAction = 'open' | 'back' | 'tab' | 'deep_link' | 'cta' | 'swipe' | 'unknown';
+
+export type ProductAnalyticsOnboardingFlow = 'account_setup' | 'viewer_setup' | 'creator_setup';
+
+export type ProductAnalyticsOnboardingStep = 'welcome' | 'identity' | 'interests' | 'follow_suggestions' | 'notifications' | 'complete';
+
+export type ProductAnalyticsOnboardingResult = 'viewed' | 'completed' | 'skipped' | 'failed';
+
+export type ProductAnalyticsOnboardingReason = 'none' | 'dismissed' | 'validation' | 'network' | 'unknown';
+
+export type ProductAnalyticsAssignmentSource = 'client' | 'server';
+
+export type ProductAnalyticsLandingPage = 'home' | 'download' | 'invite' | 'registration';
+
+export type ProductAnalyticsReferrerClass = 'direct' | 'search' | 'social' | 'referral' | 'campaign' | 'unknown';
+
+export type ProductAnalyticsRegistrationEntryPoint = 'landing' | 'invite' | 'deep_link' | 'download_prompt' | 'unknown';
+
+export const PRODUCT_ANALYTICS_EVENT_NAMES = [
+  'content_impression_recorded',
+  'playback_session_recorded',
+  'navigation_context_recorded',
+  'onboarding_step_recorded',
+  'experiment_exposure',
+  'landing_viewed',
+  'registration_started'
+] as const;
+
+export type ProductAnalyticsEventName = typeof PRODUCT_ANALYTICS_EVENT_NAMES[number];
+
+export interface ProductAnalyticsEnvelope {
+  event_id: string;
+  schema_version: 1;
+  occurred_at: string;
+  anonymous_id: string;
+  session_id: string;
+  source: ProductAnalyticsSource;
+  platform: ProductAnalyticsPlatform;
+  release: string;
+  consent_category: "product_analytics";
+}
+
+export interface ContentImpressionRecordedProperties {
+  content_id: string;
+  surface: ProductAnalyticsSurface;
+  position: number;
+  visible_ms: number;
+  recommendation_id?: string;
+}
+
+export interface PlaybackSessionRecordedProperties {
+  playback_session_id: string;
+  content_id: string;
+  surface: ProductAnalyticsSurface;
+  duration_ms: number;
+  watched_ms: number;
+  loop_count: number;
+  completed: boolean;
+  end_reason: ProductAnalyticsPlaybackEndReason;
+}
+
+export interface NavigationContextRecordedProperties {
+  from_surface: ProductAnalyticsSurface;
+  to_surface: ProductAnalyticsSurface;
+  action: ProductAnalyticsNavigationAction;
+  content_id?: string;
+  recommendation_id?: string;
+}
+
+export interface OnboardingStepRecordedProperties {
+  flow: ProductAnalyticsOnboardingFlow;
+  step: ProductAnalyticsOnboardingStep;
+  result: ProductAnalyticsOnboardingResult;
+  reason?: ProductAnalyticsOnboardingReason;
+}
+
+export interface ExperimentExposureProperties {
+  experiment_key: string;
+  variant_key: string;
+  assignment_source: ProductAnalyticsAssignmentSource;
+}
+
+export interface LandingViewedProperties {
+  landing_page: ProductAnalyticsLandingPage;
+  referrer_class: ProductAnalyticsReferrerClass;
+  utm_source?: string;
+  utm_medium?: string;
+  utm_campaign?: string;
+  utm_content?: string;
+}
+
+export interface RegistrationStartedProperties {
+  entry_point: ProductAnalyticsRegistrationEntryPoint;
+  utm_source?: string;
+  utm_medium?: string;
+  utm_campaign?: string;
+  utm_content?: string;
+}
+
+export type ProductAnalyticsEvent = ProductAnalyticsEnvelope & (
+  { event_name: 'content_impression_recorded'; properties: ContentImpressionRecordedProperties }
+  | { event_name: 'playback_session_recorded'; properties: PlaybackSessionRecordedProperties }
+  | { event_name: 'navigation_context_recorded'; properties: NavigationContextRecordedProperties }
+  | { event_name: 'onboarding_step_recorded'; properties: OnboardingStepRecordedProperties }
+  | { event_name: 'experiment_exposure'; properties: ExperimentExposureProperties }
+  | { event_name: 'landing_viewed'; properties: LandingViewedProperties }
+  | { event_name: 'registration_started'; properties: RegistrationStartedProperties }
+);

--- a/src/generated/productAnalytics.ts
+++ b/src/generated/productAnalytics.ts
@@ -1,8 +1,9 @@
 // @generated from analytics/event-contract.yaml.
-// Source contract commit: 0aa587e38a9aea3bee70fd1d0bf492dac8266dd4
+// Source contract commit: 02083864050efdba549f118ba11bf6111f4bb7ba
 // DO NOT EDIT. Update the contract and run analytics/codegen/generate.py.
-export const PRODUCT_ANALYTICS_V2_CONTRACT_COMMIT = '0aa587e38a9aea3bee70fd1d0bf492dac8266dd4' as const;
+export const PRODUCT_ANALYTICS_V2_CONTRACT_COMMIT = '02083864050efdba549f118ba11bf6111f4bb7ba' as const;
 export const PRODUCT_ANALYTICS_V2_SCHEMA_VERSION = 2 as const;
+export const PRODUCT_ANALYTICS_V2_EVENT_ID_ALGORITHM = 'sha256-rfc8785-v1' as const;
 export const PRODUCT_ANALYTICS_V2_CONSENT_DEFAULT_ENABLED: boolean | null = null;
 
 export type ProductAnalyticsV2Source = 'mobile' | 'web';

--- a/src/generated/productAnalytics.ts
+++ b/src/generated/productAnalytics.ts
@@ -1,39 +1,39 @@
 // @generated from analytics/event-contract.yaml.
-// Source contract commit: 687df20125fac8b8643892e7cfaefbd84606c83c
+// Source contract commit: 0aa587e38a9aea3bee70fd1d0bf492dac8266dd4
 // DO NOT EDIT. Update the contract and run analytics/codegen/generate.py.
-export const PRODUCT_ANALYTICS_CONTRACT_COMMIT = '687df20125fac8b8643892e7cfaefbd84606c83c' as const;
-export const PRODUCT_ANALYTICS_SCHEMA_VERSION = 1 as const;
-export const PRODUCT_ANALYTICS_CONSENT_DEFAULT_ENABLED: boolean | null = null;
+export const PRODUCT_ANALYTICS_V2_CONTRACT_COMMIT = '0aa587e38a9aea3bee70fd1d0bf492dac8266dd4' as const;
+export const PRODUCT_ANALYTICS_V2_SCHEMA_VERSION = 2 as const;
+export const PRODUCT_ANALYTICS_V2_CONSENT_DEFAULT_ENABLED: boolean | null = null;
 
-export type ProductAnalyticsSource = 'mobile' | 'web';
+export type ProductAnalyticsV2Source = 'mobile' | 'web';
 
-export type ProductAnalyticsPlatform = 'ios' | 'android' | 'web';
+export type ProductAnalyticsV2Platform = 'ios' | 'android' | 'web';
 
-export type ProductAnalyticsConsentCategory = 'product_analytics';
+export type ProductAnalyticsV2ConsentCategory = 'product_analytics';
 
-export type ProductAnalyticsSurface = 'feed' | 'following' | 'discovery' | 'profile' | 'search_results' | 'onboarding' | 'registration' | 'landing' | 'notifications' | 'settings' | 'unknown';
+export type ProductAnalyticsV2Surface = 'feed' | 'following' | 'discovery' | 'profile' | 'search_results' | 'onboarding' | 'registration' | 'landing' | 'notifications' | 'settings' | 'unknown';
 
-export type ProductAnalyticsPlaybackEndReason = 'ended' | 'paused' | 'navigation' | 'backgrounded' | 'error' | 'unknown';
+export type ProductAnalyticsV2PlaybackEndReason = 'ended' | 'paused' | 'navigation' | 'backgrounded' | 'error' | 'unknown';
 
-export type ProductAnalyticsNavigationAction = 'open' | 'back' | 'tab' | 'deep_link' | 'cta' | 'swipe' | 'unknown';
+export type ProductAnalyticsV2NavigationAction = 'open' | 'back' | 'tab' | 'deep_link' | 'cta' | 'swipe' | 'unknown';
 
-export type ProductAnalyticsOnboardingFlow = 'account_setup' | 'viewer_setup' | 'creator_setup';
+export type ProductAnalyticsV2OnboardingFlow = 'account_setup' | 'viewer_setup' | 'creator_setup';
 
-export type ProductAnalyticsOnboardingStep = 'welcome' | 'identity' | 'interests' | 'follow_suggestions' | 'notifications' | 'complete';
+export type ProductAnalyticsV2OnboardingStep = 'welcome' | 'identity' | 'interests' | 'follow_suggestions' | 'notifications' | 'complete';
 
-export type ProductAnalyticsOnboardingResult = 'viewed' | 'completed' | 'skipped' | 'failed';
+export type ProductAnalyticsV2OnboardingResult = 'viewed' | 'completed' | 'skipped' | 'failed';
 
-export type ProductAnalyticsOnboardingReason = 'none' | 'dismissed' | 'validation' | 'network' | 'unknown';
+export type ProductAnalyticsV2OnboardingReason = 'none' | 'dismissed' | 'validation' | 'network' | 'unknown';
 
-export type ProductAnalyticsAssignmentSource = 'client' | 'server';
+export type ProductAnalyticsV2AssignmentSource = 'client' | 'server';
 
-export type ProductAnalyticsLandingPage = 'home' | 'download' | 'invite' | 'registration';
+export type ProductAnalyticsV2LandingPage = 'home' | 'download' | 'invite' | 'registration';
 
-export type ProductAnalyticsReferrerClass = 'direct' | 'search' | 'social' | 'referral' | 'campaign' | 'unknown';
+export type ProductAnalyticsV2ReferrerClass = 'direct' | 'search' | 'social' | 'referral' | 'campaign' | 'unknown';
 
-export type ProductAnalyticsRegistrationEntryPoint = 'landing' | 'invite' | 'deep_link' | 'download_prompt' | 'unknown';
+export type ProductAnalyticsV2RegistrationEntryPoint = 'landing' | 'invite' | 'deep_link' | 'download_prompt' | 'unknown';
 
-export const PRODUCT_ANALYTICS_EVENT_NAMES = [
+export const PRODUCT_ANALYTICS_V2_EVENT_NAMES = [
   'content_impression_recorded',
   'playback_session_recorded',
   'navigation_context_recorded',
@@ -43,83 +43,83 @@ export const PRODUCT_ANALYTICS_EVENT_NAMES = [
   'registration_started'
 ] as const;
 
-export type ProductAnalyticsEventName = typeof PRODUCT_ANALYTICS_EVENT_NAMES[number];
+export type ProductAnalyticsV2EventName = typeof PRODUCT_ANALYTICS_V2_EVENT_NAMES[number];
 
-export interface ProductAnalyticsEnvelope {
+export interface ProductAnalyticsV2Envelope {
   event_id: string;
-  schema_version: 1;
+  schema_version: 2;
   occurred_at: string;
   anonymous_id: string;
   session_id: string;
-  source: ProductAnalyticsSource;
-  platform: ProductAnalyticsPlatform;
+  source: ProductAnalyticsV2Source;
+  platform: ProductAnalyticsV2Platform;
   release: string;
   consent_category: "product_analytics";
 }
 
-export interface ContentImpressionRecordedProperties {
+export interface ProductAnalyticsV2ContentImpressionRecordedProperties {
   content_id: string;
-  surface: ProductAnalyticsSurface;
+  surface: ProductAnalyticsV2Surface;
   position: number;
   visible_ms: number;
   recommendation_id?: string;
 }
 
-export interface PlaybackSessionRecordedProperties {
+export interface ProductAnalyticsV2PlaybackSessionRecordedProperties {
   playback_session_id: string;
   content_id: string;
-  surface: ProductAnalyticsSurface;
+  surface: ProductAnalyticsV2Surface;
   duration_ms: number;
   watched_ms: number;
   loop_count: number;
   completed: boolean;
-  end_reason: ProductAnalyticsPlaybackEndReason;
+  end_reason: ProductAnalyticsV2PlaybackEndReason;
 }
 
-export interface NavigationContextRecordedProperties {
-  from_surface: ProductAnalyticsSurface;
-  to_surface: ProductAnalyticsSurface;
-  action: ProductAnalyticsNavigationAction;
+export interface ProductAnalyticsV2NavigationContextRecordedProperties {
+  from_surface: ProductAnalyticsV2Surface;
+  to_surface: ProductAnalyticsV2Surface;
+  action: ProductAnalyticsV2NavigationAction;
   content_id?: string;
   recommendation_id?: string;
 }
 
-export interface OnboardingStepRecordedProperties {
-  flow: ProductAnalyticsOnboardingFlow;
-  step: ProductAnalyticsOnboardingStep;
-  result: ProductAnalyticsOnboardingResult;
-  reason?: ProductAnalyticsOnboardingReason;
+export interface ProductAnalyticsV2OnboardingStepRecordedProperties {
+  flow: ProductAnalyticsV2OnboardingFlow;
+  step: ProductAnalyticsV2OnboardingStep;
+  result: ProductAnalyticsV2OnboardingResult;
+  reason?: ProductAnalyticsV2OnboardingReason;
 }
 
-export interface ExperimentExposureProperties {
+export interface ProductAnalyticsV2ExperimentExposureProperties {
   experiment_key: string;
   variant_key: string;
-  assignment_source: ProductAnalyticsAssignmentSource;
+  assignment_source: ProductAnalyticsV2AssignmentSource;
 }
 
-export interface LandingViewedProperties {
-  landing_page: ProductAnalyticsLandingPage;
-  referrer_class: ProductAnalyticsReferrerClass;
+export interface ProductAnalyticsV2LandingViewedProperties {
+  landing_page: ProductAnalyticsV2LandingPage;
+  referrer_class: ProductAnalyticsV2ReferrerClass;
   utm_source?: string;
   utm_medium?: string;
   utm_campaign?: string;
   utm_content?: string;
 }
 
-export interface RegistrationStartedProperties {
-  entry_point: ProductAnalyticsRegistrationEntryPoint;
+export interface ProductAnalyticsV2RegistrationStartedProperties {
+  entry_point: ProductAnalyticsV2RegistrationEntryPoint;
   utm_source?: string;
   utm_medium?: string;
   utm_campaign?: string;
   utm_content?: string;
 }
 
-export type ProductAnalyticsEvent = ProductAnalyticsEnvelope & (
-  { event_name: 'content_impression_recorded'; properties: ContentImpressionRecordedProperties }
-  | { event_name: 'playback_session_recorded'; properties: PlaybackSessionRecordedProperties }
-  | { event_name: 'navigation_context_recorded'; properties: NavigationContextRecordedProperties }
-  | { event_name: 'onboarding_step_recorded'; properties: OnboardingStepRecordedProperties }
-  | { event_name: 'experiment_exposure'; properties: ExperimentExposureProperties }
-  | { event_name: 'landing_viewed'; properties: LandingViewedProperties }
-  | { event_name: 'registration_started'; properties: RegistrationStartedProperties }
+export type ProductAnalyticsV2Event = ProductAnalyticsV2Envelope & (
+  { event_name: 'content_impression_recorded'; properties: ProductAnalyticsV2ContentImpressionRecordedProperties }
+  | { event_name: 'playback_session_recorded'; properties: ProductAnalyticsV2PlaybackSessionRecordedProperties }
+  | { event_name: 'navigation_context_recorded'; properties: ProductAnalyticsV2NavigationContextRecordedProperties }
+  | { event_name: 'onboarding_step_recorded'; properties: ProductAnalyticsV2OnboardingStepRecordedProperties }
+  | { event_name: 'experiment_exposure'; properties: ProductAnalyticsV2ExperimentExposureProperties }
+  | { event_name: 'landing_viewed'; properties: ProductAnalyticsV2LandingViewedProperties }
+  | { event_name: 'registration_started'; properties: ProductAnalyticsV2RegistrationStartedProperties }
 );

--- a/src/generated/productAnalytics.ts
+++ b/src/generated/productAnalytics.ts
@@ -1,7 +1,7 @@
 // @generated from analytics/event-contract.yaml.
-// Source contract commit: 02083864050efdba549f118ba11bf6111f4bb7ba
+// Source contract commit: 27e21a7a1ea3c6cb998186eda50807e63806efc9
 // DO NOT EDIT. Update the contract and run analytics/codegen/generate.py.
-export const PRODUCT_ANALYTICS_V2_CONTRACT_COMMIT = '02083864050efdba549f118ba11bf6111f4bb7ba' as const;
+export const PRODUCT_ANALYTICS_V2_CONTRACT_COMMIT = '27e21a7a1ea3c6cb998186eda50807e63806efc9' as const;
 export const PRODUCT_ANALYTICS_V2_SCHEMA_VERSION = 2 as const;
 export const PRODUCT_ANALYTICS_V2_EVENT_ID_ALGORITHM = 'sha256-rfc8785-v1' as const;
 export const PRODUCT_ANALYTICS_V2_CONSENT_DEFAULT_ENABLED: boolean | null = null;


### PR DESCRIPTION
## What this added

This adds the shared analytics event definitions to the web repository.

Web, mobile, and Funnelcake must agree on every event name and field. The web repository now has an exact TypeScript copy of the shared definitions and an automated check that fails if the copy changes or comes from the wrong source.

The source is divine-context:

- shared event definition: 27e21a7a1ea3c6cb998186eda50807e63806efc9
- generated TypeScript file: 470a150d767b0c23bea66c37158cdefec6ae9743

## Why the names include V2

The web app already has older analytics code with different fields.

The new generated names include V2 so they cannot be confused with the old code. This pull request did not switch the live web app to the new events.

## What this did not do

It did not:

- start collecting new analytics
- change the existing event queue
- choose a consent setting
- change anything users can see

Part of divinevideo/divine-funnelcake#1090.

## Tests

Passed:

- the shared-file check
- 13 tests for the checker
- TypeScript checks
- the full web test suite
- lint, with only the 17 warnings that already existed
- the production build
- file formatting checks

No visual change.