### PR TITLE
feat(destination): let users copy exported media to another server

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -176,6 +176,13 @@ time, verifies advertised SHA-256 hashes, and records partial failures without
 changing signed events. Viewer authorization is retried only for the exact
 `https://media.divine.video` origin; third-party media requests remain bare.
 
+After an archive is built, the same page can mirror its unique source blobs to a
+custom HTTPS Blossom destination with BUD-04 `PUT /mirror`. The first eligible
+copy is the destination capability canary, kind-24242 upload authorization is
+scoped to one advertised hash when available, and later file failures do not
+stop the remaining copies. Generated HLS manifests are skipped, while descriptor
+hash and `HEAD` readback results remain distinct from independent byte hashing.
+
 ## Linting
 
 ESLint 9 with TypeScript, React Hooks, HTML, and three custom rules in

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -181,9 +181,10 @@ custom HTTPS Blossom destination with BUD-04 `PUT /mirror`. Destination URLs
 normalize to the domain root because BUD-01 serves every Blossom endpoint there.
 The first eligible
 copy is the destination capability canary, kind-24242 upload authorization is
-scoped to one advertised hash when available, and later file failures do not
-stop the remaining copies. Generated HLS manifests are skipped, while descriptor
-hash and `HEAD` readback results remain distinct from independent byte hashing.
+scoped to one advertised hash, and later file failures do not stop the remaining
+copies. Sources without an advertised hash and generated HLS manifests are
+skipped. Descriptor hashes and redirect-aware `HEAD` readback results remain
+distinct from independent byte hashing.
 
 ## Linting
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -177,7 +177,9 @@ changing signed events. Viewer authorization is retried only for the exact
 `https://media.divine.video` origin; third-party media requests remain bare.
 
 After an archive is built, the same page can mirror its unique source blobs to a
-custom HTTPS Blossom destination with BUD-04 `PUT /mirror`. The first eligible
+custom HTTPS Blossom destination with BUD-04 `PUT /mirror`. Destination URLs
+normalize to the domain root because BUD-01 serves every Blossom endpoint there.
+The first eligible
 copy is the destination capability canary, kind-24242 upload authorization is
 scoped to one advertised hash when available, and later file failures do not
 stop the remaining copies. Generated HLS manifests are skipped, while descriptor

--- a/src/components/exit/DestinationForm.tsx
+++ b/src/components/exit/DestinationForm.tsx
@@ -24,7 +24,7 @@ function progressLabel(progress: MirrorProgress): string {
     case "descriptor-verified": return "Mirrored and confirmed by the destination";
     case "unverified": return "Mirrored without confirmed readback";
     case "hash-mismatch": return "Destination reported a different hash";
-    case "skipped": return "Skipped generated streaming manifest";
+    case "skipped": return progress.result.reason ?? "Skipped this source";
     default: return "Could not mirror";
   }
 }

--- a/src/components/exit/DestinationForm.tsx
+++ b/src/components/exit/DestinationForm.tsx
@@ -1,0 +1,96 @@
+// ABOUTME: Collects a custom Blossom destination and reports mirror progress
+// ABOUTME: Keeps destination validation errors next to the field that needs attention
+
+import { ArrowClockwise, CheckCircle, Copy, WarningCircle } from "@phosphor-icons/react";
+import { useState } from "react";
+
+import { TransferProgress } from "@/components/exit/TransferProgress";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { DestinationError, normalizeDestinationUrl } from "@/lib/exit/destination";
+import type { MirrorProgress, MirrorSummary } from "@/lib/exit/mirrorClient";
+
+interface DestinationFormProps {
+  state: "idle" | "running" | "complete" | "failed";
+  progress: MirrorProgress | null;
+  summary: MirrorSummary | null;
+  failure: string | null;
+  onStart(destination: string): Promise<void>;
+}
+
+function progressLabel(progress: MirrorProgress): string {
+  switch (progress.result.verification) {
+    case "descriptor-verified": return "Mirrored and confirmed by the destination";
+    case "unverified": return "Mirrored without confirmed readback";
+    case "hash-mismatch": return "Destination reported a different hash";
+    case "skipped": return "Skipped generated streaming manifest";
+    default: return "Could not mirror";
+  }
+}
+
+export function DestinationForm({ state, progress, summary, failure, onStart }: DestinationFormProps) {
+  const [destination, setDestination] = useState("");
+  const [validationFailure, setValidationFailure] = useState<string | null>(null);
+
+  function submit() {
+    try {
+      const normalized = normalizeDestinationUrl(destination);
+      setDestination(normalized);
+      setValidationFailure(null);
+      void onStart(normalized);
+    } catch (error) {
+      setValidationFailure(error instanceof DestinationError ? error.message : "Enter a valid Blossom server URL.");
+    }
+  }
+
+  return (
+    <Card variant="brand" accent="violet">
+      <CardHeader>
+        <CardTitle>Copy media to another server</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-5">
+        <p className="text-base leading-relaxed text-muted-foreground">
+          Enter a Blossom server you trust. The server copies each original file directly from its current URL—your browser never re-uploads the media.
+        </p>
+        <div className="space-y-2">
+          <label htmlFor="blossom-destination" className="text-sm font-semibold text-foreground">Blossom server URL</label>
+          <Input
+            id="blossom-destination"
+            type="url"
+            inputMode="url"
+            placeholder="https://blossom.example"
+            value={destination}
+            disabled={state === "running"}
+            aria-describedby={validationFailure ? "blossom-destination-error" : undefined}
+            aria-invalid={Boolean(validationFailure)}
+            onChange={(event) => setDestination(event.target.value)}
+          />
+          {validationFailure && <p id="blossom-destination-error" className="text-sm text-destructive" role="alert">{validationFailure}</p>}
+        </div>
+        <Button type="button" variant="sticker" disabled={state === "running" || !destination.trim()} onClick={submit}>
+          {state === "running" ? <ArrowClockwise className="h-4 w-4 animate-spin" aria-hidden="true" /> : <Copy className="h-4 w-4" aria-hidden="true" />}
+          {state === "running" ? "Copying media" : "Copy my media"}
+        </Button>
+        {progress && <TransferProgress completed={progress.completed} total={progress.total} label={progressLabel(progress)} url={progress.result.source_url} />}
+        {state === "failed" && failure && (
+          <div className="flex items-start gap-3" role="alert">
+            <WarningCircle weight="fill" className="mt-1 h-5 w-5 flex-shrink-0 text-destructive" />
+            <p className="text-base leading-relaxed text-muted-foreground">{failure}</p>
+          </div>
+        )}
+        {state === "complete" && summary && (
+          <div className="flex items-start gap-3" role="status">
+            <CheckCircle weight="fill" className="mt-1 h-5 w-5 flex-shrink-0 text-brand-dark-green dark:text-brand-green" />
+            <div>
+              <p className="font-semibold text-foreground">Destination copy finished.</p>
+              <p className="text-base leading-relaxed text-muted-foreground">
+                {summary.mirrored} mirrored, {summary.failed} failed, {summary.skipped} skipped, and {summary.unverified} unverified.
+              </p>
+            </div>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/exit/MediaProgressList.tsx
+++ b/src/components/exit/MediaProgressList.tsx
@@ -2,6 +2,7 @@
 // ABOUTME: Uses plain status text so partial and mismatched results remain unambiguous
 
 import type { MediaProgress } from "@/lib/exit/mediaDownloader";
+import { TransferProgress } from "@/components/exit/TransferProgress";
 
 export function MediaProgressList({ progress }: { progress: MediaProgress | null }) {
   if (!progress) return null;
@@ -12,10 +13,5 @@ export function MediaProgressList({ progress }: { progress: MediaProgress | null
       : progress.result.verification === "hash-mismatch"
         ? "Saved separately because the hash did not match"
         : "Could not download";
-  return (
-    <div className="rounded-lg border border-brand-dark-green/15 p-4 dark:border-brand-green/25" aria-live="polite">
-      <p className="font-semibold text-foreground">Media {progress.completed} of {progress.total}</p>
-      <p className="text-sm text-muted-foreground">{label}: <span className="break-all">{progress.result.source_url}</span></p>
-    </div>
-  );
+  return <TransferProgress completed={progress.completed} total={progress.total} label={label} url={progress.result.source_url} />;
 }

--- a/src/components/exit/TransferProgress.tsx
+++ b/src/components/exit/TransferProgress.tsx
@@ -1,0 +1,16 @@
+// ABOUTME: Presents one item of progress for archive downloads and destination mirrors
+// ABOUTME: Keeps transfer status layout consistent without coupling unrelated result types
+
+export function TransferProgress({ completed, total, label, url }: {
+  completed: number;
+  total: number;
+  label: string;
+  url: string;
+}) {
+  return (
+    <div className="rounded-lg border border-brand-dark-green/15 p-4 dark:border-brand-green/25" aria-live="polite">
+      <p className="font-semibold text-foreground">Media {completed} of {total}</p>
+      <p className="text-sm text-muted-foreground">{label}: <span className="break-all">{url}</span></p>
+    </div>
+  );
+}

--- a/src/hooks/useArchiveMediaExport.ts
+++ b/src/hooks/useArchiveMediaExport.ts
@@ -4,7 +4,7 @@
 import type { NostrSigner } from "@nostrify/nostrify";
 import { useEffect, useRef, useState } from "react";
 
-import { completeArchiveMedia, serializeArchiveFiles, type ArchiveFiles, type MediaReference } from "@/lib/exit/archive";
+import { completeArchiveMedia, serializeArchiveFiles, type ArchiveFiles } from "@/lib/exit/archive";
 import { pickArchiveSink, supportsStreamingArchive } from "@/lib/exit/archiveSink";
 import { downloadArchiveMedia, type MediaProgress } from "@/lib/exit/mediaDownloader";
 import { createZipWriter } from "@/lib/exit/zip";
@@ -49,7 +49,7 @@ export function useArchiveMediaExport(input: { files: ArchiveFiles | null; signe
       const initial = serializeArchiveFiles(input.files);
       await writer.addFile("events.json", initial["events.json"]);
       const results = await downloadArchiveMedia({
-        references: input.files["media.json"] as MediaReference[],
+        references: input.files["media.json"],
         signer: input.signer,
         signal: controller.signal,
         onFile: (path, bytes) => writer.addFile(path, bytes),

--- a/src/hooks/useDestinationMirror.test.ts
+++ b/src/hooks/useDestinationMirror.test.ts
@@ -1,0 +1,48 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { fixturePubkey, makeFixtureEvent, otherFixturePubkey } from "@/lib/exit/__fixtures__/exportFixtures";
+import { FixtureSigner } from "@/lib/exit/__fixtures__/fixtureSigner";
+import { buildArchiveFiles } from "@/lib/exit/archive";
+
+import { useDestinationMirror } from "./useDestinationMirror";
+
+function files(pubkey: string) {
+  return buildArchiveFiles({
+    events: [makeFixtureEvent({ pubkey })],
+    pubkey,
+    sourceEndpoint: "https://api.divine.video",
+    pageCount: 1,
+    failures: [],
+  });
+}
+
+const signer = new FixtureSigner();
+
+describe("useDestinationMirror", () => {
+  afterEach(() => vi.unstubAllGlobals());
+
+  it("aborts active work and clears its state when the account changes", async () => {
+    const fetcher = vi.fn((_input: RequestInfo | URL, init?: RequestInit) => new Promise<Response>((_resolve, reject) => {
+      init?.signal?.addEventListener("abort", () => reject(new DOMException("Mirror cancelled", "AbortError")), { once: true });
+    }));
+    vi.stubGlobal("fetch", fetcher);
+    const { result, rerender } = renderHook(
+      ({ archive }) => useDestinationMirror({ files: archive, signer }),
+      { initialProps: { archive: files(fixturePubkey) } },
+    );
+
+    let startPromise: Promise<void> | undefined;
+    act(() => {
+      startPromise = result.current.start("https://blossom.example");
+    });
+    await waitFor(() => expect(result.current.state).toBe("running"));
+    rerender({ archive: files(otherFixturePubkey) });
+    await waitFor(() => expect(result.current.state).toBe("idle"));
+    await startPromise;
+
+    expect(fetcher.mock.calls[0][1]?.signal?.aborted).toBe(true);
+    expect(result.current.summary).toBeNull();
+    expect(result.current.failure).toBeNull();
+  });
+});

--- a/src/hooks/useDestinationMirror.test.ts
+++ b/src/hooks/useDestinationMirror.test.ts
@@ -22,6 +22,19 @@ const signer = new FixtureSigner();
 describe("useDestinationMirror", () => {
   afterEach(() => vi.unstubAllGlobals());
 
+  it("reports an unusable destination URL instead of rejecting the caller", async () => {
+    const { result } = renderHook(() => useDestinationMirror({ files: files(fixturePubkey), signer }));
+
+    await act(async () => {
+      await result.current.start("https://blossom.example/path");
+    });
+
+    expect(result.current.state).toBe("failed");
+    expect(result.current.failure).toBe(
+      "Blossom servers answer at the domain root. Use https://blossom.example instead.",
+    );
+  });
+
   it("aborts active work and clears its state when the account changes", async () => {
     const fetcher = vi.fn((_input: RequestInfo | URL, init?: RequestInit) => new Promise<Response>((_resolve, reject) => {
       init?.signal?.addEventListener("abort", () => reject(new DOMException("Mirror cancelled", "AbortError")), { once: true });

--- a/src/hooks/useDestinationMirror.ts
+++ b/src/hooks/useDestinationMirror.ts
@@ -34,7 +34,6 @@ export function useDestinationMirror(input: { files: ArchiveFiles | null; signer
 
   async function start(destinationValue: string) {
     if (!input.files || !input.signer) return;
-    const destination = normalizeDestinationUrl(destinationValue);
     const controller = new AbortController();
     activeController.current?.abort();
     activeController.current = controller;
@@ -44,7 +43,7 @@ export function useDestinationMirror(input: { files: ArchiveFiles | null; signer
     setFailure(null);
     try {
       const results = await mirrorArchiveMedia({
-        destination,
+        destination: normalizeDestinationUrl(destinationValue),
         references: input.files["media.json"] as MediaReference[],
         signer: input.signer,
         signal: controller.signal,

--- a/src/hooks/useDestinationMirror.ts
+++ b/src/hooks/useDestinationMirror.ts
@@ -1,0 +1,66 @@
+// ABOUTME: Orchestrates destination media mirroring for the account export page
+// ABOUTME: Resets and aborts mirror work when the exported account changes
+
+import type { NostrSigner } from "@nostrify/nostrify";
+import { useEffect, useRef, useState } from "react";
+
+import type { ArchiveFiles, MediaReference } from "@/lib/exit/archive";
+import { normalizeDestinationUrl } from "@/lib/exit/destination";
+import {
+  mirrorArchiveMedia,
+  summarizeMirrorResults,
+  type MirrorProgress,
+  type MirrorSummary,
+} from "@/lib/exit/mirrorClient";
+
+type DestinationMirrorState = "idle" | "running" | "complete" | "failed";
+
+export function useDestinationMirror(input: { files: ArchiveFiles | null; signer: NostrSigner | null | undefined }) {
+  const [state, setState] = useState<DestinationMirrorState>("idle");
+  const [progress, setProgress] = useState<MirrorProgress | null>(null);
+  const [summary, setSummary] = useState<MirrorSummary | null>(null);
+  const [failure, setFailure] = useState<string | null>(null);
+  const activeController = useRef<AbortController | null>(null);
+  const archivePubkey = input.files?.["manifest.json"].pubkey;
+
+  useEffect(() => {
+    activeController.current?.abort();
+    setState("idle");
+    setProgress(null);
+    setSummary(null);
+    setFailure(null);
+    return () => activeController.current?.abort();
+  }, [archivePubkey]);
+
+  async function start(destinationValue: string) {
+    if (!input.files || !input.signer) return;
+    const destination = normalizeDestinationUrl(destinationValue);
+    const controller = new AbortController();
+    activeController.current?.abort();
+    activeController.current = controller;
+    setState("running");
+    setProgress(null);
+    setSummary(null);
+    setFailure(null);
+    try {
+      const results = await mirrorArchiveMedia({
+        destination,
+        references: input.files["media.json"] as MediaReference[],
+        signer: input.signer,
+        signal: controller.signal,
+        onProgress: setProgress,
+      });
+      if (controller.signal.aborted) return;
+      setSummary(summarizeMirrorResults(results));
+      setState("complete");
+    } catch (error) {
+      if (controller.signal.aborted) return;
+      setFailure(error instanceof Error ? error.message : "The destination copy stopped. Try again.");
+      setState("failed");
+    } finally {
+      if (activeController.current === controller) activeController.current = null;
+    }
+  }
+
+  return { state, progress, summary, failure, start };
+}

--- a/src/hooks/useDestinationMirror.ts
+++ b/src/hooks/useDestinationMirror.ts
@@ -4,7 +4,7 @@
 import type { NostrSigner } from "@nostrify/nostrify";
 import { useEffect, useRef, useState } from "react";
 
-import type { ArchiveFiles, MediaReference } from "@/lib/exit/archive";
+import type { ArchiveFiles } from "@/lib/exit/archive";
 import { normalizeDestinationUrl } from "@/lib/exit/destination";
 import {
   mirrorArchiveMedia,
@@ -44,7 +44,7 @@ export function useDestinationMirror(input: { files: ArchiveFiles | null; signer
     try {
       const results = await mirrorArchiveMedia({
         destination: normalizeDestinationUrl(destinationValue),
-        references: input.files["media.json"] as MediaReference[],
+        references: input.files["media.json"],
         signer: input.signer,
         signal: controller.signal,
         onProgress: setProgress,

--- a/src/lib/__tests__/blossomAuth.test.ts
+++ b/src/lib/__tests__/blossomAuth.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
-import { createBlossomGetAuthHeader } from '@/lib/blossomAuth';
+import { createBlossomGetAuthHeader, createBlossomUploadAuthHeader } from '@/lib/blossomAuth';
 
 function makeSigner() {
   return {
@@ -40,5 +40,26 @@ describe('createBlossomGetAuthHeader', () => {
 
     const header = await createBlossomGetAuthHeader(signer, HASH);
     expect(header).toBeNull();
+  });
+});
+
+describe('createBlossomUploadAuthHeader', () => {
+  const HASH = 'b'.repeat(64);
+
+  it('signs a hash-bound kind 24242 upload event', async () => {
+    const signer = makeSigner();
+    const header = await createBlossomUploadAuthHeader(signer, HASH);
+
+    const payload = JSON.parse(atob(header.slice('Nostr '.length)));
+    expect(payload).toMatchObject({ kind: 24242, content: 'Upload blob' });
+    expect(payload.tags).toContainEqual(['t', 'upload']);
+    expect(payload.tags).toContainEqual(['x', HASH]);
+  });
+
+  it('surfaces signing failures to the mirror flow', async () => {
+    const signer = makeSigner();
+    signer.signEvent.mockRejectedValueOnce(new Error('signing denied'));
+
+    await expect(createBlossomUploadAuthHeader(signer, HASH)).rejects.toThrow('signing denied');
   });
 });

--- a/src/lib/__tests__/blossomAuth.test.ts
+++ b/src/lib/__tests__/blossomAuth.test.ts
@@ -1,6 +1,17 @@
 import { describe, it, expect, vi } from 'vitest';
 import { createBlossomGetAuthHeader, createBlossomUploadAuthHeader } from '@/lib/blossomAuth';
 
+function decodeToken(header: string) {
+  const token = header.slice('Nostr '.length);
+  const padded = token.replace(/-/g, '+').replace(/_/g, '/').padEnd(Math.ceil(token.length / 4) * 4, '=');
+  const bytes = Uint8Array.from(atob(padded), (character) => character.charCodeAt(0));
+  return JSON.parse(new TextDecoder().decode(bytes));
+}
+
+function expectBase64Url(header: string) {
+  expect(header.slice('Nostr '.length)).not.toMatch(/[+/=]/);
+}
+
 function makeSigner() {
   return {
     getPublicKey: vi.fn().mockResolvedValue('pubkey-hex'),
@@ -21,7 +32,7 @@ describe('createBlossomGetAuthHeader', () => {
     const header = await createBlossomGetAuthHeader(signer, HASH);
 
     expect(header).toMatch(/^Nostr /);
-    const payload = JSON.parse(atob(header!.slice('Nostr '.length)));
+    const payload = decodeToken(header!);
     expect(payload.kind).toBe(24242);
     expect(payload.content).toBe('Get blob');
     const tagMap = new Map(payload.tags.map((t: string[]) => [t[0], t[1]]));
@@ -50,7 +61,8 @@ describe('createBlossomUploadAuthHeader', () => {
     const signer = makeSigner();
     const header = await createBlossomUploadAuthHeader(signer, HASH);
 
-    const payload = JSON.parse(atob(header.slice('Nostr '.length)));
+    expectBase64Url(header);
+    const payload = decodeToken(header);
     expect(payload).toMatchObject({ kind: 24242, content: 'Upload blob' });
     expect(payload.tags).toContainEqual(['t', 'upload']);
     expect(payload.tags).toContainEqual(['x', HASH]);

--- a/src/lib/blossomAuth.ts
+++ b/src/lib/blossomAuth.ts
@@ -4,8 +4,31 @@
 import type { NostrSigner } from '@nostrify/nostrify';
 import { debugLog, debugError } from './debug';
 
-const BLOSSOM_GET_KIND = 24242;
+const BLOSSOM_AUTH_KIND = 24242;
 const DEFAULT_EXPIRATION_SECONDS = 60;
+
+type BlossomAuthAction = 'get' | 'upload';
+
+async function createBlossomAuthHeader(
+  signer: NostrSigner,
+  action: BlossomAuthAction,
+  sha256: string | undefined,
+  expirationSeconds: number,
+): Promise<string> {
+  const now = Math.floor(Date.now() / 1000);
+  const template = {
+    kind: BLOSSOM_AUTH_KIND,
+    content: action === 'get' ? 'Get blob' : 'Upload blob',
+    tags: [
+      ['t', action],
+      ...(sha256 ? [['x', sha256]] : []),
+      ['expiration', String(now + expirationSeconds)],
+    ],
+    created_at: now,
+  };
+  const signedEvent = await signer.signEvent(template);
+  return `Nostr ${btoa(JSON.stringify(signedEvent))}`;
+}
 
 export async function createBlossomGetAuthHeader(
   signer: NostrSigner,
@@ -13,24 +36,21 @@ export async function createBlossomGetAuthHeader(
   expirationSeconds: number = DEFAULT_EXPIRATION_SECONDS,
 ): Promise<string | null> {
   try {
-    const now = Math.floor(Date.now() / 1000);
-    const template = {
-      kind: BLOSSOM_GET_KIND,
-      content: 'Get blob',
-      tags: [
-        ['t', 'get'],
-        ['x', sha256],
-        ['expiration', String(now + expirationSeconds)],
-      ],
-      created_at: now,
-    };
-    const signedEvent = await signer.signEvent(template);
-    const encoded = btoa(JSON.stringify(signedEvent));
-
+    const header = await createBlossomAuthHeader(signer, 'get', sha256, expirationSeconds);
     debugLog('[blossomAuth] Created GET auth header for requested blob');
-    return `Nostr ${encoded}`;
+    return header;
   } catch (error) {
     debugError('[blossomAuth] Failed to generate GET auth header:', error);
     return null;
   }
+}
+
+export async function createBlossomUploadAuthHeader(
+  signer: NostrSigner,
+  sha256?: string,
+  expirationSeconds: number = DEFAULT_EXPIRATION_SECONDS,
+): Promise<string> {
+  const header = await createBlossomAuthHeader(signer, 'upload', sha256, expirationSeconds);
+  debugLog('[blossomAuth] Created upload auth header for requested blob');
+  return header;
 }

--- a/src/lib/blossomAuth.ts
+++ b/src/lib/blossomAuth.ts
@@ -9,6 +9,17 @@ const DEFAULT_EXPIRATION_SECONDS = 60;
 
 type BlossomAuthAction = 'get' | 'upload';
 
+function encodeBase64(value: string): string {
+  const bytes = new TextEncoder().encode(value);
+  let binary = '';
+  for (const byte of bytes) binary += String.fromCharCode(byte);
+  return btoa(binary);
+}
+
+function encodeBase64Url(value: string): string {
+  return encodeBase64(value).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+
 async function createBlossomAuthHeader(
   signer: NostrSigner,
   action: BlossomAuthAction,
@@ -27,7 +38,11 @@ async function createBlossomAuthHeader(
     created_at: now,
   };
   const signedEvent = await signer.signEvent(template);
-  return `Nostr ${btoa(JSON.stringify(signedEvent))}`;
+  const serializedEvent = JSON.stringify(signedEvent);
+  const encodedEvent = action === 'upload'
+    ? encodeBase64Url(serializedEvent)
+    : encodeBase64(serializedEvent);
+  return `Nostr ${encodedEvent}`;
 }
 
 export async function createBlossomGetAuthHeader(
@@ -47,7 +62,7 @@ export async function createBlossomGetAuthHeader(
 
 export async function createBlossomUploadAuthHeader(
   signer: NostrSigner,
-  sha256?: string,
+  sha256: string,
   expirationSeconds: number = DEFAULT_EXPIRATION_SECONDS,
 ): Promise<string> {
   const header = await createBlossomAuthHeader(signer, 'upload', sha256, expirationSeconds);

--- a/src/lib/exit/destination.test.ts
+++ b/src/lib/exit/destination.test.ts
@@ -20,6 +20,7 @@ describe("normalizeDestinationUrl", () => {
     ["https://blossom.example/path", "path-not-allowed"],
     ["https://blossom.example?token=secret", "query-not-allowed"],
     ["https://blossom.example#place", "fragment-not-allowed"],
+    ["https://blossom.example/path///", "path-not-allowed"],
   ])("rejects %s", (value, code) => {
     expect(() => normalizeDestinationUrl(value)).toThrow(DestinationError);
     try {

--- a/src/lib/exit/destination.test.ts
+++ b/src/lib/exit/destination.test.ts
@@ -4,13 +4,20 @@ import { DestinationError, normalizeDestinationUrl } from "./destination";
 
 describe("normalizeDestinationUrl", () => {
   it("normalizes an HTTPS server and removes trailing slashes", () => {
-    expect(normalizeDestinationUrl("  https://blossom.example/path///  ")).toBe("https://blossom.example/path");
+    expect(normalizeDestinationUrl("  https://blossom.example///  ")).toBe("https://blossom.example");
+  });
+
+  it("names the root a BUD-01 server answers at when a path is supplied", () => {
+    expect(() => normalizeDestinationUrl("https://blossom.example/path")).toThrow(
+      "Blossom servers answer at the domain root. Use https://blossom.example instead.",
+    );
   });
 
   it.each([
     ["not a url", "invalid-url"],
     ["http://blossom.example", "insecure-scheme"],
     ["https://user:pass@blossom.example", "embedded-credentials"],
+    ["https://blossom.example/path", "path-not-allowed"],
     ["https://blossom.example?token=secret", "query-not-allowed"],
     ["https://blossom.example#place", "fragment-not-allowed"],
   ])("rejects %s", (value, code) => {

--- a/src/lib/exit/destination.test.ts
+++ b/src/lib/exit/destination.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+
+import { DestinationError, normalizeDestinationUrl } from "./destination";
+
+describe("normalizeDestinationUrl", () => {
+  it("normalizes an HTTPS server and removes trailing slashes", () => {
+    expect(normalizeDestinationUrl("  https://blossom.example/path///  ")).toBe("https://blossom.example/path");
+  });
+
+  it.each([
+    ["not a url", "invalid-url"],
+    ["http://blossom.example", "insecure-scheme"],
+    ["https://user:pass@blossom.example", "embedded-credentials"],
+    ["https://blossom.example?token=secret", "query-not-allowed"],
+    ["https://blossom.example#place", "fragment-not-allowed"],
+  ])("rejects %s", (value, code) => {
+    expect(() => normalizeDestinationUrl(value)).toThrow(DestinationError);
+    try {
+      normalizeDestinationUrl(value);
+    } catch (error) {
+      expect(error).toMatchObject({ code });
+    }
+  });
+});

--- a/src/lib/exit/destination.ts
+++ b/src/lib/exit/destination.ts
@@ -5,6 +5,7 @@ export type DestinationErrorCode =
   | "invalid-url"
   | "insecure-scheme"
   | "embedded-credentials"
+  | "path-not-allowed"
   | "query-not-allowed"
   | "fragment-not-allowed"
   | "unreachable"
@@ -42,6 +43,13 @@ export function normalizeDestinationUrl(value: string): string {
   if (destination.hash) {
     throw new DestinationError("fragment-not-allowed", "Remove the fragment from this URL.");
   }
-  destination.pathname = destination.pathname.replace(/\/+$/, "");
-  return destination.toString().replace(/\/$/, "");
+  // BUD-01 requires every Blossom endpoint to live at the domain root, so a
+  // path would deterministically address the wrong `/mirror` endpoint.
+  if (destination.pathname.replace(/\/+$/, "")) {
+    throw new DestinationError(
+      "path-not-allowed",
+      `Blossom servers answer at the domain root. Use ${destination.origin} instead.`,
+    );
+  }
+  return destination.origin;
 }

--- a/src/lib/exit/destination.ts
+++ b/src/lib/exit/destination.ts
@@ -1,0 +1,47 @@
+// ABOUTME: Validates and normalizes user-provided Blossom destination URLs
+// ABOUTME: Rejects URL features that could hide credentials or change endpoint routing
+
+export type DestinationErrorCode =
+  | "invalid-url"
+  | "insecure-scheme"
+  | "embedded-credentials"
+  | "query-not-allowed"
+  | "fragment-not-allowed"
+  | "unreachable"
+  | "auth-required"
+  | "no-mirror-support"
+  | "rate-limited";
+
+export class DestinationError extends Error {
+  constructor(
+    public readonly code: DestinationErrorCode,
+    message: string,
+    public readonly status?: number,
+  ) {
+    super(message);
+    this.name = "DestinationError";
+  }
+}
+
+export function normalizeDestinationUrl(value: string): string {
+  let destination: URL;
+  try {
+    destination = new URL(value.trim());
+  } catch {
+    throw new DestinationError("invalid-url", "Enter a complete Blossom server URL.");
+  }
+  if (destination.protocol !== "https:") {
+    throw new DestinationError("insecure-scheme", "Use an HTTPS Blossom server URL.");
+  }
+  if (destination.username || destination.password) {
+    throw new DestinationError("embedded-credentials", "Remove the username and password from this URL.");
+  }
+  if (destination.search) {
+    throw new DestinationError("query-not-allowed", "Remove the query string from this URL.");
+  }
+  if (destination.hash) {
+    throw new DestinationError("fragment-not-allowed", "Remove the fragment from this URL.");
+  }
+  destination.pathname = destination.pathname.replace(/\/+$/, "");
+  return destination.toString().replace(/\/$/, "");
+}

--- a/src/lib/exit/mirrorClient.test.ts
+++ b/src/lib/exit/mirrorClient.test.ts
@@ -21,6 +21,13 @@ function descriptor(sha256 = hash, size = 5) {
   return { url: `https://blossom.example/${sha256}`, sha256, size, type: "video/mp4" };
 }
 
+function decodeAuthorization(value: string): { tags: string[][] } {
+  const token = value.slice("Nostr ".length);
+  const padded = token.replace(/-/g, "+").replace(/_/g, "/").padEnd(Math.ceil(token.length / 4) * 4, "=");
+  const bytes = Uint8Array.from(atob(padded), (character) => character.charCodeAt(0));
+  return JSON.parse(new TextDecoder().decode(bytes));
+}
+
 describe("mirrorArchiveMedia", () => {
   beforeEach(() => vi.clearAllMocks());
 
@@ -96,7 +103,8 @@ describe("mirrorArchiveMedia", () => {
     expect(results[1].verification).toBe("unverified");
   });
 
-  it("skips HLS manifests and summarizes all four user-facing counts", async () => {
+  it("skips HLS manifests and reports their progress in source order", async () => {
+    const onProgress = vi.fn();
     const fetcher = vi.fn<typeof fetch>()
       .mockResolvedValueOnce(new Response(JSON.stringify(descriptor()), { status: 200 }))
       .mockResolvedValueOnce(new Response(null, { status: 200, headers: { "content-length": "5" } }));
@@ -105,22 +113,65 @@ describe("mirrorArchiveMedia", () => {
       references: [reference("https://source.example/master.m3u8", null), reference("https://source.example/video", hash)],
       signer,
       fetcher,
+      onProgress,
     });
     expect(results).toMatchObject([
       { verification: "skipped" },
       { verification: "descriptor-verified" },
     ]);
+    expect(onProgress.mock.calls.map(([progress]) => progress.completed)).toEqual([1, 2]);
   });
 
-  it("mirrors a source without an advertised hash and reports it as unverified", async () => {
-    const fetcher = vi.fn<typeof fetch>()
-      .mockResolvedValueOnce(new Response(JSON.stringify(descriptor()), { status: 200 }))
-      .mockResolvedValueOnce(new Response(null, { status: 200, headers: { "content-length": "5" } }));
+  it("skips a source without an advertised hash before signing or requesting it", async () => {
+    const fetcher = vi.fn<typeof fetch>();
     const results = await mirrorArchiveMedia({
       destination: "https://blossom.example", references: [reference("https://source.example/no-hash", null)], signer, fetcher,
     });
-    expect(results[0]).toMatchObject({ verification: "unverified", destination_sha256: hash });
-    expect(fetcher.mock.calls[0][1]).toMatchObject({ method: "PUT" });
+    expect(results[0]).toMatchObject({
+      verification: "skipped",
+      destination_sha256: null,
+      reason: expect.stringContaining("did not advertise a SHA-256 hash"),
+    });
+    expect(signer.signEvent).not.toHaveBeenCalled();
+    expect(fetcher).not.toHaveBeenCalled();
+  });
+
+  it("sends a BUD-11-compliant authorization token to a strict destination", async () => {
+    const fetcher = vi.fn<typeof fetch>(async (_input, init) => {
+      if (init?.method === "HEAD") {
+        return new Response(null, { status: 200, headers: { "content-length": "5" } });
+      }
+      const authorization = new Headers(init?.headers).get("Authorization") ?? "";
+      const token = authorization.slice("Nostr ".length);
+      if (!authorization.startsWith("Nostr ") || /[+/=]/.test(token)) return new Response(null, { status: 401 });
+      const event = decodeAuthorization(authorization);
+      if (!event.tags.some((tag) => tag[0] === "x" && tag[1] === hash)) return new Response(null, { status: 401 });
+      return new Response(JSON.stringify(descriptor()), { status: 200 });
+    });
+
+    const results = await mirrorArchiveMedia({
+      destination: "https://blossom.example",
+      references: [reference("https://source.example/video")],
+      signer,
+      fetcher,
+    });
+
+    expect(results[0].verification).toBe("descriptor-verified");
+  });
+
+  it("allows destination readback to follow redirects", async () => {
+    const fetcher = vi.fn<typeof fetch>()
+      .mockResolvedValueOnce(new Response(JSON.stringify(descriptor()), { status: 200 }))
+      .mockResolvedValueOnce(new Response(null, { status: 200, headers: { "content-length": "5" } }));
+
+    await mirrorArchiveMedia({
+      destination: "https://blossom.example",
+      references: [reference("https://source.example/video")],
+      signer,
+      fetcher,
+    });
+
+    expect(fetcher.mock.calls[1][1]).not.toMatchObject({ redirect: "error" });
   });
 
   it("follows a BUD-01 redirect when reading the mirrored blob back", async () => {

--- a/src/lib/exit/mirrorClient.test.ts
+++ b/src/lib/exit/mirrorClient.test.ts
@@ -135,6 +135,24 @@ describe("mirrorArchiveMedia", () => {
     expect(fetcher.mock.calls[1][1]).toMatchObject({ method: "HEAD", redirect: "follow" });
   });
 
+  it("passes the destination's own X-Reason on to the person reading the summary", async () => {
+    const fetcher = vi.fn(async () => new Response(null, {
+      status: 413,
+      headers: { "x-reason": "  Blob exceeds the 100 MB   limit for this account  " },
+    }));
+    const results = await mirrorArchiveMedia({
+      destination: "https://blossom.example",
+      references: [reference("https://source.example/one"), reference("https://source.example/two", otherHash)],
+      signer,
+      fetcher,
+    });
+
+    expect(results[0]).toMatchObject({
+      verification: "failed",
+      reason: "The destination refused this file (HTTP 413). The server said: Blob exceeds the 100 MB limit for this account",
+    });
+  });
+
   it("records malformed destination JSON as a file failure", async () => {
     const results = await mirrorArchiveMedia({
       destination: "https://blossom.example",

--- a/src/lib/exit/mirrorClient.test.ts
+++ b/src/lib/exit/mirrorClient.test.ts
@@ -123,6 +123,18 @@ describe("mirrorArchiveMedia", () => {
     expect(fetcher.mock.calls[0][1]).toMatchObject({ method: "PUT" });
   });
 
+  it("follows a BUD-01 redirect when reading the mirrored blob back", async () => {
+    const fetcher = vi.fn<typeof fetch>()
+      .mockResolvedValueOnce(new Response(JSON.stringify(descriptor()), { status: 200 }))
+      .mockResolvedValueOnce(new Response(null, { status: 200, headers: { "content-length": "5" } }));
+    const results = await mirrorArchiveMedia({
+      destination: "https://blossom.example", references: [reference("https://source.example/one")], signer, fetcher,
+    });
+
+    expect(results[0].verification).toBe("descriptor-verified");
+    expect(fetcher.mock.calls[1][1]).toMatchObject({ method: "HEAD", redirect: "follow" });
+  });
+
   it("records malformed destination JSON as a file failure", async () => {
     const results = await mirrorArchiveMedia({
       destination: "https://blossom.example",

--- a/src/lib/exit/mirrorClient.test.ts
+++ b/src/lib/exit/mirrorClient.test.ts
@@ -1,0 +1,143 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { NostrSigner } from "@nostrify/nostrify";
+
+import type { MediaReference } from "./archive";
+import { DestinationError } from "./destination";
+import { mirrorArchiveMedia } from "./mirrorClient";
+
+const hash = "a".repeat(64);
+const otherHash = "b".repeat(64);
+const thirdHash = "c".repeat(64);
+const signer = {
+  signEvent: vi.fn(async (event) => ({ ...event, id: "c".repeat(64), pubkey: "d".repeat(64), sig: "e".repeat(128) })),
+} as unknown as NostrSigner;
+
+function reference(url: string, sha256: string | null = hash): MediaReference {
+  return { event_id: "f".repeat(64), tag: "url", url, sha256 };
+}
+
+function descriptor(sha256 = hash, size = 5) {
+  return { url: `https://blossom.example/${sha256}`, sha256, size, type: "video/mp4" };
+}
+
+describe("mirrorArchiveMedia", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("uses the first real mirror as a canary without mirroring it twice", async () => {
+    const fetcher = vi.fn<typeof fetch>()
+      .mockResolvedValueOnce(new Response(JSON.stringify(descriptor()), { status: 200 }))
+      .mockResolvedValueOnce(new Response(null, { status: 200, headers: { "content-length": "5" } }))
+      .mockResolvedValueOnce(new Response(JSON.stringify(descriptor(otherHash)), { status: 200 }))
+      .mockResolvedValueOnce(new Response(null, { status: 200, headers: { "content-length": "5" } }));
+
+    const results = await mirrorArchiveMedia({
+      destination: "https://blossom.example",
+      references: [reference("https://source.example/one"), reference("https://source.example/two", otherHash)],
+      signer,
+      fetcher,
+    });
+
+    expect(results).toHaveLength(2);
+    expect(fetcher.mock.calls.filter(([, init]) => init?.method === "PUT")).toHaveLength(2);
+    expect(results[0].verification).toBe("descriptor-verified");
+  });
+
+  it.each([
+    [401, "auth-required"],
+    [403, "auth-required"],
+    [404, "no-mirror-support"],
+    [405, "no-mirror-support"],
+    [501, "no-mirror-support"],
+  ])("fails fast when the canary returns %s", async (status, code) => {
+    const fetcher = vi.fn(async () => new Response(null, { status }));
+    await expect(mirrorArchiveMedia({
+      destination: "https://blossom.example",
+      references: [reference("https://source.example/one"), reference("https://source.example/two", otherHash)],
+      signer,
+      fetcher,
+    })).rejects.toMatchObject({ code });
+    expect(fetcher).toHaveBeenCalledOnce();
+  });
+
+  it("describes a canary CORS or network failure honestly", async () => {
+    const fetcher = vi.fn(async () => { throw new TypeError("Failed to fetch"); });
+    await expect(mirrorArchiveMedia({
+      destination: "https://blossom.example",
+      references: [reference("https://source.example/one")], signer, fetcher,
+    })).rejects.toMatchObject({
+      code: "unreachable",
+      message: expect.stringContaining("may be down, or it may not accept requests from other websites"),
+    });
+  });
+
+  it("honors Retry-After before retrying a rate limit", async () => {
+    const wait = vi.fn(async () => undefined);
+    const fetcher = vi.fn<typeof fetch>()
+      .mockResolvedValueOnce(new Response(null, { status: 429, headers: { "retry-after": "2" } }))
+      .mockResolvedValueOnce(new Response(JSON.stringify(descriptor()), { status: 200 }))
+      .mockResolvedValueOnce(new Response(null, { status: 200, headers: { "content-length": "5" } }));
+    await mirrorArchiveMedia({ destination: "https://blossom.example", references: [reference("https://source.example/one")], signer, fetcher, wait });
+    expect(wait).toHaveBeenCalledWith(2000, undefined);
+  });
+
+  it("rejects a mismatched descriptor and continues after later file failures", async () => {
+    const fetcher = vi.fn<typeof fetch>()
+      .mockResolvedValueOnce(new Response(JSON.stringify(descriptor(otherHash)), { status: 200 }))
+      .mockResolvedValueOnce(new Response(JSON.stringify(descriptor(thirdHash)), { status: 200 }))
+      .mockResolvedValueOnce(new Response(null, { status: 200, headers: { "content-length": "9" } }));
+    const results = await mirrorArchiveMedia({
+      destination: "https://blossom.example",
+      references: [reference("https://source.example/one"), reference("https://source.example/two", thirdHash)],
+      signer,
+      fetcher,
+    });
+    expect(results[0].verification).toBe("hash-mismatch");
+    expect(results[1].verification).toBe("unverified");
+  });
+
+  it("skips HLS manifests and summarizes all four user-facing counts", async () => {
+    const fetcher = vi.fn<typeof fetch>()
+      .mockResolvedValueOnce(new Response(JSON.stringify(descriptor()), { status: 200 }))
+      .mockResolvedValueOnce(new Response(null, { status: 200, headers: { "content-length": "5" } }));
+    const results = await mirrorArchiveMedia({
+      destination: "https://blossom.example",
+      references: [reference("https://source.example/master.m3u8", null), reference("https://source.example/video", hash)],
+      signer,
+      fetcher,
+    });
+    expect(results).toMatchObject([
+      { verification: "skipped" },
+      { verification: "descriptor-verified" },
+    ]);
+  });
+
+  it("mirrors a source without an advertised hash and reports it as unverified", async () => {
+    const fetcher = vi.fn<typeof fetch>()
+      .mockResolvedValueOnce(new Response(JSON.stringify(descriptor()), { status: 200 }))
+      .mockResolvedValueOnce(new Response(null, { status: 200, headers: { "content-length": "5" } }));
+    const results = await mirrorArchiveMedia({
+      destination: "https://blossom.example", references: [reference("https://source.example/no-hash", null)], signer, fetcher,
+    });
+    expect(results[0]).toMatchObject({ verification: "unverified", destination_sha256: hash });
+    expect(fetcher.mock.calls[0][1]).toMatchObject({ method: "PUT" });
+  });
+
+  it("records malformed destination JSON as a file failure", async () => {
+    const results = await mirrorArchiveMedia({
+      destination: "https://blossom.example",
+      references: [reference("https://source.example/one")],
+      signer,
+      fetcher: vi.fn(async () => new Response("not json", { status: 200 })),
+    });
+    expect(results[0]).toMatchObject({ verification: "failed", reason: "The destination returned an invalid blob descriptor." });
+  });
+
+  it("throws a typed destination error after exhausted canary rate limits", async () => {
+    const fetcher = vi.fn(async () => new Response(null, { status: 429 }));
+    await expect(mirrorArchiveMedia({
+      destination: "https://blossom.example", references: [reference("https://source.example/one")], signer, fetcher,
+      wait: async () => undefined, maxRateLimitRetries: 1,
+    })).rejects.toBeInstanceOf(DestinationError);
+  });
+});

--- a/src/lib/exit/mirrorClient.ts
+++ b/src/lib/exit/mirrorClient.ts
@@ -70,6 +70,10 @@ function isHlsManifest(url: string): boolean {
 
 function defaultWait(milliseconds: number, signal?: AbortSignal): Promise<void> {
   return new Promise((resolve, reject) => {
+    if (signal?.aborted) {
+      reject(new DOMException("Mirror cancelled", "AbortError"));
+      return;
+    }
     const timeout = window.setTimeout(resolve, milliseconds);
     signal?.addEventListener("abort", () => {
       window.clearTimeout(timeout);

--- a/src/lib/exit/mirrorClient.ts
+++ b/src/lib/exit/mirrorClient.ts
@@ -140,11 +140,15 @@ function failedResult(
   };
 }
 
-async function requestMirror(references: MediaReference[], options: MirrorOptions): Promise<Response | DestinationError> {
+async function requestMirror(
+  references: MediaReference[],
+  sha256: string,
+  options: MirrorOptions,
+): Promise<Response | DestinationError> {
   const fetcher = options.fetcher ?? fetch;
   const wait = options.wait ?? defaultWait;
   for (let attempt = 0; ; attempt += 1) {
-    const authorization = await createBlossomUploadAuthHeader(options.signer, references[0].sha256 ?? undefined);
+    const authorization = await createBlossomUploadAuthHeader(options.signer, sha256);
     try {
       const response = await fetcher(`${options.destination}/mirror`, {
         method: "PUT",
@@ -202,10 +206,10 @@ async function verifyReadback(
 
 async function mirrorOne(
   references: MediaReference[],
+  expectedHash: string,
   options: MirrorOptions,
 ): Promise<{ result: MirrorResult; destinationError: DestinationError | null }> {
-  const expectedHash = references[0].sha256;
-  const response = await requestMirror(references, options);
+  const response = await requestMirror(references, expectedHash, options);
   if (response instanceof DestinationError) {
     return { result: failedResult(references, "failed", response.message), destinationError: response };
   }
@@ -233,18 +237,32 @@ async function mirrorOne(
 
 export async function mirrorArchiveMedia(options: MirrorOptions): Promise<MirrorResult[]> {
   const groups = groupReferences(options.references);
-  const work = groups.filter(([reference]) => !isHlsManifest(reference.url));
-  const skipped = groups.filter(([reference]) => isHlsManifest(reference.url)).map((references): MirrorResult => ({
-    references, source_url: references[0].url, destination_url: null, expected_sha256: references[0].sha256,
-    destination_sha256: null, byte_size: null, verification: "skipped", reason: "Streaming manifests are generated derivatives and were not copied.",
-  }));
-  const results: MirrorResult[] = [...skipped];
-  for (let index = 0; index < work.length; index += 1) {
+  const results: MirrorResult[] = [];
+  let mirrorAttempts = 0;
+  for (const references of groups) {
     if (options.signal?.aborted) throw new DOMException("Mirror cancelled", "AbortError");
-    const outcome = await mirrorOne(work[index], options);
-    if (index === 0 && outcome.destinationError) throw outcome.destinationError;
-    results.push(outcome.result);
-    options.onProgress?.({ completed: results.length, total: groups.length, result: outcome.result });
+    const reference = references[0];
+    let result: MirrorResult;
+    if (isHlsManifest(reference.url)) {
+      result = {
+        references, source_url: reference.url, destination_url: null, expected_sha256: reference.sha256,
+        destination_sha256: null, byte_size: null, verification: "skipped",
+        reason: "Streaming manifests are generated derivatives and were not copied.",
+      };
+    } else if (!reference.sha256) {
+      result = {
+        references, source_url: reference.url, destination_url: null, expected_sha256: null,
+        destination_sha256: null, byte_size: null, verification: "skipped",
+        reason: "The source did not advertise a SHA-256 hash, so a secure copy could not be authorized.",
+      };
+    } else {
+      const outcome = await mirrorOne(references, reference.sha256, options);
+      if (mirrorAttempts === 0 && outcome.destinationError) throw outcome.destinationError;
+      mirrorAttempts += 1;
+      result = outcome.result;
+    }
+    results.push(result);
+    options.onProgress?.({ completed: results.length, total: groups.length, result });
   }
   return results;
 }

--- a/src/lib/exit/mirrorClient.ts
+++ b/src/lib/exit/mirrorClient.ts
@@ -97,6 +97,14 @@ function destinationFailure(status: number, destination: string): DestinationErr
   return null;
 }
 
+// BUD-01 lets a server attach a human-readable `X-Reason` to any error. It is
+// diagnostic text only, never control flow, so it is bounded and stripped of
+// line breaks before it reaches the page.
+function serverReason(response: Response): string {
+  const reason = response.headers.get("x-reason")?.replace(/\s+/g, " ").trim();
+  return reason ? ` The server said: ${reason.slice(0, 200)}` : "";
+}
+
 function parseDescriptor(value: unknown): BlobDescriptor | null {
   if (!value || typeof value !== "object") return null;
   const descriptor = value as Partial<BlobDescriptor>;
@@ -204,7 +212,10 @@ async function mirrorOne(
     return { result: failedResult(references, "failed", destinationError.message), destinationError };
   }
   if (!response.ok) {
-    return { result: failedResult(references, "failed", `The destination refused this file (HTTP ${response.status}).`), destinationError: null };
+    return {
+      result: failedResult(references, "failed", `The destination refused this file (HTTP ${response.status}).${serverReason(response)}`),
+      destinationError: null,
+    };
   }
   const descriptor = await readDescriptor(response);
   if (!descriptor) {

--- a/src/lib/exit/mirrorClient.ts
+++ b/src/lib/exit/mirrorClient.ts
@@ -165,10 +165,13 @@ async function verifyReadback(
 ): Promise<MirrorResult> {
   const expectedHash = references[0].sha256;
   try {
+    // BUD-01 lets a blob endpoint answer with 307/308 to a CDN, and guarantees
+    // the redirect target still carries the same sha256. Refusing to follow
+    // reported every CDN-backed destination as unverified.
     const response = await (options.fetcher ?? fetch)(descriptor.url, {
       method: "HEAD",
       signal: options.signal,
-      redirect: "error",
+      redirect: "follow",
     });
     const size = response.headers.get("content-length");
     if (expectedHash && response.ok && size !== null && Number(size) === descriptor.size) {

--- a/src/lib/exit/mirrorClient.ts
+++ b/src/lib/exit/mirrorClient.ts
@@ -1,0 +1,241 @@
+// ABOUTME: Mirrors exported media to a user-selected Blossom server with BUD-04
+// ABOUTME: Uses the first real copy as a capability canary and records partial failures
+
+import type { NostrSigner } from "@nostrify/nostrify";
+
+import { createBlossomUploadAuthHeader } from "@/lib/blossomAuth";
+
+import type { MediaReference } from "./archive";
+import { DestinationError } from "./destination";
+
+export type MirrorVerification = "descriptor-verified" | "unverified" | "hash-mismatch" | "failed" | "skipped";
+
+export interface MirrorResult {
+  references: MediaReference[];
+  source_url: string;
+  destination_url: string | null;
+  expected_sha256: string | null;
+  destination_sha256: string | null;
+  byte_size: number | null;
+  verification: MirrorVerification;
+  reason?: string;
+}
+
+export interface MirrorProgress {
+  completed: number;
+  total: number;
+  result: MirrorResult;
+}
+
+export interface MirrorSummary {
+  mirrored: number;
+  failed: number;
+  skipped: number;
+  unverified: number;
+}
+
+interface BlobDescriptor {
+  url: string;
+  sha256: string;
+  size: number;
+}
+
+interface MirrorOptions {
+  destination: string;
+  references: MediaReference[];
+  signer: NostrSigner;
+  signal?: AbortSignal;
+  fetcher?: typeof fetch;
+  wait?: (milliseconds: number, signal?: AbortSignal) => Promise<void>;
+  maxRateLimitRetries?: number;
+  onProgress?(progress: MirrorProgress): void;
+}
+
+function groupReferences(references: MediaReference[]): MediaReference[][] {
+  const grouped = new Map<string, MediaReference[]>();
+  for (const reference of references) {
+    const key = reference.sha256 ? `hash:${reference.sha256}` : `url:${reference.url}`;
+    grouped.set(key, [...(grouped.get(key) ?? []), reference]);
+  }
+  return [...grouped.values()];
+}
+
+function isHlsManifest(url: string): boolean {
+  try {
+    return new URL(url).pathname.toLowerCase().endsWith(".m3u8");
+  } catch {
+    return false;
+  }
+}
+
+function defaultWait(milliseconds: number, signal?: AbortSignal): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const timeout = window.setTimeout(resolve, milliseconds);
+    signal?.addEventListener("abort", () => {
+      window.clearTimeout(timeout);
+      reject(new DOMException("Mirror cancelled", "AbortError"));
+    }, { once: true });
+  });
+}
+
+function retryDelay(response: Response): number {
+  const value = response.headers.get("retry-after");
+  if (!value) return 1000;
+  const seconds = Number(value);
+  if (Number.isFinite(seconds)) return Math.max(0, seconds * 1000);
+  const date = Date.parse(value);
+  return Number.isNaN(date) ? 1000 : Math.max(0, date - Date.now());
+}
+
+function destinationFailure(status: number, destination: string): DestinationError | null {
+  if (status === 401 || status === 403) {
+    return new DestinationError("auth-required", `${destination} needs account access before it can mirror media.`, status);
+  }
+  if (status === 404 || status === 405 || status === 501) {
+    return new DestinationError("no-mirror-support", `${destination} does not support Blossom media mirroring.`, status);
+  }
+  return null;
+}
+
+function parseDescriptor(value: unknown): BlobDescriptor | null {
+  if (!value || typeof value !== "object") return null;
+  const descriptor = value as Partial<BlobDescriptor>;
+  if (typeof descriptor.url !== "string" || typeof descriptor.sha256 !== "string" || typeof descriptor.size !== "number") return null;
+  if (!/^[a-f0-9]{64}$/i.test(descriptor.sha256) || descriptor.size < 0) return null;
+  try {
+    if (new URL(descriptor.url).protocol !== "https:") return null;
+  } catch {
+    return null;
+  }
+  return { url: descriptor.url, sha256: descriptor.sha256.toLowerCase(), size: descriptor.size };
+}
+
+function failedResult(
+  references: MediaReference[],
+  verification: Extract<MirrorVerification, "failed" | "hash-mismatch">,
+  reason: string,
+  descriptor?: BlobDescriptor,
+): MirrorResult {
+  return {
+    references,
+    source_url: references[0].url,
+    destination_url: descriptor?.url ?? null,
+    expected_sha256: references[0].sha256,
+    destination_sha256: descriptor?.sha256 ?? null,
+    byte_size: descriptor?.size ?? null,
+    verification,
+    reason,
+  };
+}
+
+async function requestMirror(references: MediaReference[], options: MirrorOptions): Promise<Response | DestinationError> {
+  const fetcher = options.fetcher ?? fetch;
+  const wait = options.wait ?? defaultWait;
+  for (let attempt = 0; ; attempt += 1) {
+    const authorization = await createBlossomUploadAuthHeader(options.signer, references[0].sha256 ?? undefined);
+    try {
+      const response = await fetcher(`${options.destination}/mirror`, {
+        method: "PUT",
+        signal: options.signal,
+        headers: { Authorization: authorization, "Content-Type": "application/json" },
+        body: JSON.stringify({ url: references[0].url }),
+      });
+      if (response.status !== 429 || attempt >= (options.maxRateLimitRetries ?? 2)) return response;
+      await wait(retryDelay(response), options.signal);
+    } catch (error) {
+      if (options.signal?.aborted) throw new DOMException("Mirror cancelled", "AbortError");
+      if (!(error instanceof TypeError)) throw error;
+      return new DestinationError("unreachable", `Your browser couldn't reach ${options.destination}. The server may be down, or it may not accept requests from other websites.`);
+    }
+  }
+}
+
+async function readDescriptor(response: Response): Promise<BlobDescriptor | null> {
+  try {
+    return parseDescriptor(await response.json());
+  } catch {
+    return null;
+  }
+}
+
+async function verifyReadback(
+  references: MediaReference[],
+  descriptor: BlobDescriptor,
+  options: MirrorOptions,
+): Promise<MirrorResult> {
+  const expectedHash = references[0].sha256;
+  try {
+    const response = await (options.fetcher ?? fetch)(descriptor.url, {
+      method: "HEAD",
+      signal: options.signal,
+      redirect: "error",
+    });
+    const size = response.headers.get("content-length");
+    if (expectedHash && response.ok && size !== null && Number(size) === descriptor.size) {
+      return { references, source_url: references[0].url, destination_url: descriptor.url, expected_sha256: expectedHash,
+        destination_sha256: descriptor.sha256, byte_size: descriptor.size, verification: "descriptor-verified" };
+    }
+  } catch {
+    if (options.signal?.aborted) throw new DOMException("Mirror cancelled", "AbortError");
+  }
+  return { references, source_url: references[0].url, destination_url: descriptor.url, expected_sha256: expectedHash,
+    destination_sha256: descriptor.sha256, byte_size: descriptor.size, verification: "unverified",
+    reason: expectedHash
+      ? "The destination reported the expected hash, but browser readback could not be confirmed."
+      : "The source did not advertise a hash, so the destination copy could not be compared." };
+}
+
+async function mirrorOne(
+  references: MediaReference[],
+  options: MirrorOptions,
+): Promise<{ result: MirrorResult; destinationError: DestinationError | null }> {
+  const expectedHash = references[0].sha256;
+  const response = await requestMirror(references, options);
+  if (response instanceof DestinationError) {
+    return { result: failedResult(references, "failed", response.message), destinationError: response };
+  }
+  const destinationError = response.status === 429
+    ? new DestinationError("rate-limited", `${options.destination} is rate limiting media copies. Try again later.`, 429)
+    : destinationFailure(response.status, options.destination);
+  if (destinationError) {
+    return { result: failedResult(references, "failed", destinationError.message), destinationError };
+  }
+  if (!response.ok) {
+    return { result: failedResult(references, "failed", `The destination refused this file (HTTP ${response.status}).`), destinationError: null };
+  }
+  const descriptor = await readDescriptor(response);
+  if (!descriptor) {
+    return { result: failedResult(references, "failed", "The destination returned an invalid blob descriptor."), destinationError: null };
+  }
+  if (expectedHash && descriptor.sha256 !== expectedHash.toLowerCase()) {
+    return { result: failedResult(references, "hash-mismatch", "The destination reported a different hash.", descriptor), destinationError: null };
+  }
+  return { result: await verifyReadback(references, descriptor, options), destinationError: null };
+}
+
+export async function mirrorArchiveMedia(options: MirrorOptions): Promise<MirrorResult[]> {
+  const groups = groupReferences(options.references);
+  const work = groups.filter(([reference]) => !isHlsManifest(reference.url));
+  const skipped = groups.filter(([reference]) => isHlsManifest(reference.url)).map((references): MirrorResult => ({
+    references, source_url: references[0].url, destination_url: null, expected_sha256: references[0].sha256,
+    destination_sha256: null, byte_size: null, verification: "skipped", reason: "Streaming manifests are generated derivatives and were not copied.",
+  }));
+  const results: MirrorResult[] = [...skipped];
+  for (let index = 0; index < work.length; index += 1) {
+    if (options.signal?.aborted) throw new DOMException("Mirror cancelled", "AbortError");
+    const outcome = await mirrorOne(work[index], options);
+    if (index === 0 && outcome.destinationError) throw outcome.destinationError;
+    results.push(outcome.result);
+    options.onProgress?.({ completed: results.length, total: groups.length, result: outcome.result });
+  }
+  return results;
+}
+
+export function summarizeMirrorResults(results: MirrorResult[]): MirrorSummary {
+  return {
+    mirrored: results.filter((result) => result.verification === "descriptor-verified").length,
+    failed: results.filter((result) => result.verification === "failed" || result.verification === "hash-mismatch").length,
+    skipped: results.filter((result) => result.verification === "skipped").length,
+    unverified: results.filter((result) => result.verification === "unverified").length,
+  };
+}

--- a/src/pages/ExitStartPage.test.tsx
+++ b/src/pages/ExitStartPage.test.tsx
@@ -7,6 +7,7 @@ import { createFixtureFetch } from "@/lib/exit/__fixtures__/fixtureFetch";
 import { FixtureSigner } from "@/lib/exit/__fixtures__/fixtureSigner";
 import {
   fixturePubkey,
+  fixtureMediaHash,
   makeFixtureEvent,
   otherFixturePubkey,
 } from "@/lib/exit/__fixtures__/exportFixtures";
@@ -110,6 +111,41 @@ describe("ExitStartPage", () => {
     expect(
       screen.getByText(/2 pages read, 2 events and 2 media references collected from Divine/)
     ).toBeInTheDocument();
+  });
+
+  it("validates a custom Blossom destination inline", async () => {
+    mockUseCurrentUser.mockReturnValue(signedIn());
+    vi.stubGlobal("fetch", createFixtureFetch("one-page"));
+    render(<TestApp><ExitStartPage /></TestApp>);
+    await userEvent.click(screen.getByRole("button", { name: /Create my archive/ }));
+    await waitFor(() => expect(screen.getByRole("heading", { name: "Move your media" })).toBeInTheDocument());
+
+    await userEvent.type(screen.getByLabelText("Blossom server URL"), "http://blossom.example");
+    await userEvent.click(screen.getByRole("button", { name: "Copy my media" }));
+
+    expect(screen.getByText("Use an HTTPS Blossom server URL.")).toBeInTheDocument();
+  });
+
+  it("reports destination mirror counts", async () => {
+    mockUseCurrentUser.mockReturnValue(signedIn());
+    vi.stubGlobal("fetch", createFixtureFetch("one-page"));
+    render(<TestApp><ExitStartPage /></TestApp>);
+    await userEvent.click(screen.getByRole("button", { name: /Create my archive/ }));
+    await waitFor(() => expect(screen.getByRole("heading", { name: "Move your media" })).toBeInTheDocument());
+
+    vi.stubGlobal("fetch", vi.fn<typeof fetch>()
+      .mockResolvedValueOnce(new Response(JSON.stringify({
+        url: `https://blossom.example/${fixtureMediaHash}`,
+        sha256: fixtureMediaHash,
+        size: 5,
+        type: "video/mp4",
+      }), { status: 200 }))
+      .mockResolvedValueOnce(new Response(null, { status: 200, headers: { "content-length": "5" } })));
+    await userEvent.type(screen.getByLabelText("Blossom server URL"), "https://blossom.example");
+    await userEvent.click(screen.getByRole("button", { name: "Copy my media" }));
+
+    await waitFor(() => expect(screen.getByText("Destination copy finished.")).toBeInTheDocument());
+    expect(screen.getByRole("status")).toHaveTextContent("1 mirrored, 0 failed, 0 skipped, and 0 unverified.");
   });
 
   it("explains the media limitation when direct file saving is unavailable", async () => {

--- a/src/pages/ExitStartPage.test.tsx
+++ b/src/pages/ExitStartPage.test.tsx
@@ -126,6 +126,19 @@ describe("ExitStartPage", () => {
     expect(screen.getByText("Use an HTTPS Blossom server URL.")).toBeInTheDocument();
   });
 
+  it("rejects a Blossom destination with an endpoint path", async () => {
+    mockUseCurrentUser.mockReturnValue(signedIn());
+    vi.stubGlobal("fetch", createFixtureFetch("one-page"));
+    render(<TestApp><ExitStartPage /></TestApp>);
+    await userEvent.click(screen.getByRole("button", { name: /Create my archive/ }));
+    await waitFor(() => expect(screen.getByRole("heading", { name: "Move your media" })).toBeInTheDocument());
+
+    await userEvent.type(screen.getByLabelText("Blossom server URL"), "https://blossom.example/path");
+    await userEvent.click(screen.getByRole("button", { name: "Copy my media" }));
+
+    expect(screen.getByText("Blossom servers answer at the domain root. Use https://blossom.example instead.")).toBeInTheDocument();
+  });
+
   it("reports destination mirror counts", async () => {
     mockUseCurrentUser.mockReturnValue(signedIn());
     vi.stubGlobal("fetch", createFixtureFetch("one-page"));

--- a/src/pages/ExitStartPage.tsx
+++ b/src/pages/ExitStartPage.tsx
@@ -5,6 +5,7 @@ import {
   Archive,
   ArrowClockwise,
   CheckCircle,
+  Copy,
   DownloadSimple,
   Key,
   WarningCircle,
@@ -17,6 +18,7 @@ import { Link } from "react-router-dom";
 import { LocalNsecBanner } from "@/components/auth/LocalNsecBanner";
 import { KeySafetyNotice } from "@/components/exit/KeySafetyNotice";
 import { MediaProgressList } from "@/components/exit/MediaProgressList";
+import { DestinationForm } from "@/components/exit/DestinationForm";
 import { LoginArea } from "@/components/auth/LoginArea";
 import { MarketingLayout } from "@/components/MarketingLayout";
 import { SectionHero } from "@/components/static-pages";
@@ -25,6 +27,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { getFunnelcakeBaseUrl } from "@/config/api";
 import { useCurrentUser } from "@/hooks/useCurrentUser";
 import { useArchiveMediaExport } from "@/hooks/useArchiveMediaExport";
+import { useDestinationMirror } from "@/hooks/useDestinationMirror";
 import { buildArchiveFiles, serializeArchiveFiles, type ArchiveFiles } from "@/lib/exit/archive";
 import { exportOwnerEvents, OwnerExportError, type ExportProgress } from "@/lib/exit/ownerExportClient";
 import { createZip } from "@/lib/exit/zip";
@@ -94,6 +97,7 @@ export function ExitStartPage() {
   const currentPubkey = useRef(user?.pubkey);
   currentPubkey.current = user?.pubkey;
   const mediaExport = useArchiveMediaExport({ files: archiveFiles, signer });
+  const destinationMirror = useDestinationMirror({ files: archiveFiles, signer });
 
   useEffect(() => {
     activeExport.current?.abort();
@@ -404,6 +408,24 @@ export function ExitStartPage() {
             </div>
           )}
         </section>
+
+        {archiveFiles && signer && (
+          <section>
+            <SectionHero
+              eyebrow="Choose a destination"
+              icon={<Copy weight="fill" className="h-7 w-7" />}
+              title="Move your media"
+              lead="Copy the original files to another Blossom server. Nothing is removed from Divine, and one refused file will not stop the rest."
+            />
+            <DestinationForm
+              state={destinationMirror.state}
+              progress={destinationMirror.progress}
+              summary={destinationMirror.summary}
+              failure={destinationMirror.failure}
+              onStart={destinationMirror.start}
+            />
+          </section>
+        )}
 
         <section>
           <SectionHero


### PR DESCRIPTION
## Summary

- Users who have built an account archive can enter a custom HTTPS Blossom server and copy original media that advertises a SHA-256 hash without routing upload bytes through the browser.
- The flow rejects unsafe or non-root server URLs, uses the first eligible copy as the compatibility check, continues after individual file failures, and reports mirrored, failed, skipped, and unverified totals.

## Motivation

- Account export previously stopped at a downloadable archive, so moving media to user-selected infrastructure still required protocol knowledge and manual tooling.
- Blossom has no universal mirror-capability probe. This uses the first real BUD-04 mirror request as the honest canary, fails fast only for destination-wide errors, and keeps later failures isolated to their files.
- BUD-11 upload authorization is bound to the advertised hash and encoded as unpadded Base64url. Sources without a hash are skipped because a valid mirror authorization cannot be created without one.
- Descriptor hash plus redirect-aware HEAD readback is reported separately from independent byte hashing. Generated HLS manifests are also skipped.
- This does not add destination presets, change archive contents, mirror age-gated sources through browser auth, republish events, or remove anything from Divine.

The existing authenticated GET encoder intentionally remains padded standard Base64 for now: the deployed Divine media viewer currently accepts that encoding only. Changing it in this PR would regress age-gated playback; the new upload/mirror path uses the BUD-11 encoding required by third-party destinations.

## Related Issue

- Closes #594
- Part of #592

## Testing

- [x] `npm run test`
- [x] 2,353 unit tests pass after rebasing and integrating reviewer fixes
- [x] Focused tests cover strict BUD-11 authorization validation, hashless and HLS skips, root-only URL validation, redirect-aware readback, destination error reasons, canary failures, retry, malformed descriptors, hash mismatch, progress ordering, summary rendering, and account-change cancellation
- [ ] Manual verification completed — no verified third-party destination is intentionally configured for v1

## Visuals

- [ ] UI change with screenshots/video attached — the destination form is gated behind a signed archive run and is covered by page-level rendering tests
- [ ] No visual change
- [x] Visuals and text avoid sensitive external brand or partner names unless explicitly approved
