### PR TITLE
feat(discovery): say sponsored by on featured collections

### DIFF
--- a/src/lib/i18n/locales.test.ts
+++ b/src/lib/i18n/locales.test.ts
@@ -120,7 +120,7 @@ const MUST_BE_TRANSLATED_PREFIXES = [
   // docstring above excludes on purpose.
   'notificationsPage.errorTitle',
   'notificationsPage.errorFallback',
-  'discovery.paidPartnership',
+  'discovery.sponsoredBy',
   // Featured-navigation fallback copy. Same reasoning: full sentences, named
   // individually rather than widening to `videoPage.` so the short labels that
   // sit alongside them are not dragged in.

--- a/src/lib/i18n/locales/ar/common.json
+++ b/src/lib/i18n/locales/ar/common.json
@@ -70,7 +70,7 @@
     "hot": "رائج",
     "new": "جديد",
     "featured": "مميز",
-    "paidPartnership": "شراكة مدفوعة مع <bdi>{{sponsorName}}</bdi>",
+    "sponsoredBy": "برعاية <bdi>{{sponsorName}}</bdi>",
     "tags": "الوسوم",
     "verifiedOnly": "من صنع البشر",
     "verifiedOnlyHint": "يتم عرض الفيديوهات التي تحتوي على تحقق ProofMode فقط",

--- a/src/lib/i18n/locales/de/common.json
+++ b/src/lib/i18n/locales/de/common.json
@@ -70,7 +70,7 @@
     "hot": "Heiss",
     "new": "Neu",
     "featured": "Empfohlen",
-    "paidPartnership": "Bezahlte Partnerschaft mit <bdi>{{sponsorName}}</bdi>",
+    "sponsoredBy": "Gesponsert von <bdi>{{sponsorName}}</bdi>",
     "tags": "Tags",
     "verifiedOnly": "Von Menschen gemacht",
     "verifiedOnlyHint": "Es werden nur Videos mit ProofMode-Verifizierung angezeigt",

--- a/src/lib/i18n/locales/en/common.json
+++ b/src/lib/i18n/locales/en/common.json
@@ -70,7 +70,7 @@
     "hot": "Hot",
     "new": "New",
     "featured": "Featured",
-    "paidPartnership": "In paid partnership with <bdi>{{sponsorName}}</bdi>",
+    "sponsoredBy": "Sponsored by <bdi>{{sponsorName}}</bdi>",
     "tags": "Tags",
     "verifiedOnly": "Human Made",
     "verifiedOnlyHint": "Showing only videos with ProofMode verification",

--- a/src/lib/i18n/locales/es/common.json
+++ b/src/lib/i18n/locales/es/common.json
@@ -70,7 +70,7 @@
     "hot": "Popular",
     "new": "Nuevo",
     "featured": "Destacado",
-    "paidPartnership": "En colaboración pagada con <bdi>{{sponsorName}}</bdi>",
+    "sponsoredBy": "Patrocinado por <bdi>{{sponsorName}}</bdi>",
     "tags": "Etiquetas",
     "verifiedOnly": "Hecho por humanos",
     "verifiedOnlyHint": "Mostrando solo videos con verificacion ProofMode",

--- a/src/lib/i18n/locales/fil/common.json
+++ b/src/lib/i18n/locales/fil/common.json
@@ -70,7 +70,7 @@
     "hot": "Sikat",
     "new": "Bago",
     "featured": "Tampok",
-    "paidPartnership": "Bayad na partnership kasama ang <bdi>{{sponsorName}}</bdi>",
+    "sponsoredBy": "Sponsored ng <bdi>{{sponsorName}}</bdi>",
     "tags": "Mga Tag",
     "verifiedOnly": "Gawa ng Tao",
     "verifiedOnlyHint": "Mga video lang na may ProofMode verification.",

--- a/src/lib/i18n/locales/fr/common.json
+++ b/src/lib/i18n/locales/fr/common.json
@@ -70,7 +70,7 @@
     "hot": "Tendance",
     "new": "Nouveau",
     "featured": "A la une",
-    "paidPartnership": "Partenariat rémunéré avec <bdi>{{sponsorName}}</bdi>",
+    "sponsoredBy": "Sponsorisé par <bdi>{{sponsorName}}</bdi>",
     "tags": "Tags",
     "verifiedOnly": "Cree par des humains",
     "verifiedOnlyHint": "Affiche uniquement les videos avec verification ProofMode",

--- a/src/lib/i18n/locales/id/common.json
+++ b/src/lib/i18n/locales/id/common.json
@@ -70,7 +70,7 @@
     "hot": "Populer",
     "new": "Baru",
     "featured": "Unggulan",
-    "paidPartnership": "Kemitraan berbayar dengan <bdi>{{sponsorName}}</bdi>",
+    "sponsoredBy": "Disponsori oleh <bdi>{{sponsorName}}</bdi>",
     "tags": "Tag",
     "verifiedOnly": "Buatan manusia",
     "verifiedOnlyHint": "Hanya menampilkan video dengan verifikasi ProofMode",

--- a/src/lib/i18n/locales/it/common.json
+++ b/src/lib/i18n/locales/it/common.json
@@ -70,7 +70,7 @@
     "hot": "Caldo",
     "new": "Nuovo",
     "featured": "In evidenza",
-    "paidPartnership": "Partnership a pagamento con <bdi>{{sponsorName}}</bdi>",
+    "sponsoredBy": "Sponsorizzato da <bdi>{{sponsorName}}</bdi>",
     "tags": "Tag",
     "verifiedOnly": "Creato da umani",
     "verifiedOnlyHint": "Mostra solo video con verifica ProofMode",

--- a/src/lib/i18n/locales/ja/common.json
+++ b/src/lib/i18n/locales/ja/common.json
@@ -70,7 +70,7 @@
     "hot": "人気",
     "new": "新着",
     "featured": "注目",
-    "paidPartnership": "<bdi>{{sponsorName}}</bdi>との有料パートナーシップ",
+    "sponsoredBy": "提供: <bdi>{{sponsorName}}</bdi>",
     "tags": "タグ",
     "verifiedOnly": "人が作成",
     "verifiedOnlyHint": "ProofMode 検証済みの動画のみ表示しています",

--- a/src/lib/i18n/locales/ko/common.json
+++ b/src/lib/i18n/locales/ko/common.json
@@ -70,7 +70,7 @@
     "hot": "인기",
     "new": "신규",
     "featured": "추천",
-    "paidPartnership": "<bdi>{{sponsorName}}</bdi>와의 유료 파트너십",
+    "sponsoredBy": "<bdi>{{sponsorName}}</bdi> 협찬",
     "tags": "태그",
     "verifiedOnly": "사람이 만든 콘텐츠",
     "verifiedOnlyHint": "ProofMode 검증이 있는 동영상만 표시합니다",

--- a/src/lib/i18n/locales/ms/common.json
+++ b/src/lib/i18n/locales/ms/common.json
@@ -70,7 +70,7 @@
     "hot": "Hangat",
     "new": "Baharu",
     "featured": "Pilihan",
-    "paidPartnership": "Perkongsian berbayar dengan <bdi>{{sponsorName}}</bdi>",
+    "sponsoredBy": "Ditaja oleh <bdi>{{sponsorName}}</bdi>",
     "tags": "Tag",
     "verifiedOnly": "Buatan Manusia",
     "verifiedOnlyHint": "Menunjukkan hanya video dengan pengesahan ProofMode",

--- a/src/lib/i18n/locales/nl/common.json
+++ b/src/lib/i18n/locales/nl/common.json
@@ -70,7 +70,7 @@
     "hot": "Heet",
     "new": "Nieuw",
     "featured": "Uitgelicht",
-    "paidPartnership": "Betaald partnerschap met <bdi>{{sponsorName}}</bdi>",
+    "sponsoredBy": "Gesponsord door <bdi>{{sponsorName}}</bdi>",
     "tags": "Tags",
     "verifiedOnly": "Door mensen gemaakt",
     "verifiedOnlyHint": "Toont alleen video's met ProofMode-verificatie",

--- a/src/lib/i18n/locales/pl/common.json
+++ b/src/lib/i18n/locales/pl/common.json
@@ -70,7 +70,7 @@
     "hot": "Gorace",
     "new": "Nowe",
     "featured": "Polecane",
-    "paidPartnership": "Płatna współpraca z <bdi>{{sponsorName}}</bdi>",
+    "sponsoredBy": "Sponsorowane przez <bdi>{{sponsorName}}</bdi>",
     "tags": "Tagi",
     "verifiedOnly": "Stworzone przez ludzi",
     "verifiedOnlyHint": "Pokazuje tylko filmy z weryfikacja ProofMode",

--- a/src/lib/i18n/locales/pt/common.json
+++ b/src/lib/i18n/locales/pt/common.json
@@ -70,7 +70,7 @@
     "hot": "Em alta",
     "new": "Novo",
     "featured": "Destaque",
-    "paidPartnership": "Parceria paga com <bdi>{{sponsorName}}</bdi>",
+    "sponsoredBy": "Patrocinado por <bdi>{{sponsorName}}</bdi>",
     "tags": "Tags",
     "verifiedOnly": "Feito por humanos",
     "verifiedOnlyHint": "Mostrando apenas videos com verificacao ProofMode",

--- a/src/lib/i18n/locales/ro/common.json
+++ b/src/lib/i18n/locales/ro/common.json
@@ -70,7 +70,7 @@
     "hot": "Popular",
     "new": "Nou",
     "featured": "Recomandat",
-    "paidPartnership": "Parteneriat plătit cu <bdi>{{sponsorName}}</bdi>",
+    "sponsoredBy": "Sponsorizat de <bdi>{{sponsorName}}</bdi>",
     "tags": "Etichete",
     "verifiedOnly": "Creat de oameni",
     "verifiedOnlyHint": "Afiseaza doar videoclipuri cu verificare ProofMode",

--- a/src/lib/i18n/locales/sv/common.json
+++ b/src/lib/i18n/locales/sv/common.json
@@ -70,7 +70,7 @@
     "hot": "Hett",
     "new": "Nytt",
     "featured": "Utvalt",
-    "paidPartnership": "Betalt partnerskap med <bdi>{{sponsorName}}</bdi>",
+    "sponsoredBy": "Sponsrat av <bdi>{{sponsorName}}</bdi>",
     "tags": "Taggar",
     "verifiedOnly": "Skapad av manniskor",
     "verifiedOnlyHint": "Visar endast videor med ProofMode-verifiering",

--- a/src/lib/i18n/locales/tr/common.json
+++ b/src/lib/i18n/locales/tr/common.json
@@ -70,7 +70,7 @@
     "hot": "Populer",
     "new": "Yeni",
     "featured": "Öne çıkan",
-    "paidPartnership": "<bdi>{{sponsorName}}</bdi> ile ücretli iş birliği",
+    "sponsoredBy": "<bdi>{{sponsorName}}</bdi> sponsorluğunda",
     "tags": "Etiketler",
     "verifiedOnly": "Insan yapimi",
     "verifiedOnlyHint": "Yalnizca ProofMode dogrulamali videolar gosteriliyor",

--- a/src/lib/i18n/locales/ur/common.json
+++ b/src/lib/i18n/locales/ur/common.json
@@ -70,7 +70,7 @@
     "hot": "ہاٹ",
     "new": "نئے",
     "featured": "نمایاں",
-    "paidPartnership": "<bdi>{{sponsorName}}</bdi> کے ساتھ بامعاوضہ شراکت داری",
+    "sponsoredBy": "<bdi>{{sponsorName}}</bdi> کی جانب سے اسپانسر شدہ",
     "tags": "ٹیگز",
     "verifiedOnly": "انسان کا بنایا",
     "verifiedOnlyHint": "صرف ProofMode تصدیق شدہ ویڈیوز دکھائی جا رہی ہیں",

--- a/src/lib/i18n/locales/vi/common.json
+++ b/src/lib/i18n/locales/vi/common.json
@@ -70,7 +70,7 @@
     "hot": "Hot",
     "new": "Mới",
     "featured": "Nổi bật",
-    "paidPartnership": "Hợp tác trả phí với <bdi>{{sponsorName}}</bdi>",
+    "sponsoredBy": "Được tài trợ bởi <bdi>{{sponsorName}}</bdi>",
     "tags": "Thẻ",
     "verifiedOnly": "Do con người tạo ra",
     "verifiedOnlyHint": "Chỉ hiển thị video có xác minh ProofMode",

--- a/src/lib/i18n/locales/zh/common.json
+++ b/src/lib/i18n/locales/zh/common.json
@@ -70,7 +70,7 @@
     "hot": "火爆",
     "new": "最新",
     "featured": "精选",
-    "paidPartnership": "与 <bdi>{{sponsorName}}</bdi> 的付费合作",
+    "sponsoredBy": "由 <bdi>{{sponsorName}}</bdi> 赞助",
     "tags": "标签",
     "verifiedOnly": "真人创作",
     "verifiedOnlyHint": "只显示通过 ProofMode 验证的视频",

--- a/src/pages/DiscoveryPage.test.tsx
+++ b/src/pages/DiscoveryPage.test.tsx
@@ -17,7 +17,7 @@ function getPartnershipDisclosure(text: string): HTMLElement {
 
 function queryPartnershipDisclosure(): HTMLElement | null {
   return screen.queryByText(
-    (_, element) => element?.textContent?.includes('colaboración pagada') ?? false,
+    (_, element) => element?.textContent?.includes('Patrocinado por') ?? false,
     { selector: 'span' },
   );
 }
@@ -376,7 +376,7 @@ describe('DiscoveryPage', () => {
     );
 
     expect(screen.getByTestId('video-feed-featured')).toHaveAttribute('data-featured-tab-id', 'ft_1234abcd');
-    const disclosure = getPartnershipDisclosure('En colaboración pagada con Acme Bikes');
+    const disclosure = getPartnershipDisclosure('Patrocinado por Acme Bikes');
     expect(disclosure).toBeInTheDocument();
     expect(disclosure.querySelector('bdi')).toHaveTextContent('Acme Bikes');
     expect(screen.getByRole('tab', { name: 'Destacado: Skate week' })).toHaveTextContent('Skate week');
@@ -406,7 +406,7 @@ describe('DiscoveryPage', () => {
       </MemoryRouter>,
     );
 
-    const disclosure = getPartnershipDisclosure('En colaboración pagada con Acme Bikes');
+    const disclosure = getPartnershipDisclosure('Patrocinado por Acme Bikes');
     expect(disclosure).toHaveClass('inline-block');
     expect(disclosure.className).not.toMatch(/(^|\s)(inline-)?flex(\s|$)/);
   });
@@ -451,7 +451,7 @@ describe('DiscoveryPage', () => {
         </MemoryRouter>,
       );
 
-      expect(getPartnershipDisclosure('En colaboración pagada con Acme Bikes')).toBeInTheDocument();
+      expect(getPartnershipDisclosure('Patrocinado por Acme Bikes')).toBeInTheDocument();
       expect(screen.getByText(feedState)).toBeInTheDocument();
     },
   );
@@ -475,7 +475,30 @@ describe('DiscoveryPage', () => {
       </MemoryRouter>,
     );
 
-    const disclosure = getPartnershipDisclosure('شراكة مدفوعة مع Acme Bikes');
+    const disclosure = getPartnershipDisclosure('برعاية Acme Bikes');
+    expect(disclosure.querySelector('bdi')).toHaveTextContent('Acme Bikes');
+  });
+
+  it('keeps the sponsor first with a separating space in Urdu', async () => {
+    window.localStorage.setItem(LOCALE_STORAGE_KEY, 'ur');
+    await initializeI18n({ force: true, languages: ['ur'] });
+    mockFeaturedTab.current = {
+      id: 'ft_1234abcd',
+      slug: 'seasonal-theme',
+      label: 'Especial',
+      pillLabel: null,
+      sponsorName: 'Acme Bikes',
+    };
+
+    render(
+      <MemoryRouter initialEntries={['/discovery/seasonal-theme']}>
+        <Routes>
+          <Route path="/discovery/:tab" element={<DiscoveryPage />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    const disclosure = getPartnershipDisclosure('Acme Bikes کی جانب سے اسپانسر شدہ');
     expect(disclosure.querySelector('bdi')).toHaveTextContent('Acme Bikes');
   });
 

--- a/src/pages/DiscoveryPage.tsx
+++ b/src/pages/DiscoveryPage.tsx
@@ -371,7 +371,7 @@ export function DiscoveryPage() {
                   <span className="inline-block max-w-full rounded-full border border-border bg-background px-3 py-1 text-center text-sm font-medium text-foreground">
                     {/* bdi keeps Latin sponsor names stable inside RTL disclosure copy. */}
                     <Trans
-                      i18nKey="discovery.paidPartnership"
+                      i18nKey="discovery.sponsoredBy"
                       values={{ sponsorName: activeTabItem.featuredTab.sponsorName }}
                       components={{ bdi: <bdi /> }}
                     />


### PR DESCRIPTION
## Summary

- Changes the featured collection disclosure from “In paid partnership with” to “Sponsored by” in every supported locale.
- Renames the translation key to match the new wording and adds regression coverage for sponsor-first Urdu ordering.
- Preserves the inline disclosure layout and bidirectional text isolation that keep sponsor-name spacing readable.

All 20 supported locales were updated; none were excluded.

## Motivation

Featured collections need the shorter sponsorship disclosure consistently across languages. Updating the key in every catalog makes an incomplete locale migration fail the existing locale-parity checks, while the focused component coverage protects both sponsor-last and sponsor-first sentence shapes.

This does not change featured collection eligibility, API data, feed behavior, or disclosure styling.

## Related Issue

- Closes #636

## Testing

- [x] `npx vitest run src/pages/DiscoveryPage.test.tsx` (26 tests)
- [x] `npx vitest run src/lib/i18n/locales.test.ts` (6 tests)
- [x] `npm test` (285 files, 2,321 tests; type-check, lint, and production build)
- [x] `npm run test:visual` (25 Playwright tests)

## Visuals

- [x] Copy-only UI change; exact Spanish, Arabic, and Urdu output and the existing inline-layout guard are covered by component tests.
- [x] Visuals and text avoid sensitive external brand or partner names.
