### PR TITLE
feat(archive): download verified media in account exports

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -166,6 +166,15 @@ locales. `@fontsource-variable/inter` supplies typography.
 `@unhead/react` manages the document head. `sonner` and `vaul` provide toast
 and drawer UI. `vite-plugin-pwa` generates the PWA service worker.
 
+### Account Archive Export
+
+The `/exit/start` flow reads raw signed events through the owner-export API and
+builds archive metadata in `src/lib/exit/`. Its media option writes a store-only
+Zip64 archive directly to a user-selected file, downloads one unique blob at a
+time, verifies advertised SHA-256 hashes, and records partial failures without
+changing signed events. Viewer authorization is retried only for the exact
+`https://media.divine.video` origin; third-party media requests remain bare.
+
 ## Linting
 
 ESLint 9 with TypeScript, React Hooks, HTML, and three custom rules in

--- a/src/components/exit/MediaProgressList.tsx
+++ b/src/components/exit/MediaProgressList.tsx
@@ -1,0 +1,21 @@
+// ABOUTME: Shows per-blob verification progress while a media archive is written
+// ABOUTME: Uses plain status text so partial and mismatched results remain unambiguous
+
+import type { MediaProgress } from "@/lib/exit/mediaDownloader";
+
+export function MediaProgressList({ progress }: { progress: MediaProgress | null }) {
+  if (!progress) return null;
+  const label = progress.result.verification === "verified"
+    ? "Verified"
+    : progress.result.verification === "unverified"
+      ? "Saved without an advertised hash"
+      : progress.result.verification === "hash-mismatch"
+        ? "Saved separately because the hash did not match"
+        : "Could not download";
+  return (
+    <div className="rounded-lg border border-brand-dark-green/15 p-4 dark:border-brand-green/25" aria-live="polite">
+      <p className="font-semibold text-foreground">Media {progress.completed} of {progress.total}</p>
+      <p className="text-sm text-muted-foreground">{label}: {progress.result.source_url}</p>
+    </div>
+  );
+}

--- a/src/components/exit/MediaProgressList.tsx
+++ b/src/components/exit/MediaProgressList.tsx
@@ -15,7 +15,7 @@ export function MediaProgressList({ progress }: { progress: MediaProgress | null
   return (
     <div className="rounded-lg border border-brand-dark-green/15 p-4 dark:border-brand-green/25" aria-live="polite">
       <p className="font-semibold text-foreground">Media {progress.completed} of {progress.total}</p>
-      <p className="text-sm text-muted-foreground">{label}: {progress.result.source_url}</p>
+      <p className="text-sm text-muted-foreground">{label}: <span className="break-all">{progress.result.source_url}</span></p>
     </div>
   );
 }

--- a/src/hooks/useArchiveMediaExport.ts
+++ b/src/hooks/useArchiveMediaExport.ts
@@ -1,0 +1,75 @@
+// ABOUTME: Orchestrates streamed media archive creation for the account export page
+// ABOUTME: Keeps picker, downloader, ZIP finalization, and progress state out of the page
+
+import type { NostrSigner } from "@nostrify/nostrify";
+import { useEffect, useRef, useState } from "react";
+
+import { completeArchiveMedia, serializeArchiveFiles, type ArchiveFiles, type MediaReference } from "@/lib/exit/archive";
+import { pickArchiveSink, supportsStreamingArchive } from "@/lib/exit/archiveSink";
+import { downloadArchiveMedia, type MediaProgress } from "@/lib/exit/mediaDownloader";
+import { createZipWriter } from "@/lib/exit/zip";
+
+type MediaExportState = "idle" | "running" | "complete" | "failed";
+
+export function useArchiveMediaExport(input: { files: ArchiveFiles | null; signer: NostrSigner | null | undefined }) {
+  const [state, setState] = useState<MediaExportState>("idle");
+  const [progress, setProgress] = useState<MediaProgress | null>(null);
+  const [failure, setFailure] = useState<string | null>(null);
+  const activeController = useRef<AbortController | null>(null);
+  const archivePubkey = input.files?.["manifest.json"].pubkey;
+
+  useEffect(() => {
+    activeController.current?.abort();
+    setState("idle");
+    setProgress(null);
+    setFailure(null);
+    return () => activeController.current?.abort();
+  }, [archivePubkey]);
+
+  async function start() {
+    if (!input.files || !input.signer || !supportsStreamingArchive()) return;
+    const pubkey = input.files["manifest.json"].pubkey;
+    let sink;
+    try {
+      sink = await pickArchiveSink(`divine-export-${pubkey}-with-media.zip`);
+    } catch (error) {
+      if (error instanceof DOMException && error.name === "AbortError") return;
+      setFailure(error instanceof Error ? error.message : "The media archive could not be created.");
+      setState("failed");
+      return;
+    }
+    const writer = createZipWriter(sink);
+    const controller = new AbortController();
+    activeController.current?.abort();
+    activeController.current = controller;
+    setState("running");
+    setFailure(null);
+    setProgress(null);
+    try {
+      const initial = serializeArchiveFiles(input.files);
+      await writer.addFile("events.json", initial["events.json"]);
+      const results = await downloadArchiveMedia({
+        references: input.files["media.json"] as MediaReference[],
+        signer: input.signer,
+        signal: controller.signal,
+        onFile: (path, bytes) => writer.addFile(path, bytes),
+        onProgress: setProgress,
+      });
+      if (controller.signal.aborted) throw new DOMException("Download cancelled", "AbortError");
+      const completed = serializeArchiveFiles(completeArchiveMedia(input.files, results));
+      await writer.addFile("manifest.json", completed["manifest.json"]);
+      await writer.addFile("media.json", completed["media.json"]);
+      await writer.addFile("media-checksums.txt", completed["media-checksums.txt"]);
+      await writer.close();
+      setState("complete");
+    } catch (error) {
+      await writer.abort(error);
+      setFailure(error instanceof Error ? error.message : "The media archive could not be created.");
+      setState("failed");
+    } finally {
+      if (activeController.current === controller) activeController.current = null;
+    }
+  }
+
+  return { state, progress, failure, supported: supportsStreamingArchive(), start };
+}

--- a/src/lib/blossomAuth.ts
+++ b/src/lib/blossomAuth.ts
@@ -27,7 +27,7 @@ export async function createBlossomGetAuthHeader(
     const signedEvent = await signer.signEvent(template);
     const encoded = btoa(JSON.stringify(signedEvent));
 
-    debugLog(`[blossomAuth] Created GET auth header for sha256 ${sha256.slice(0, 8)}…`);
+    debugLog('[blossomAuth] Created GET auth header for requested blob');
     return `Nostr ${encoded}`;
   } catch (error) {
     debugError('[blossomAuth] Failed to generate GET auth header:', error);

--- a/src/lib/exit/archive.test.ts
+++ b/src/lib/exit/archive.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import { fixtureMediaHash, fixturePubkey, makeFixtureEvent } from "./__fixtures__/exportFixtures";
-import { buildArchiveFiles, discoverMediaReferences, serializeArchiveFiles } from "./archive";
+import { buildArchiveFiles, completeArchiveMedia, discoverMediaReferences, serializeArchiveFiles } from "./archive";
 
 describe("archive builder", () => {
   it("preserves raw events and writes manifest metadata", () => {
@@ -171,5 +171,26 @@ describe("archive builder", () => {
     });
 
     expect(Object.keys(serializeArchiveFiles(archive))).toEqual(["events.json", "manifest.json", "media.json"]);
+  });
+
+  it("merges per-reference results, summarizes blobs, and certifies only trusted paths", () => {
+    const archive = buildArchiveFiles({
+      events: [makeFixtureEvent()], pubkey: fixturePubkey, sourceEndpoint: "https://api.divine.video",
+      pageCount: 1, failures: [], generatedAt: new Date("2026-08-12T21:00:00Z"),
+    });
+    const reference = archive["media.json"][0];
+    const completed = completeArchiveMedia(archive, [
+      { references: [reference], source_url: reference.url, expected_sha256: fixtureMediaHash,
+        computed_sha256: fixtureMediaHash, byte_size: 5, content_type: "video/mp4",
+        archive_path: `media/${fixtureMediaHash}.mp4`, verification: "verified" },
+      { references: [{ ...reference, url: "https://example.com/wrong" }], source_url: "https://example.com/wrong",
+        expected_sha256: fixtureMediaHash, computed_sha256: "e".repeat(64), byte_size: 4, content_type: "video/mp4",
+        archive_path: `media/mismatched/${fixtureMediaHash}.mp4`, verification: "hash-mismatch" },
+    ]);
+    expect(completed["manifest.json"].media).toEqual({
+      media_total: 2, media_verified: 1, media_unverified: 0, media_mismatched: 1, media_failed: 0,
+    });
+    expect(completed["media.json"]).toHaveLength(2);
+    expect(completed["media-checksums.txt"]).toBe(`${fixtureMediaHash}  media/${fixtureMediaHash}.mp4\n`);
   });
 });

--- a/src/lib/exit/archive.ts
+++ b/src/lib/exit/archive.ts
@@ -5,6 +5,7 @@ import type { NostrEvent } from "@nostrify/nostrify";
 
 import { isHex64 } from "./hex";
 import type { OwnerExportError } from "./ownerExportClient";
+import type { MediaDownloadResult, MediaVerification } from "./mediaDownloader";
 
 export interface MediaReference {
   event_id: string;
@@ -25,12 +26,33 @@ export interface ArchiveManifest {
     message: string;
     status?: number;
   }>;
+  media?: MediaSummary;
+}
+
+export interface MediaSummary {
+  media_total: number;
+  media_verified: number;
+  media_unverified: number;
+  media_mismatched: number;
+  media_failed: number;
+}
+
+export interface ArchivedMediaReference extends MediaReference {
+  source_url: string;
+  expected_sha256: string | null;
+  computed_sha256: string | null;
+  byte_size: number | null;
+  content_type: string | null;
+  archive_path: string | null;
+  verification: MediaVerification;
+  failure_reason?: string;
 }
 
 export interface ArchiveFiles {
   "events.json": NostrEvent[];
   "manifest.json": ArchiveManifest;
-  "media.json": MediaReference[];
+  "media.json": MediaReference[] | ArchivedMediaReference[];
+  "media-checksums.txt"?: string;
 }
 
 const URL_TAGS = new Set(["url", "image", "thumb", "thumbnail"]);
@@ -162,10 +184,52 @@ export function buildArchiveFiles(input: {
   };
 }
 
-export function serializeArchiveFiles(files: ArchiveFiles): Record<string, string> {
+export function mergeMediaResults(results: MediaDownloadResult[]): ArchivedMediaReference[] {
+  return results.flatMap((result) => result.references.map((reference) => ({
+    ...reference,
+    source_url: result.source_url,
+    expected_sha256: result.expected_sha256,
+    computed_sha256: result.computed_sha256,
+    byte_size: result.byte_size,
+    content_type: result.content_type,
+    archive_path: result.archive_path,
+    verification: result.verification,
+    ...(result.failure_reason ? { failure_reason: result.failure_reason } : {}),
+  })));
+}
+
+export function summarizeMedia(results: MediaDownloadResult[]): MediaSummary {
   return {
+    media_total: results.length,
+    media_verified: results.filter((result) => result.verification === "verified").length,
+    media_unverified: results.filter((result) => result.verification === "unverified").length,
+    media_mismatched: results.filter((result) => result.verification === "hash-mismatch").length,
+    media_failed: results.filter((result) => result.verification === "failed").length,
+  };
+}
+
+export function createMediaChecksums(results: MediaDownloadResult[]): string {
+  const lines = results
+    .filter((result) => result.archive_path && (result.verification === "verified" || result.verification === "unverified"))
+    .map((result) => `${result.computed_sha256}  ${result.archive_path}`);
+  return lines.length ? `${lines.join("\n")}\n` : "";
+}
+
+export function completeArchiveMedia(files: ArchiveFiles, results: MediaDownloadResult[]): ArchiveFiles {
+  return {
+    ...files,
+    "manifest.json": { ...files["manifest.json"], media: summarizeMedia(results) },
+    "media.json": mergeMediaResults(results),
+    "media-checksums.txt": createMediaChecksums(results),
+  };
+}
+
+export function serializeArchiveFiles(files: ArchiveFiles): Record<string, string> {
+  const serialized: Record<string, string> = {
     "events.json": `${JSON.stringify(files["events.json"], null, 2)}\n`,
     "manifest.json": `${JSON.stringify(files["manifest.json"], null, 2)}\n`,
     "media.json": `${JSON.stringify(files["media.json"], null, 2)}\n`
   };
+  if (files["media-checksums.txt"] !== undefined) serialized["media-checksums.txt"] = files["media-checksums.txt"];
+  return serialized;
 }

--- a/src/lib/exit/archiveSink.test.ts
+++ b/src/lib/exit/archiveSink.test.ts
@@ -1,0 +1,23 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { pickArchiveSink, supportsStreamingArchive } from "./archiveSink";
+
+describe("archiveSink", () => {
+  afterEach(() => vi.unstubAllGlobals());
+
+  it("reports unsupported browsers without allocating an in-memory fallback", async () => {
+    expect(supportsStreamingArchive()).toBe(false);
+    await expect(pickArchiveSink("archive.zip")).rejects.toThrow("cannot build one large media archive");
+  });
+
+  it("opens a ZIP file and returns its writable sink", async () => {
+    const writable = { write: vi.fn(), close: vi.fn(), abort: vi.fn() };
+    const picker = vi.fn(async () => ({ createWritable: async () => writable }));
+    vi.stubGlobal("showSaveFilePicker", picker);
+    await expect(pickArchiveSink("archive.zip")).resolves.toBe(writable);
+    expect(picker).toHaveBeenCalledWith({
+      suggestedName: "archive.zip",
+      types: [{ description: "ZIP archive", accept: { "application/zip": [".zip"] } }],
+    });
+  });
+});

--- a/src/lib/exit/archiveSink.ts
+++ b/src/lib/exit/archiveSink.ts
@@ -1,0 +1,26 @@
+// ABOUTME: Adapts the File System Access API writable stream to the archive ZIP sink
+// ABOUTME: Keeps unsupported-browser detection isolated from archive orchestration
+
+import type { ZipSink } from "./zip";
+
+interface ArchiveWritable {
+  write(chunk: Uint8Array): Promise<void>;
+  close(): Promise<void>;
+  abort(reason?: unknown): Promise<void>;
+}
+
+interface SaveFileHandle { createWritable(): Promise<ArchiveWritable>; }
+interface SavePickerWindow extends Window {
+  showSaveFilePicker?: (options: { suggestedName: string; types: Array<{ description: string; accept: Record<string, string[]> }> }) => Promise<SaveFileHandle>;
+}
+
+export function supportsStreamingArchive(): boolean {
+  return typeof (window as SavePickerWindow).showSaveFilePicker === "function";
+}
+
+export async function pickArchiveSink(suggestedName: string): Promise<ZipSink> {
+  const picker = (window as SavePickerWindow).showSaveFilePicker;
+  if (!picker) throw new Error("This browser cannot build one large media archive.");
+  const handle = await picker({ suggestedName, types: [{ description: "ZIP archive", accept: { "application/zip": [".zip"] } }] });
+  return handle.createWritable();
+}

--- a/src/lib/exit/mediaDownloader.test.ts
+++ b/src/lib/exit/mediaDownloader.test.ts
@@ -1,0 +1,103 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { MediaReference } from "./archive";
+import { downloadArchiveMedia, isDivineMediaOrigin } from "./mediaDownloader";
+
+const helloHash = "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824";
+const reference = (url: string, sha256: string | null = helloHash): MediaReference => ({
+  event_id: "1111111111111111111111111111111111111111111111111111111111111111",
+  tag: "url",
+  url,
+  sha256,
+});
+
+describe("downloadArchiveMedia", () => {
+  beforeEach(() => vi.restoreAllMocks());
+
+  it("verifies bytes and writes them under their hash", async () => {
+    const onFile = vi.fn(async () => undefined);
+    const results = await downloadArchiveMedia({
+      references: [reference("https://media.divine.video/blob")],
+      fetcher: vi.fn(async () => new Response("hello", { headers: { "content-type": "video/mp4" } })),
+      onFile,
+    });
+    expect(results[0]).toMatchObject({ verification: "verified", computed_sha256: helloHash, archive_path: `media/${helloHash}.mp4` });
+    expect(onFile).toHaveBeenCalledWith(`media/${helloHash}.mp4`, expect.any(Uint8Array));
+  });
+
+  it("tries another source for the same hash after a mismatch", async () => {
+    const fetcher = vi.fn(async (input: RequestInfo | URL) => new Response(String(input).includes("bad") ? "wrong" : "hello"));
+    const results = await downloadArchiveMedia({
+      references: [reference("https://example.com/bad"), reference("https://example.com/good")],
+      fetcher,
+      onFile: async () => undefined,
+    });
+    expect(fetcher).toHaveBeenCalledTimes(2);
+    expect(results[0]).toMatchObject({ verification: "verified", source_url: "https://example.com/good" });
+    expect(results[0].references).toHaveLength(2);
+  });
+
+  it("quarantines the last mismatch when every mirror is invalid", async () => {
+    const onFile = vi.fn(async () => undefined);
+    const results = await downloadArchiveMedia({
+      references: [reference("https://example.com/wrong-one"), reference("https://example.com/wrong-two")],
+      fetcher: vi.fn(async () => new Response("wrong")),
+      onFile,
+    });
+    expect(results[0].verification).toBe("hash-mismatch");
+    expect(onFile).toHaveBeenCalledWith(`media/mismatched/${helloHash}.bin`, expect.any(Uint8Array));
+  });
+
+  it("quarantines a mismatched file without certifying it", async () => {
+    const onFile = vi.fn(async () => undefined);
+    const results = await downloadArchiveMedia({
+      references: [reference("https://example.com/wrong")],
+      fetcher: vi.fn(async () => new Response("wrong", { headers: { "content-type": "image/jpeg" } })),
+      onFile,
+    });
+    expect(results[0]).toMatchObject({ verification: "hash-mismatch", archive_path: `media/mismatched/${helloHash}.jpg` });
+  });
+
+  it("records HTTP, network, cancellation, and sink failures instead of throwing", async () => {
+    const controller = new AbortController();
+    controller.abort();
+    const cases = [
+      await downloadArchiveMedia({ references: [reference("https://example.com/404")], fetcher: vi.fn(async () => new Response(null, { status: 404 })), onFile: async () => undefined }),
+      await downloadArchiveMedia({ references: [reference("https://example.com/network")], fetcher: vi.fn(async () => { throw new TypeError("offline"); }), onFile: async () => undefined }),
+      await downloadArchiveMedia({ references: [reference("https://example.com/cancel")], signal: controller.signal, fetcher: vi.fn(), onFile: async () => undefined }),
+      await downloadArchiveMedia({ references: [reference("https://example.com/write")], fetcher: vi.fn(async () => new Response("hello")), onFile: async () => { throw new Error("disk full"); } }),
+    ];
+    for (const [result] of cases) expect(result.verification).toBe("failed");
+  });
+
+  it("rejects truncated responses and disables automatic redirects", async () => {
+    const fetcher = vi.fn<typeof fetch>(async () => new Response("short", { headers: { "content-length": "99" } }));
+    const [result] = await downloadArchiveMedia({
+      references: [reference("https://example.com/truncated")], fetcher, onFile: async () => undefined,
+    });
+    expect(result).toMatchObject({ verification: "failed" });
+    expect(fetcher.mock.calls[0][1]).toMatchObject({ redirect: "error" });
+  });
+
+  it("retries an auth challenge only for the exact Divine media origin", async () => {
+    const divineFetch = vi.fn()
+      .mockResolvedValueOnce(new Response(null, { status: 401 }))
+      .mockResolvedValueOnce(new Response("hello"));
+    const signer = { getPublicKey: vi.fn(), signEvent: vi.fn(async (event) => ({ ...event, id: "a".repeat(64), pubkey: "b".repeat(64), sig: "c".repeat(128) })) };
+    await downloadArchiveMedia({ references: [reference("https://media.divine.video/blob")], signer, fetcher: divineFetch, onFile: async () => undefined });
+    expect(divineFetch).toHaveBeenCalledTimes(2);
+    expect((divineFetch.mock.calls[1][1]?.headers as Record<string, string>).Authorization).toMatch(/^Nostr /);
+
+    const thirdPartyFetch = vi.fn(async () => new Response(null, { status: 401 }));
+    await downloadArchiveMedia({ references: [reference("https://media.divine.video.evil.example/blob")], signer, fetcher: thirdPartyFetch, onFile: async () => undefined });
+    expect(thirdPartyFetch).toHaveBeenCalledOnce();
+  });
+});
+
+describe("isDivineMediaOrigin", () => {
+  it("requires the exact HTTPS origin", () => {
+    expect(isDivineMediaOrigin("https://media.divine.video/blob")).toBe(true);
+    expect(isDivineMediaOrigin("http://media.divine.video/blob")).toBe(false);
+    expect(isDivineMediaOrigin("https://media.divine.video.evil.example/blob")).toBe(false);
+  });
+});

--- a/src/lib/exit/mediaDownloader.ts
+++ b/src/lib/exit/mediaDownloader.ts
@@ -1,0 +1,134 @@
+// ABOUTME: Downloads archive media sequentially and verifies content-addressed bytes
+// ABOUTME: Tries alternate sources for one hash and never leaks viewer auth off Divine media
+
+import type { NostrSigner } from "@nostrify/nostrify";
+
+import { createMediaViewerAuthHeader } from "@/lib/mediaViewerAuth";
+import type { MediaReference } from "./archive";
+
+export type MediaVerification = "verified" | "unverified" | "hash-mismatch" | "failed";
+
+export interface MediaDownloadResult {
+  references: MediaReference[];
+  source_url: string;
+  expected_sha256: string | null;
+  computed_sha256: string | null;
+  byte_size: number | null;
+  content_type: string | null;
+  archive_path: string | null;
+  verification: MediaVerification;
+  failure_reason?: string;
+}
+
+export interface MediaProgress {
+  completed: number;
+  total: number;
+  result: MediaDownloadResult;
+}
+
+interface DownloadOptions {
+  references: MediaReference[];
+  signer?: NostrSigner | null;
+  signal?: AbortSignal;
+  fetcher?: typeof fetch;
+  onFile(path: string, bytes: Uint8Array): Promise<void>;
+  onProgress?(progress: MediaProgress): void;
+}
+
+const EXTENSIONS: Record<string, string> = {
+  "video/mp4": "mp4", "video/webm": "webm", "image/jpeg": "jpg", "image/png": "png",
+  "image/webp": "webp", "image/gif": "gif", "application/vnd.apple.mpegurl": "m3u8",
+};
+
+export function isDivineMediaOrigin(url: string): boolean {
+  try {
+    const parsed = new URL(url);
+    return parsed.protocol === "https:" && parsed.hostname === "media.divine.video";
+  } catch {
+    return false;
+  }
+}
+
+function extension(contentType: string | null): string {
+  return EXTENSIONS[contentType?.split(";")[0].trim().toLowerCase() ?? ""] ?? "bin";
+}
+
+function hex(bytes: ArrayBuffer): string {
+  return Array.from(new Uint8Array(bytes), (byte) => byte.toString(16).padStart(2, "0")).join("");
+}
+
+async function fetchCandidate(url: string, expectedHash: string | null, options: Pick<DownloadOptions, "fetcher" | "signer" | "signal">) {
+  const fetcher = options.fetcher ?? fetch;
+  const request = async (authorization?: string | null) => fetcher(url, {
+    method: "GET", signal: options.signal, redirect: "error",
+    headers: authorization ? { Authorization: authorization } : undefined,
+  });
+  let response = await request();
+  if ((response.status === 401 || response.status === 403) && isDivineMediaOrigin(url)) {
+    const auth = await createMediaViewerAuthHeader({ signer: options.signer, url, sha256: expectedHash ?? undefined });
+    if (auth) response = await request(auth);
+  }
+  if (!response.ok) throw new Error(`HTTP ${response.status}`);
+  if (!isDivineMediaOrigin(response.url || url) && isDivineMediaOrigin(url)) throw new Error("Divine media redirected to an untrusted origin");
+  const bytes = new Uint8Array(await response.arrayBuffer());
+  const advertisedSize = response.headers.get("content-length");
+  if (advertisedSize && Number(advertisedSize) !== bytes.length) throw new Error("Response byte count did not match Content-Length");
+  return { bytes, contentType: response.headers.get("content-type"), finalUrl: response.url || url };
+}
+
+function groups(references: MediaReference[]): MediaReference[][] {
+  const grouped = new Map<string, MediaReference[]>();
+  for (const reference of references) {
+    const key = reference.sha256 ? `hash:${reference.sha256}` : `url:${reference.url}`;
+    grouped.set(key, [...(grouped.get(key) ?? []), reference]);
+  }
+  return [...grouped.values()];
+}
+
+export async function downloadArchiveMedia(options: DownloadOptions): Promise<MediaDownloadResult[]> {
+  const batches = groups(options.references);
+  const results: MediaDownloadResult[] = [];
+  for (const references of batches) {
+    const expectedHash = references[0].sha256;
+    const candidates = [...new Set(references.map((reference) => reference.url))];
+    let result: MediaDownloadResult | null = null;
+    let mismatch: { result: MediaDownloadResult; bytes: Uint8Array } | null = null;
+    const failures: string[] = [];
+    for (const url of candidates) {
+      if (options.signal?.aborted) { failures.push("Download cancelled"); break; }
+      try {
+        const response = await fetchCandidate(url, expectedHash, options);
+        const computedHash = hex(await crypto.subtle.digest("SHA-256", response.bytes));
+        const status: MediaVerification = expectedHash ? (expectedHash === computedHash ? "verified" : "hash-mismatch") : "unverified";
+        const folder = status === "hash-mismatch" ? "media/mismatched" : status === "unverified" ? "media/unverified" : "media";
+        const archivePath = `${folder}/${status === "hash-mismatch" ? expectedHash : computedHash}.${extension(response.contentType)}`;
+        if (status === "hash-mismatch" && candidates.length > 1) {
+          failures.push(`${url}: hash mismatch`);
+          mismatch = { bytes: response.bytes, result: { references, source_url: response.finalUrl,
+            expected_sha256: expectedHash, computed_sha256: computedHash, byte_size: response.bytes.length,
+            content_type: response.contentType, archive_path: archivePath, verification: status } };
+          continue;
+        }
+        await options.onFile(archivePath, response.bytes);
+        result = { references, source_url: response.finalUrl, expected_sha256: expectedHash, computed_sha256: computedHash,
+          byte_size: response.bytes.length, content_type: response.contentType, archive_path: archivePath, verification: status };
+        break;
+      } catch (error) {
+        failures.push(`${url}: ${error instanceof Error ? error.message : "download failed"}`);
+      }
+    }
+    if (!result && mismatch) {
+      try {
+        await options.onFile(mismatch.result.archive_path!, mismatch.bytes);
+        result = mismatch.result;
+      } catch (error) {
+        failures.push(`quarantine write: ${error instanceof Error ? error.message : "failed"}`);
+      }
+    }
+    result ??= { references, source_url: candidates[0], expected_sha256: expectedHash, computed_sha256: null,
+      byte_size: null, content_type: null, archive_path: null, verification: "failed", failure_reason: failures.join("; ") };
+    results.push(result);
+    options.onProgress?.({ completed: results.length, total: batches.length, result });
+  }
+  return results;
+}

--- a/src/lib/exit/zip.test.ts
+++ b/src/lib/exit/zip.test.ts
@@ -61,6 +61,16 @@ describe("createZip", () => {
     expect(unzipStored(bytes)["first"]).toEqual(new Uint8Array(9));
   });
 
+  it("marks entry names as UTF-8 so non-ASCII paths survive extraction", async () => {
+    const bytes = await createZipBytes({ "média/✓.txt": "hi\n" });
+    // General-purpose bit 11 lives at offset 6 of the local header and offset 8
+    // of the central directory header; without it readers fall back to CP437.
+    expect(bytes[6] | (bytes[7] << 8)).toBe(0x0800);
+    const central = bytes.findIndex((_, offset) => readUint32(bytes, offset) === 0x02014b50);
+    expect(bytes[central + 8] | (bytes[central + 9] << 8)).toBe(0x0800);
+    expect(Object.keys(unzipStored(bytes))).toEqual(["média/✓.txt"]);
+  });
+
   it("aborts the underlying sink after a failed export", async () => {
     const abort = vi.fn(async () => undefined);
     const writer = createZipWriter({ write: async () => undefined, abort });

--- a/src/lib/exit/zip.test.ts
+++ b/src/lib/exit/zip.test.ts
@@ -1,60 +1,71 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
-import { createZip, createZipBytes } from "./zip";
+import { createZip, createZipBytes, createZipWriter } from "./zip";
 
 function readUint32(bytes: Uint8Array, offset: number): number {
-  return bytes[offset] | (bytes[offset + 1] << 8) | (bytes[offset + 2] << 16) | (bytes[offset + 3] << 24);
+  return (bytes[offset] | (bytes[offset + 1] << 8) | (bytes[offset + 2] << 16) | (bytes[offset + 3] << 24)) >>> 0;
 }
 
-function readUint16(bytes: Uint8Array, offset: number): number {
-  return bytes[offset] | (bytes[offset + 1] << 8);
-}
-
-function unzipStored(bytes: Uint8Array): Record<string, string> {
-  const files: Record<string, string> = {};
+function unzipStored(bytes: Uint8Array): Record<string, Uint8Array> {
+  const files: Record<string, Uint8Array> = {};
   let offset = 0;
-
   while (offset < bytes.length && readUint32(bytes, offset) === 0x04034b50) {
-    const compression = readUint16(bytes, offset + 8);
-    const size = readUint32(bytes, offset + 18);
-    const nameLength = readUint16(bytes, offset + 26);
-    const extraLength = readUint16(bytes, offset + 28);
+    const nameLength = bytes[offset + 26] | (bytes[offset + 27] << 8);
+    const extraLength = bytes[offset + 28] | (bytes[offset + 29] << 8);
+    const size32 = readUint32(bytes, offset + 18);
     const nameStart = offset + 30;
     const name = new TextDecoder().decode(bytes.slice(nameStart, nameStart + nameLength));
-    const dataStart = nameStart + nameLength + extraLength;
-    const data = bytes.slice(dataStart, dataStart + size);
-
-    if (compression !== 0) {
-      throw new Error(`expected stored compression for ${name}`);
-    }
-
-    files[name] = new TextDecoder().decode(data);
+    const extraStart = nameStart + nameLength;
+    const size = size32 === 0xffffffff
+      ? Number(bytes.slice(extraStart + 4, extraStart + 12).reduceRight((total, byte) => total * 256 + byte, 0))
+      : size32;
+    const dataStart = extraStart + extraLength;
+    files[name] = bytes.slice(dataStart, dataStart + size);
     offset = dataStart + size;
   }
-
   return files;
 }
 
 describe("createZip", () => {
-  it("creates a zip blob whose stored files round-trip", async () => {
-    const files = {
-      "events.json": "[]\n",
-      "manifest.json": "{}\n",
-      "media.json": "[]\n"
-    };
-    const zipBytes = createZipBytes(files);
-    const zip = createZip(files);
-
+  it("round-trips text and binary entries", async () => {
+    const files = { "events.json": "[]\n", "media/blob.bin": new Uint8Array([0, 1, 255]) };
+    const bytes = await createZipBytes(files);
+    const zip = await createZip(files);
     expect(zip.type).toBe("application/zip");
-    expect(zip.size).toBe(zipBytes.byteLength);
-    expect(unzipStored(zipBytes)).toEqual(files);
+    expect(zip.size).toBe(bytes.length);
+    expect(new TextDecoder().decode(unzipStored(bytes)["events.json"])).toBe("[]\n");
+    expect(unzipStored(bytes)["media/blob.bin"]).toEqual(new Uint8Array([0, 1, 255]));
   });
 
-  it("fails loudly when the archive has more entries than ZIP32 can represent", () => {
-    const files = Object.fromEntries(
-      Array.from({ length: 0x10000 }, (_, index) => [`file-${index}.json`, "{}\n"])
-    );
+  it("writes entries to the sink before close", async () => {
+    const write = vi.fn(async () => undefined);
+    const writer = createZipWriter({ write });
+    await writer.addFile("one", "body");
+    expect(write).toHaveBeenCalledTimes(2);
+    await writer.close();
+  });
 
-    expect(() => createZipBytes(files)).toThrow("too many files");
+  it("emits Zip64 records for size, offset, directory, and count thresholds", async () => {
+    const chunks: Uint8Array[] = [];
+    const writer = createZipWriter({ write: async (chunk) => { chunks.push(chunk); } }, { zip32Limit: 8n, zip16Limit: 1n });
+    await writer.addFile("first", new Uint8Array(9));
+    await writer.addFile("second", new Uint8Array(1));
+    await writer.close();
+    const bytes = new Uint8Array(chunks.reduce((size, chunk) => size + chunk.length, 0));
+    let offset = 0;
+    for (const chunk of chunks) {
+      bytes.set(chunk, offset);
+      offset += chunk.length;
+    }
+    expect(Array.from({ length: bytes.length - 3 }, (_, offset) => readUint32(bytes, offset))).toContain(0x06064b50);
+    expect(unzipStored(bytes)["first"]).toEqual(new Uint8Array(9));
+  });
+
+  it("aborts the underlying sink after a failed export", async () => {
+    const abort = vi.fn(async () => undefined);
+    const writer = createZipWriter({ write: async () => undefined, abort });
+    await writer.abort(new Error("cancelled"));
+    expect(abort).toHaveBeenCalledOnce();
+    await expect(writer.addFile("late", "nope")).rejects.toThrow("already closed");
   });
 });

--- a/src/lib/exit/zip.ts
+++ b/src/lib/exit/zip.ts
@@ -1,161 +1,179 @@
-// ABOUTME: Minimal store-only ZIP writer for the account archive download
-// ABOUTME: Avoids a compression dependency for the handful of JSON files we emit
+// ABOUTME: Streaming store-only ZIP64 writer for account archives
+// ABOUTME: Writes each entry directly to a sink while retaining only central-directory metadata
 
 const encoder = new TextEncoder();
-const MAX_ZIP32_VALUE = 0xffffffff;
+const ZIP32_MAX = 0xffffffffn;
+const ZIP16_MAX = 0xffffn;
 
-interface CentralDirectoryEntry {
+export interface ZipSink {
+  write(chunk: Uint8Array): Promise<void>;
+  close?(): Promise<void>;
+  abort?(reason?: unknown): Promise<void>;
+}
+
+export type ZipContent = string | Uint8Array;
+
+export interface ZipWriter {
+  addFile(name: string, content: ZipContent): Promise<void>;
+  close(): Promise<void>;
+  abort(reason?: unknown): Promise<void>;
+}
+
+interface Entry {
   name: Uint8Array;
   crc32: number;
-  size: number;
-  offset: number;
+  size: bigint;
+  offset: bigint;
+  zip64Size: boolean;
+  zip64Offset: boolean;
+}
+
+interface ZipWriterOptions {
+  zip32Limit?: bigint;
+  zip16Limit?: bigint;
 }
 
 const CRC_TABLE = (() => {
   const table = new Uint32Array(256);
-
-  for (let i = 0; i < 256; i += 1) {
-    let value = i;
-    for (let bit = 0; bit < 8; bit += 1) {
-      value = value & 1 ? 0xedb88320 ^ (value >>> 1) : value >>> 1;
-    }
-    table[i] = value >>> 0;
+  for (let index = 0; index < 256; index += 1) {
+    let value = index;
+    for (let bit = 0; bit < 8; bit += 1) value = value & 1 ? 0xedb88320 ^ (value >>> 1) : value >>> 1;
+    table[index] = value >>> 0;
   }
-
   return table;
 })();
 
 function crc32(bytes: Uint8Array): number {
   let crc = 0xffffffff;
-
-  for (const byte of bytes) {
-    crc = CRC_TABLE[(crc ^ byte) & 0xff] ^ (crc >>> 8);
-  }
-
+  for (const byte of bytes) crc = CRC_TABLE[(crc ^ byte) & 0xff] ^ (crc >>> 8);
   return (crc ^ 0xffffffff) >>> 0;
 }
 
-function uint16(value: number): Uint8Array {
-  return new Uint8Array([value & 0xff, (value >>> 8) & 0xff]);
+function uint16(value: number | bigint): Uint8Array {
+  const number = Number(value);
+  return new Uint8Array([number & 0xff, (number >>> 8) & 0xff]);
 }
 
-function uint32(value: number): Uint8Array {
-  if (!Number.isSafeInteger(value) || value < 0 || value > MAX_ZIP32_VALUE) {
-    throw new RangeError("This archive is too large for this ZIP writer. Try a smaller export.");
-  }
+function uint32(value: number | bigint): Uint8Array {
+  const number = Number(BigInt(value) & ZIP32_MAX);
+  return new Uint8Array([number & 0xff, (number >>> 8) & 0xff, (number >>> 16) & 0xff, (number >>> 24) & 0xff]);
+}
 
-  return new Uint8Array([
-    value & 0xff,
-    (value >>> 8) & 0xff,
-    (value >>> 16) & 0xff,
-    (value >>> 24) & 0xff
-  ]);
+function uint64(value: bigint): Uint8Array {
+  const bytes = new Uint8Array(8);
+  let remaining = value;
+  for (let index = 0; index < bytes.length; index += 1) {
+    bytes[index] = Number(remaining & 0xffn);
+    remaining >>= 8n;
+  }
+  return bytes;
 }
 
 function concat(parts: Uint8Array[]): Uint8Array {
-  const total = parts.reduce((sum, part) => sum + part.length, 0);
-
-  if (total > MAX_ZIP32_VALUE) {
-    throw new RangeError("This archive is too large for this ZIP writer. Try a smaller export.");
-  }
-
-  const output = new Uint8Array(total);
+  const result = new Uint8Array(parts.reduce((total, part) => total + part.length, 0));
   let offset = 0;
-
   for (const part of parts) {
-    output.set(part, offset);
+    result.set(part, offset);
     offset += part.length;
   }
-
-  return output;
+  return result;
 }
 
-export function createZipBytes(files: Record<string, string>): Uint8Array {
-  const localParts: Uint8Array[] = [];
-  const centralParts: Uint8Array[] = [];
-  const entries: CentralDirectoryEntry[] = [];
-  let offset = 0;
-
-  for (const [filename, content] of Object.entries(files)) {
-    if (entries.length >= 0xffff) {
-      throw new RangeError("This archive has too many files for this ZIP writer.");
-    }
-
-    const name = encoder.encode(filename);
-    const body = encoder.encode(content);
-    const checksum = crc32(body);
-    const localHeader = concat([
-      uint32(0x04034b50),
-      uint16(20),
-      uint16(0),
-      uint16(0),
-      uint16(0),
-      uint16(0),
-      uint32(checksum),
-      uint32(body.length),
-      uint32(body.length),
-      uint16(name.length),
-      uint16(0),
-      name
-    ]);
-
-    localParts.push(localHeader, body);
-    entries.push({ name, crc32: checksum, size: body.length, offset });
-    offset += localHeader.length + body.length;
-
-    if (offset > MAX_ZIP32_VALUE) {
-      throw new RangeError("This archive is too large for this ZIP writer. Try a smaller export.");
-    }
-  }
-
-  const centralDirectoryOffset = offset;
-
-  for (const entry of entries) {
-    centralParts.push(
-      concat([
-        uint32(0x02014b50),
-        uint16(20),
-        uint16(20),
-        uint16(0),
-        uint16(0),
-        uint16(0),
-        uint16(0),
-        uint32(entry.crc32),
-        uint32(entry.size),
-        uint32(entry.size),
-        uint16(entry.name.length),
-        uint16(0),
-        uint16(0),
-        uint16(0),
-        uint16(0),
-        uint32(0),
-        uint32(entry.offset),
-        entry.name
-      ])
-    );
-  }
-
-  const centralDirectory = concat(centralParts);
-  const endOfCentralDirectory = concat([
-    uint32(0x06054b50),
-    uint16(0),
-    uint16(0),
-    uint16(entries.length),
-    uint16(entries.length),
-    uint32(centralDirectory.length),
-    uint32(centralDirectoryOffset),
-    uint16(0)
-  ]);
-
-  return concat([...localParts, centralDirectory, endOfCentralDirectory]);
+function zip64Extra(values: bigint[]): Uint8Array {
+  const body = concat(values.map(uint64));
+  return concat([uint16(0x0001), uint16(body.length), body]);
 }
 
-export function createZip(files: Record<string, string>): Blob {
-  const bytes = createZipBytes(files);
-  const copy = new Uint8Array(bytes.byteLength);
-  copy.set(bytes);
+export function createZipWriter(sink: ZipSink, options: ZipWriterOptions = {}): ZipWriter {
+  const zip32Limit = options.zip32Limit ?? ZIP32_MAX;
+  const zip16Limit = options.zip16Limit ?? ZIP16_MAX;
+  const entries: Entry[] = [];
+  let offset = 0n;
+  let finished = false;
 
-  return new Blob([copy.buffer], {
-    type: "application/zip"
-  });
+  async function write(chunk: Uint8Array) {
+    await sink.write(chunk);
+    offset += BigInt(chunk.length);
+  }
+
+  return {
+    async addFile(name, content) {
+      if (finished) throw new Error("This ZIP writer is already closed.");
+      const encodedName = encoder.encode(name);
+      if (encodedName.length > 0xffff) throw new RangeError("This archive entry name is too long.");
+      const body = typeof content === "string" ? encoder.encode(content) : content;
+      const size = BigInt(body.length);
+      const entryOffset = offset;
+      const zip64Size = size > zip32Limit;
+      const zip64Offset = entryOffset > zip32Limit;
+      const checksum = crc32(body);
+      const extra = zip64Size ? zip64Extra([size, size]) : new Uint8Array();
+      entries.push({ name: encodedName, crc32: checksum, size, offset: entryOffset, zip64Size, zip64Offset });
+      await write(concat([
+        uint32(0x04034b50), uint16(zip64Size ? 45 : 20), uint16(0), uint16(0), uint16(0), uint16(0),
+        uint32(checksum), uint32(zip64Size ? ZIP32_MAX : size), uint32(zip64Size ? ZIP32_MAX : size),
+        uint16(encodedName.length), uint16(extra.length), encodedName, extra,
+      ]));
+      await write(body);
+    },
+
+    async close() {
+      if (finished) return;
+      finished = true;
+      const centralOffset = offset;
+      let usesZip64 = false;
+      for (const entry of entries) {
+        const values: bigint[] = [];
+        if (entry.zip64Size) values.push(entry.size, entry.size);
+        if (entry.zip64Offset) values.push(entry.offset);
+        const extra = values.length ? zip64Extra(values) : new Uint8Array();
+        usesZip64 ||= values.length > 0;
+        await write(concat([
+          uint32(0x02014b50), uint16(45), uint16(values.length ? 45 : 20), uint16(0), uint16(0), uint16(0), uint16(0),
+          uint32(entry.crc32), uint32(entry.zip64Size ? ZIP32_MAX : entry.size), uint32(entry.zip64Size ? ZIP32_MAX : entry.size),
+          uint16(entry.name.length), uint16(extra.length), uint16(0), uint16(0), uint16(0), uint32(0),
+          uint32(entry.zip64Offset ? ZIP32_MAX : entry.offset), entry.name, extra,
+        ]));
+      }
+      const centralSize = offset - centralOffset;
+      const count = BigInt(entries.length);
+      usesZip64 ||= centralOffset > zip32Limit || centralSize > zip32Limit || count > zip16Limit;
+      if (usesZip64) {
+        const zip64Offset = offset;
+        await write(concat([
+          uint32(0x06064b50), uint64(44n), uint16(45), uint16(45), uint32(0), uint32(0),
+          uint64(count), uint64(count), uint64(centralSize), uint64(centralOffset),
+        ]));
+        await write(concat([uint32(0x07064b50), uint32(0), uint64(zip64Offset), uint32(1)]));
+      }
+      await write(concat([
+        uint32(0x06054b50), uint16(0), uint16(0),
+        uint16(count > zip16Limit ? ZIP16_MAX : count), uint16(count > zip16Limit ? ZIP16_MAX : count),
+        uint32(centralSize > zip32Limit ? ZIP32_MAX : centralSize), uint32(centralOffset > zip32Limit ? ZIP32_MAX : centralOffset), uint16(0),
+      ]));
+      await sink.close?.();
+    },
+
+    async abort(reason) {
+      if (finished) return;
+      finished = true;
+      await sink.abort?.(reason);
+    },
+  };
+}
+
+export async function createZipBytes(files: Record<string, ZipContent>): Promise<Uint8Array> {
+  const parts: Uint8Array[] = [];
+  const writer = createZipWriter({ write: async (chunk) => { parts.push(chunk); } });
+  for (const [name, content] of Object.entries(files)) await writer.addFile(name, content);
+  await writer.close();
+  return concat(parts);
+}
+
+export async function createZip(files: Record<string, ZipContent>): Promise<Blob> {
+  const parts: BlobPart[] = [];
+  const writer = createZipWriter({ write: async (chunk) => { parts.push(chunk.slice().buffer); } });
+  for (const [name, content] of Object.entries(files)) await writer.addFile(name, content);
+  await writer.close();
+  return new Blob(parts, { type: "application/zip" });
 }

--- a/src/lib/exit/zip.ts
+++ b/src/lib/exit/zip.ts
@@ -3,6 +3,8 @@
 
 const encoder = new TextEncoder();
 const ZIP32_MAX = 0xffffffffn;
+// General-purpose bit 11 (EFS): entry names are UTF-8, not CP437.
+const UTF8_NAME_FLAG = 0x0800;
 const ZIP16_MAX = 0xffffn;
 
 export interface ZipSink {
@@ -110,7 +112,7 @@ export function createZipWriter(sink: ZipSink, options: ZipWriterOptions = {}): 
       const extra = zip64Size ? zip64Extra([size, size]) : new Uint8Array();
       entries.push({ name: encodedName, crc32: checksum, size, offset: entryOffset, zip64Size, zip64Offset });
       await write(concat([
-        uint32(0x04034b50), uint16(zip64Size ? 45 : 20), uint16(0), uint16(0), uint16(0), uint16(0),
+        uint32(0x04034b50), uint16(zip64Size ? 45 : 20), uint16(UTF8_NAME_FLAG), uint16(0), uint16(0), uint16(0),
         uint32(checksum), uint32(zip64Size ? ZIP32_MAX : size), uint32(zip64Size ? ZIP32_MAX : size),
         uint16(encodedName.length), uint16(extra.length), encodedName, extra,
       ]));
@@ -129,7 +131,7 @@ export function createZipWriter(sink: ZipSink, options: ZipWriterOptions = {}): 
         const extra = values.length ? zip64Extra(values) : new Uint8Array();
         usesZip64 ||= values.length > 0;
         await write(concat([
-          uint32(0x02014b50), uint16(45), uint16(values.length ? 45 : 20), uint16(0), uint16(0), uint16(0), uint16(0),
+          uint32(0x02014b50), uint16(45), uint16(values.length ? 45 : 20), uint16(UTF8_NAME_FLAG), uint16(0), uint16(0), uint16(0),
           uint32(entry.crc32), uint32(entry.zip64Size ? ZIP32_MAX : entry.size), uint32(entry.zip64Size ? ZIP32_MAX : entry.size),
           uint16(entry.name.length), uint16(extra.length), uint16(0), uint16(0), uint16(0), uint32(0),
           uint32(entry.zip64Offset ? ZIP32_MAX : entry.offset), entry.name, extra,

--- a/src/pages/ExitStartPage.test.tsx
+++ b/src/pages/ExitStartPage.test.tsx
@@ -112,6 +112,37 @@ describe("ExitStartPage", () => {
     ).toBeInTheDocument();
   });
 
+  it("explains the media limitation when direct file saving is unavailable", async () => {
+    mockUseCurrentUser.mockReturnValue(signedIn());
+    vi.stubGlobal("fetch", createFixtureFetch("one-page"));
+    render(<TestApp><ExitStartPage /></TestApp>);
+    await userEvent.click(screen.getByRole("button", { name: /Create my archive/ }));
+    await waitFor(() => expect(screen.getByText(/Your archive is ready/)).toBeInTheDocument());
+    expect(screen.getByRole("button", { name: /Save media archive/ })).toBeDisabled();
+    expect(screen.getByText(/cannot safely assemble one large media archive/)).toBeInTheDocument();
+  });
+
+  it("streams media to a selected file and reports a quarantined mismatch", async () => {
+    mockUseCurrentUser.mockReturnValue(signedIn());
+    vi.stubGlobal("fetch", createFixtureFetch("one-page"));
+    const write = vi.fn(async () => undefined);
+    const close = vi.fn(async () => undefined);
+    const abort = vi.fn(async () => undefined);
+    vi.stubGlobal("showSaveFilePicker", vi.fn(async () => ({
+      createWritable: async () => ({ write, close, abort }),
+    })));
+    render(<TestApp><ExitStartPage /></TestApp>);
+    await userEvent.click(screen.getByRole("button", { name: /Create my archive/ }));
+    await waitFor(() => expect(screen.getByText(/Your archive is ready/)).toBeInTheDocument());
+    vi.stubGlobal("fetch", vi.fn(async () => new Response("hello", { headers: { "content-type": "video/mp4" } })));
+    await userEvent.click(screen.getByRole("button", { name: /Save media archive/ }));
+    await waitFor(() => expect(screen.getByText("Your media archive is saved.")).toBeInTheDocument());
+    expect(screen.getByText(/Saved separately because the hash did not match/)).toBeInTheDocument();
+    expect(write).toHaveBeenCalled();
+    expect(close).toHaveBeenCalledOnce();
+    expect(abort).not.toHaveBeenCalled();
+  });
+
   it("uses the active Funnelcake environment", async () => {
     mockUseCurrentUser.mockReturnValue(signedIn());
     localStorage.setItem("divine_dev_funnelcake_api_mode", "staging");

--- a/src/pages/ExitStartPage.tsx
+++ b/src/pages/ExitStartPage.tsx
@@ -16,6 +16,7 @@ import { Link } from "react-router-dom";
 
 import { LocalNsecBanner } from "@/components/auth/LocalNsecBanner";
 import { KeySafetyNotice } from "@/components/exit/KeySafetyNotice";
+import { MediaProgressList } from "@/components/exit/MediaProgressList";
 import { LoginArea } from "@/components/auth/LoginArea";
 import { MarketingLayout } from "@/components/MarketingLayout";
 import { SectionHero } from "@/components/static-pages";
@@ -23,6 +24,7 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { getFunnelcakeBaseUrl } from "@/config/api";
 import { useCurrentUser } from "@/hooks/useCurrentUser";
+import { useArchiveMediaExport } from "@/hooks/useArchiveMediaExport";
 import { buildArchiveFiles, serializeArchiveFiles, type ArchiveFiles } from "@/lib/exit/archive";
 import { exportOwnerEvents, OwnerExportError, type ExportProgress } from "@/lib/exit/ownerExportClient";
 import { createZip } from "@/lib/exit/zip";
@@ -46,12 +48,12 @@ function downloadErrorMessage(error: unknown): string {
   return "The archive could not be downloaded. Try creating it again.";
 }
 
-function downloadArchive(files: ArchiveFiles): void {
+async function downloadArchive(files: ArchiveFiles): Promise<void> {
   if (typeof URL.createObjectURL !== "function") {
     throw new Error("This browser cannot create the archive download. Try another browser.");
   }
 
-  const zip = createZip(serializeArchiveFiles(files));
+  const zip = await createZip(serializeArchiveFiles(files));
   const url = URL.createObjectURL(zip);
   const link = document.createElement("a");
 
@@ -71,7 +73,7 @@ export function ExitStartPage() {
       {
         name: "description",
         content:
-          "Download a portable archive of your Divine posts, video records, and media references.",
+          "Download a portable archive of your Divine posts, video records, and media files.",
       },
     ],
   });
@@ -91,6 +93,7 @@ export function ExitStartPage() {
   const activeExport = useRef<AbortController | null>(null);
   const currentPubkey = useRef(user?.pubkey);
   currentPubkey.current = user?.pubkey;
+  const mediaExport = useArchiveMediaExport({ files: archiveFiles, signer });
 
   useEffect(() => {
     activeExport.current?.abort();
@@ -167,13 +170,13 @@ export function ExitStartPage() {
     }
   }
 
-  function handleDownloadArchive() {
+  async function handleDownloadArchive() {
     if (!archiveFiles) {
       return;
     }
 
     try {
-      downloadArchive(archiveFiles);
+      await downloadArchive(archiveFiles);
     } catch (error) {
       setFailure(downloadErrorMessage(error));
       setState("failed");
@@ -258,13 +261,42 @@ export function ExitStartPage() {
                 <Button
                   type="button"
                   variant="outline"
-                  onClick={handleDownloadArchive}
+                  onClick={() => void handleDownloadArchive()}
                   disabled={!archiveFiles}
                 >
                   <DownloadSimple className="h-4 w-4" aria-hidden="true" />
                   Download archive (.zip)
                 </Button>
+                <Button
+                  type="button"
+                  variant="sticker"
+                  onClick={() => void mediaExport.start()}
+                  disabled={!archiveFiles || !mediaExport.supported || mediaExport.state === "running"}
+                >
+                  {mediaExport.state === "running" ? (
+                    <ArrowClockwise className="h-4 w-4 animate-spin" aria-hidden="true" />
+                  ) : (
+                    <DownloadSimple className="h-4 w-4" aria-hidden="true" />
+                  )}
+                  {mediaExport.state === "running" ? "Saving media" : "Save media archive"}
+                </Button>
               </div>
+
+              {!mediaExport.supported && archiveFiles && (
+                <p className="text-sm leading-relaxed text-muted-foreground">
+                  This browser can download the JSON archive, but it cannot safely assemble one large media archive. Use a browser that supports saving directly to a file for the media copy.
+                </p>
+              )}
+
+              <MediaProgressList progress={mediaExport.progress} />
+
+              {mediaExport.state === "complete" && (
+                <p className="text-base font-semibold text-foreground" role="status">Your media archive is saved.</p>
+              )}
+
+              {mediaExport.state === "failed" && mediaExport.failure && (
+                <p className="text-base text-destructive" role="alert">{mediaExport.failure}</p>
+              )}
 
               {!signer && (
                 <Card variant="brand" accent="pink">


### PR DESCRIPTION
## Summary

- Account exports can now save the referenced video and image bytes into one streamed archive without holding the full ZIP in browser memory.
- Every downloaded blob is checked against its advertised SHA-256 hash. Valid files are certified, unknown hashes are recorded, mismatches are quarantined, and unavailable files remain non-fatal.
- Archive metadata preserves every source-event relationship and includes a media summary plus an offline `sha256sum -c` checksum file.

## Motivation

The existing export stopped at media URLs, so it was not an offline copy and could not prove that downloaded media matched the content-addressed source. Adding media to the old in-memory ZIP path would also duplicate the entire archive in memory and fail for large accounts.

This change writes a store-only Zip64 archive directly to a user-selected file, downloads one unique blob at a time, tries alternate URLs for the same expected hash, and only retries viewer authorization for the exact Divine media origin. Browsers without direct file-saving support retain the existing JSON archive and get a clear explanation instead of an unsafe unbounded-memory fallback.

This does not transform media bytes, change raw `events.json` contents, add destination mirroring, or add resumable directory exports.

## Related Issue

- Closes #593

## Testing

- [x] `npm run test` — typecheck, lint, 2,306 unit tests in 284 files, and production build
- [x] `npm run test:visual` — 25 Playwright visual and WCAG checks
- [x] Focused coverage for Zip64 boundaries, binary entries, verified/unverified/mismatched media, alternate mirrors, auth isolation, redirects, truncated responses, partial failures, picker support, and progress UI

## Visuals

- [ ] UI change with screenshots/video attached
- [ ] No visual change
- [x] Visuals and text avoid sensitive external brand or partner names unless explicitly approved

The signed-in export state has a new “Save media archive” action and compact per-file progress status. Automated visual and accessibility checks pass; no baseline changed.
