### PR TITLE
fix(logging): keep Nostr identifiers usable in diagnostics

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -312,6 +312,7 @@ Always deduplicate videos by `pubkey:kind:d-tag`, NOT by event ID. Different eve
 - API uses hex format (64 chars)
 - Users share bech32 (`npub1...`, `note1...`)
 - Always decode bech32 to hex before API calls
+- Log public Nostr identifiers such as event IDs, pubkeys, and npubs at full length. Never log secrets such as nsecs, ncryptsecs, or raw private/signing keys, even partially.
 
 ### Profile Data
 Funnelcake profile response is nested:

--- a/src/components/VideoCard.tsx
+++ b/src/components/VideoCard.tsx
@@ -170,7 +170,7 @@ export function VideoCard({
 
   // Log once per video mount to trace aspect ratio decisions
   useMemo(() => {
-    debugLog(`[AspectRatio] video=${video.id?.slice(0, 8)} isClassicVine=${isClassicVine}`,
+    debugLog(`[AspectRatio] video=${video.id} isClassicVine=${isClassicVine}`,
       `loopCount=${video.loopCount} isVineMigrated=${video.isVineMigrated}`,
       `dimensions=${video.dimensions} vineTimestamp=${video.originalVineTimestamp}`);
   }, [video.id, isClassicVine, video.loopCount, video.isVineMigrated, video.dimensions, video.originalVineTimestamp]);
@@ -205,7 +205,7 @@ export function VideoCard({
   // unlike HLS streams which may be transcoded to different dimensions.
   const handleThumbnailDimensions = useCallback((d: { width: number; height: number }) => {
     const newRatio = d.width / d.height;
-    console.log(`[AspectRatio] THUMBNAIL video=${video.id?.slice(0, 8)} dims=${d.width}x${d.height} ratio=${newRatio.toFixed(3)} isClassicVine=${isClassicVine} → ${isClassicVine ? 'IGNORED (classic vine)' : 'APPLIED'}`);
+    debugLog(`[AspectRatio] THUMBNAIL video=${video.id} dims=${d.width}x${d.height} ratio=${newRatio.toFixed(3)} isClassicVine=${isClassicVine} → ${isClassicVine ? 'IGNORED (classic vine)' : 'APPLIED'}`);
     if (isClassicVine) return; // Classic Vines locked to 1:1
     thumbnailRatioRef.current = newRatio;
     setVideoAspectRatio(newRatio);
@@ -219,7 +219,7 @@ export function VideoCard({
     const thumbRatio = thumbnailRatioRef.current;
 
     if (isClassicVine) {
-      console.log(`[AspectRatio] VIDEO video=${video.id?.slice(0, 8)} dims=${d.width}x${d.height} ratio=${newRatio.toFixed(3)} → IGNORED (classic vine, forcing 1:1)`);
+      debugLog(`[AspectRatio] VIDEO video=${video.id} dims=${d.width}x${d.height} ratio=${newRatio.toFixed(3)} → IGNORED (classic vine, forcing 1:1)`);
       return;
     }
 
@@ -227,7 +227,7 @@ export function VideoCard({
     if (thumbRatio !== null) {
       const ratioChange = Math.abs(newRatio - thumbRatio) / thumbRatio;
       if (ratioChange > 0.1) {
-        console.log(`[AspectRatio] VIDEO video=${video.id?.slice(0, 8)} dims=${d.width}x${d.height} ratio=${newRatio.toFixed(3)} → IGNORED (${(ratioChange * 100).toFixed(0)}% off thumbnail=${thumbRatio.toFixed(3)})`);
+        debugLog(`[AspectRatio] VIDEO video=${video.id} dims=${d.width}x${d.height} ratio=${newRatio.toFixed(3)} → IGNORED (${(ratioChange * 100).toFixed(0)}% off thumbnail=${thumbRatio.toFixed(3)})`);
         return; // >10% difference = HLS distortion, ignore
       }
     }
@@ -237,12 +237,12 @@ export function VideoCard({
       const isNewLandscape = newRatio > 1.1;
       // Don't let HLS flip a video with declared portrait/square dimensions to landscape
       if (isInitialPortraitOrSquare && isNewLandscape) {
-        console.log(`[AspectRatio] VIDEO video=${video.id?.slice(0, 8)} dims=${d.width}x${d.height} ratio=${newRatio.toFixed(3)} → IGNORED (declared ${initialAspectRatio.toFixed(3)} but HLS says landscape)`);
+        debugLog(`[AspectRatio] VIDEO video=${video.id} dims=${d.width}x${d.height} ratio=${newRatio.toFixed(3)} → IGNORED (declared ${initialAspectRatio.toFixed(3)} but HLS says landscape)`);
         return;
       }
     }
 
-    console.log(`[AspectRatio] VIDEO video=${video.id?.slice(0, 8)} dims=${d.width}x${d.height} ratio=${newRatio.toFixed(3)} → APPLIED (was ${videoAspectRatio.toFixed(3)})`);
+    debugLog(`[AspectRatio] VIDEO video=${video.id} dims=${d.width}x${d.height} ratio=${newRatio.toFixed(3)} → APPLIED (was ${videoAspectRatio.toFixed(3)})`);
     setVideoAspectRatio(newRatio);
   }, [initialAspectRatio, hasDeclaredDimensions, isClassicVine, video.id, videoAspectRatio]);
   const _isMobile = useIsMobile();

--- a/src/hooks/useAuthor.ts
+++ b/src/hooks/useAuthor.ts
@@ -64,7 +64,7 @@ export function useAuthor(pubkey: string | undefined, options?: UseAuthorOptions
       // Try Funnelcake REST API first (fast, ~50ms)
       if (isFunnelcakeAvailable(apiUrl)) {
         try {
-          debugLog(`[useAuthor] REST fetch for ${pubkey.slice(0, 8)}...`);
+          debugLog(`[useAuthor] REST fetch for ${pubkey}...`);
           const profile = await fetchUserProfile(apiUrl, pubkey, signal);
 
           if (profile) {
@@ -78,7 +78,7 @@ export function useAuthor(pubkey: string | undefined, options?: UseAuthorOptions
               lud16: profile.lud16,
               website: profile.website,
             };
-            debugLog(`[useAuthor] REST got profile for ${pubkey.slice(0, 8)}...`);
+            debugLog(`[useAuthor] REST got profile for ${pubkey}...`);
             return { metadata };
           }
 
@@ -89,7 +89,7 @@ export function useAuthor(pubkey: string | undefined, options?: UseAuthorOptions
           if (isAbortError(err)) {
             throw err;
           }
-          debugLog(`[useAuthor] REST failed for ${pubkey.slice(0, 8)}, falling back to WebSocket:`, err);
+          debugLog(`[useAuthor] REST failed for ${pubkey}, falling back to WebSocket:`, err);
           reportFallback(err instanceof Error ? err.message : String(err));
         }
       } else {
@@ -97,7 +97,7 @@ export function useAuthor(pubkey: string | undefined, options?: UseAuthorOptions
       }
 
       // WebSocket fallback (slow, can take seconds)
-      debugLog(`[useAuthor] WebSocket fetch for ${pubkey.slice(0, 8)}...`);
+      debugLog(`[useAuthor] WebSocket fetch for ${pubkey}...`);
 
       const events = await nostr.query(
         [{ kinds: [0], authors: [pubkey!], limit: 5 }],
@@ -105,14 +105,14 @@ export function useAuthor(pubkey: string | undefined, options?: UseAuthorOptions
       );
 
       if (events.length === 0) {
-        debugLog(`[useAuthor] No profile found for ${pubkey.slice(0, 8)}...`);
+        debugLog(`[useAuthor] No profile found for ${pubkey}...`);
         return {};
       }
 
       // Take the most recent event (kind 0 is replaceable)
       const event = events.sort((a, b) => b.created_at - a.created_at)[0];
 
-      debugLog(`[useAuthor] WebSocket got profile for ${pubkey.slice(0, 8)}...`);
+      debugLog(`[useAuthor] WebSocket got profile for ${pubkey}...`);
 
       // Also add to event cache for future synchronous access
       eventCache.event(event).catch(() => {

--- a/src/hooks/useAuthor.ts
+++ b/src/hooks/useAuthor.ts
@@ -64,7 +64,7 @@ export function useAuthor(pubkey: string | undefined, options?: UseAuthorOptions
       // Try Funnelcake REST API first (fast, ~50ms)
       if (isFunnelcakeAvailable(apiUrl)) {
         try {
-          debugLog(`[useAuthor] REST fetch for ${pubkey}...`);
+          debugLog(`[useAuthor] REST fetch for ${pubkey}`);
           const profile = await fetchUserProfile(apiUrl, pubkey, signal);
 
           if (profile) {
@@ -78,7 +78,7 @@ export function useAuthor(pubkey: string | undefined, options?: UseAuthorOptions
               lud16: profile.lud16,
               website: profile.website,
             };
-            debugLog(`[useAuthor] REST got profile for ${pubkey}...`);
+            debugLog(`[useAuthor] REST got profile for ${pubkey}`);
             return { metadata };
           }
 
@@ -97,7 +97,7 @@ export function useAuthor(pubkey: string | undefined, options?: UseAuthorOptions
       }
 
       // WebSocket fallback (slow, can take seconds)
-      debugLog(`[useAuthor] WebSocket fetch for ${pubkey}...`);
+      debugLog(`[useAuthor] WebSocket fetch for ${pubkey}`);
 
       const events = await nostr.query(
         [{ kinds: [0], authors: [pubkey!], limit: 5 }],
@@ -105,14 +105,14 @@ export function useAuthor(pubkey: string | undefined, options?: UseAuthorOptions
       );
 
       if (events.length === 0) {
-        debugLog(`[useAuthor] No profile found for ${pubkey}...`);
+        debugLog(`[useAuthor] No profile found for ${pubkey}`);
         return {};
       }
 
       // Take the most recent event (kind 0 is replaceable)
       const event = events.sort((a, b) => b.created_at - a.created_at)[0];
 
-      debugLog(`[useAuthor] WebSocket got profile for ${pubkey}...`);
+      debugLog(`[useAuthor] WebSocket got profile for ${pubkey}`);
 
       // Also add to event cache for future synchronous access
       eventCache.event(event).catch(() => {

--- a/src/hooks/useInfiniteVideos.ts
+++ b/src/hooks/useInfiniteVideos.ts
@@ -214,7 +214,7 @@ export function useInfiniteVideos({
             events.slice(0, 3).map(e => ({
               created_at: e.created_at,
               date: new Date(e.created_at * 1000).toISOString(),
-              id: e.id.substring(0, 8)
+              id: e.id
             }))
           );
         }

--- a/src/lib/analytics.tracking.test.ts
+++ b/src/lib/analytics.tracking.test.ts
@@ -4,6 +4,7 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 
 const mockLogEvent = vi.fn();
+const mockSetUserId = vi.fn();
 
 vi.mock('firebase/app', () => ({
   initializeApp: vi.fn(() => ({})),
@@ -12,7 +13,7 @@ vi.mock('firebase/app', () => ({
 vi.mock('firebase/analytics', () => ({
   getAnalytics: vi.fn(() => ({})),
   logEvent: (...args: unknown[]) => mockLogEvent(...args),
-  setUserId: vi.fn(),
+  setUserId: (...args: unknown[]) => mockSetUserId(...args),
   setAnalyticsCollectionEnabled: vi.fn(),
 }));
 
@@ -83,5 +84,25 @@ describe('trackNonFatalError console echo', () => {
       }
       spy.mockRestore();
     }
+  });
+});
+
+describe('setAnalyticsUserId', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+  });
+
+  it('uses the full public key for analytics and local diagnostics', async () => {
+    const publicKey = '1'.repeat(64);
+    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    const mod = await loadEnabledAnalytics();
+
+    mod.setAnalyticsUserId(publicKey);
+
+    expect(mockSetUserId).toHaveBeenCalledWith(expect.anything(), publicKey);
+    expect(log).toHaveBeenCalledWith('[Analytics] User ID set:', publicKey);
+    expect(log).not.toHaveBeenCalledWith('[Analytics] User ID set:', expect.stringContaining('...'));
+    log.mockRestore();
   });
 });

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -4,6 +4,9 @@
 import { initializeApp, type FirebaseApp } from 'firebase/app';
 import { getAnalytics, logEvent, setUserId, setAnalyticsCollectionEnabled, type Analytics } from 'firebase/analytics';
 import { getPerformance, trace, type FirebasePerformance } from 'firebase/performance';
+
+import { debugLog } from '@/lib/debug';
+
 import { onAnalyticsConsentChanged } from './cookieConsent';
 
 // Sim-suppression hard block. Set by divine-brain's virtual-persona
@@ -172,7 +175,7 @@ export function setAnalyticsUserId(userId: string | null) {
   try {
     if (userId) {
       setUserId(analytics, userId);
-      console.log('[Analytics] User ID set:', userId.substring(0, 8) + '...');
+      debugLog('[Analytics] User ID set:', userId);
     } else {
       setUserId(analytics, null);
       console.log('[Analytics] User ID cleared');

--- a/tests/nostr-id-log-truncation.test.ts
+++ b/tests/nostr-id-log-truncation.test.ts
@@ -40,9 +40,36 @@ function isIdentifierShortening(node: ts.Node): node is ts.CallExpression {
   return IDENTIFIER_NAME.test(node.expression.expression.getText());
 }
 
+/**
+ * An identifier only stands for a variable in some positions. In `video.id` and
+ * `{ id: value }` the `id` names a property, so matching it against local
+ * variables would blame an unrelated `const id` elsewhere in the file.
+ */
+function isValueReference(node: ts.Identifier): boolean {
+  const parent = node.parent;
+  if (!parent) return true;
+  if (ts.isPropertyAccessExpression(parent) && parent.name === node) return false;
+  if (ts.isQualifiedName(parent) && parent.right === node) return false;
+  if (ts.isPropertyAssignment(parent) && parent.name === node) return false;
+  if (ts.isBindingElement(parent) && parent.propertyName === node) return false;
+  if (ts.isJsxAttribute(parent) && parent.name === node) return false;
+  return true;
+}
+
+/** Nodes that hold their own `const`/`let` bindings. */
+function isScope(node: ts.Node): boolean {
+  return ts.isSourceFile(node)
+    || ts.isBlock(node)
+    || ts.isModuleBlock(node)
+    || ts.isCaseBlock(node)
+    || ts.isForStatement(node)
+    || ts.isForInStatement(node)
+    || ts.isForOfStatement(node);
+}
+
 export function findNostrIdLogTruncations(file: string, source: string): Violation[] {
   const sourceFile = ts.createSourceFile(file, source, ts.ScriptTarget.Latest, true, ts.ScriptKind.TSX);
-  const shortenedLocals = new Map<string, ts.CallExpression>();
+  const shortenedLocals = new Map<ts.Node, Map<string, ts.CallExpression>>();
   const violations = new Map<number, Violation>();
 
   const record = (node: ts.Node) => {
@@ -54,10 +81,31 @@ export function findNostrIdLogTruncations(file: string, source: string): Violati
     });
   };
 
+  const enclosingScope = (node: ts.Node): ts.Node => {
+    for (let current = node.parent; current; current = current.parent) {
+      if (isScope(current)) return current;
+    }
+    return sourceFile;
+  };
+
+  const resolveShortening = (node: ts.Identifier): ts.CallExpression | undefined => {
+    for (let current: ts.Node | undefined = node; current; current = current.parent) {
+      if (!isScope(current)) continue;
+      const shortening = shortenedLocals.get(current)?.get(node.text);
+      if (shortening) return shortening;
+    }
+    return undefined;
+  };
+
   const collectLocals = (node: ts.Node) => {
     if (ts.isVariableDeclaration(node) && ts.isIdentifier(node.name) && node.initializer) {
       const visitInitializer = (candidate: ts.Node) => {
-        if (isIdentifierShortening(candidate)) shortenedLocals.set(node.name.text, candidate);
+        if (isIdentifierShortening(candidate)) {
+          const scope = enclosingScope(node);
+          const locals = shortenedLocals.get(scope) ?? new Map<string, ts.CallExpression>();
+          locals.set(node.name.text, candidate);
+          shortenedLocals.set(scope, locals);
+        }
         ts.forEachChild(candidate, visitInitializer);
       };
       visitInitializer(node.initializer);
@@ -67,8 +115,8 @@ export function findNostrIdLogTruncations(file: string, source: string): Violati
 
   const inspectLogArgument = (node: ts.Node) => {
     if (isIdentifierShortening(node)) record(node);
-    if (ts.isIdentifier(node)) {
-      const shortening = shortenedLocals.get(node.text);
+    if (ts.isIdentifier(node) && isValueReference(node)) {
+      const shortening = resolveShortening(node);
       if (shortening) record(shortening);
     }
     ts.forEachChild(node, inspectLogArgument);
@@ -106,11 +154,49 @@ describe('Nostr identifier logging', () => {
     expect(findNostrIdLogTruncations('synthetic.ts', source)).toHaveLength(1);
   });
 
+  it('detects a shortened identifier logged from an inner scope', () => {
+    const source = `
+      const preview = pubkey.slice(0, 8);
+      function report() {
+        debugLog('author', preview);
+      }
+    `;
+
+    expect(findNostrIdLogTruncations('synthetic.ts', source)).toHaveLength(1);
+  });
+
   it('allows UI truncation, list sampling, and full identifier logs', () => {
     const source = `
       const label = event.id.slice(0, 8);
       const sample = pubkeys.slice(0, 5);
       debugLog(event.id, sample);
+    `;
+
+    expect(findNostrIdLogTruncations('synthetic.ts', source)).toEqual([]);
+  });
+
+  it('does not blame a UI truncation for a property that happens to share its name', () => {
+    const source = `
+      const id = event.id.slice(0, 8);
+      const pubkey = author.pubkey.slice(0, 8);
+      debugLog(video.id, event.pubkey);
+      debugLog(\`ev=\${video.id}\`);
+      debugLog({ id: video.id });
+    `;
+
+    expect(findNostrIdLogTruncations('synthetic.ts', source)).toEqual([]);
+  });
+
+  it('does not blame a UI truncation for a same-named variable in another scope', () => {
+    const source = `
+      function Badge({ event }) {
+        const label = event.id.slice(0, 8);
+        return label;
+      }
+      function announce(text) {
+        const label = text.toUpperCase();
+        debugLog('label', label);
+      }
     `;
 
     expect(findNostrIdLogTruncations('synthetic.ts', source)).toEqual([]);

--- a/tests/nostr-id-log-truncation.test.ts
+++ b/tests/nostr-id-log-truncation.test.ts
@@ -1,0 +1,126 @@
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { extname, join } from 'node:path';
+import ts from 'typescript';
+import { describe, expect, it } from 'vitest';
+
+const LOG_FUNCTIONS = new Set([
+  'debugError',
+  'debugLog',
+  'debugWarn',
+  'verboseLog',
+]);
+const IDENTIFIER_NAME = /(?:^|[._])(?:id|npub|pubkey)$|(?:Id|ID|Npub|Pubkey)$/;
+
+type Violation = {
+  column: number;
+  file: string;
+  line: number;
+};
+
+function walk(dir: string, out: string[] = []): string[] {
+  for (const name of readdirSync(dir)) {
+    const path = join(dir, name);
+    if (statSync(path).isDirectory()) walk(path, out);
+    else if (['.ts', '.tsx'].includes(extname(path))) out.push(path);
+  }
+  return out;
+}
+
+function isLogCall(node: ts.CallExpression): boolean {
+  if (ts.isIdentifier(node.expression)) return LOG_FUNCTIONS.has(node.expression.text);
+  return ts.isPropertyAccessExpression(node.expression)
+    && ts.isIdentifier(node.expression.expression)
+    && node.expression.expression.text === 'console';
+}
+
+function isIdentifierShortening(node: ts.Node): node is ts.CallExpression {
+  if (!ts.isCallExpression(node) || !ts.isPropertyAccessExpression(node.expression)) return false;
+  if (!['slice', 'substring'].includes(node.expression.name.text)) return false;
+  if (node.arguments.length < 2 || node.arguments[0].getText() !== '0') return false;
+  return IDENTIFIER_NAME.test(node.expression.expression.getText());
+}
+
+export function findNostrIdLogTruncations(file: string, source: string): Violation[] {
+  const sourceFile = ts.createSourceFile(file, source, ts.ScriptTarget.Latest, true, ts.ScriptKind.TSX);
+  const shortenedLocals = new Map<string, ts.CallExpression>();
+  const violations = new Map<number, Violation>();
+
+  const record = (node: ts.Node) => {
+    const position = sourceFile.getLineAndCharacterOfPosition(node.getStart(sourceFile));
+    violations.set(node.getStart(sourceFile), {
+      file,
+      line: position.line + 1,
+      column: position.character + 1,
+    });
+  };
+
+  const collectLocals = (node: ts.Node) => {
+    if (ts.isVariableDeclaration(node) && ts.isIdentifier(node.name) && node.initializer) {
+      const visitInitializer = (candidate: ts.Node) => {
+        if (isIdentifierShortening(candidate)) shortenedLocals.set(node.name.text, candidate);
+        ts.forEachChild(candidate, visitInitializer);
+      };
+      visitInitializer(node.initializer);
+    }
+    ts.forEachChild(node, collectLocals);
+  };
+
+  const inspectLogArgument = (node: ts.Node) => {
+    if (isIdentifierShortening(node)) record(node);
+    if (ts.isIdentifier(node)) {
+      const shortening = shortenedLocals.get(node.text);
+      if (shortening) record(shortening);
+    }
+    ts.forEachChild(node, inspectLogArgument);
+  };
+
+  const inspectLogs = (node: ts.Node) => {
+    if (ts.isCallExpression(node) && isLogCall(node)) {
+      node.arguments.forEach(inspectLogArgument);
+      return;
+    }
+    ts.forEachChild(node, inspectLogs);
+  };
+
+  collectLocals(sourceFile);
+  inspectLogs(sourceFile);
+  return [...violations.values()];
+}
+
+describe('Nostr identifier logging', () => {
+  it('detects direct and nested truncation in log arguments', () => {
+    const source = `
+      debugLog(event.id.slice(0, 8));
+      console.log(events.map((event) => ({ id: event.id.substring(0, 12) })));
+    `;
+
+    expect(findNostrIdLogTruncations('synthetic.ts', source)).toHaveLength(2);
+  });
+
+  it('detects a shortened identifier assigned before logging', () => {
+    const source = `
+      const preview = pubkey.slice(0, 8);
+      debugLog('author', preview);
+    `;
+
+    expect(findNostrIdLogTruncations('synthetic.ts', source)).toHaveLength(1);
+  });
+
+  it('allows UI truncation, list sampling, and full identifier logs', () => {
+    const source = `
+      const label = event.id.slice(0, 8);
+      const sample = pubkeys.slice(0, 5);
+      debugLog(event.id, sample);
+    `;
+
+    expect(findNostrIdLogTruncations('synthetic.ts', source)).toEqual([]);
+  });
+
+  it('keeps source logging free of shortened Nostr identifiers', () => {
+    const violations = walk('src').flatMap((file) =>
+      findNostrIdLogTruncations(file, readFileSync(file, 'utf8')),
+    );
+
+    expect(violations).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

- Preserve complete public Nostr event IDs and pubkeys in diagnostic output so relay and API activity can be correlated reliably.
- Gate noisy aspect-ratio and analytics identity console echoes behind the existing localhost-only debug logger.
- Add a TypeScript-parser guard that rejects direct and one-hop local identifier truncation in source logging, plus an explicit rule that secret signing material must never be logged.

> Avoid naming corporate partners, customers, or other sensitive external brands in this PR title or body. Use generic descriptors unless a maintainer explicitly approves the public reference.

## Motivation

- Fourteen diagnostics discarded most of an event ID or pubkey immediately before logging it, leaving values that could not be used in exact Nostr queries or matched across services.
- Full public identifiers remain limited to deliberately scoped runtime diagnostics. Tests use synthetic values, and no observed user identifiers are added to repository or GitHub artifacts.
- Analytics already passed the complete pubkey to Firebase; this PR changes only the accompanying browser-console echo and limits it to local debugging. UI abbreviations and the support-widget display name are intentionally unchanged.

## Related Issue

- Closes #638

## Testing

- [x] `npm run test`
- [x] Manual verification completed: confirmed the guard failed on all 14 original sites, passed after remediation, and detects planted direct, nested, and one-hop local violations.

## Visuals

- [ ] UI change with screenshots/video attached
- [x] No visual change
- [x] Visuals and text avoid sensitive external brand or partner names unless explicitly approved