### PR TITLE
feat(download): send visitors to the right mobile app store

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -80,6 +80,9 @@ routing resolves user profiles (e.g., `alice.divine.video/`) by reading the
 subdomain and loading the corresponding Nostr profile. Static hosts use
 `404.html` (copied from [`index.html`](./index.html) during build) as a
 catch-all fallback.
+The public `/download` marketing route detects the visitor's mobile platform
+in the browser and presents the matching app-store link without automatically
+redirecting; unknown and desktop platforms receive every store choice.
 The retired `/discovery/new` chronological feed redirects to
 `/discovery/hot`; Discovery does not expose or mount an all-new-video feed.
 `/discovery/:tab` accepts the built-in Discovery tabs plus the currently

--- a/compute-js/src/crawlerHandlers.js
+++ b/compute-js/src/crawlerHandlers.js
@@ -10,6 +10,28 @@ const FUNNELCAKE_API_URL = 'https://relay.divine.video';
 const DEFAULT_OG_IMAGE = 'https://divine.video/og.png';
 const DEFAULT_SITE_DESCRIPTION = 'Watch and share 6-second looping videos on the decentralized Nostr network.';
 
+export function handleDownloadOgTags(url, hostnameToUse) {
+  const html = buildCrawlerHtml({
+    title: 'Download Divine',
+    description: 'Get Divine from the App Store, Google Play, or ZapStore.',
+    image: DEFAULT_OG_IMAGE,
+    url: `https://${hostnameToUse}${url.pathname}`,
+    ogType: 'website',
+    twitterCard: 'summary_large_image',
+    imageWidth: 1200,
+    imageHeight: 630,
+  });
+
+  return new Response(html, {
+    status: 200,
+    headers: {
+      'Content-Type': 'text/html; charset=utf-8',
+      'Cache-Control': 'public, max-age=300',
+      'Vary': 'User-Agent',
+    },
+  });
+}
+
 /**
  * Fetch video metadata from Funnelcake API using Fastly backend
  */

--- a/compute-js/src/crawlerHandlers.js
+++ b/compute-js/src/crawlerHandlers.js
@@ -13,7 +13,7 @@ const DEFAULT_SITE_DESCRIPTION = 'Watch and share 6-second looping videos on the
 export function handleDownloadOgTags(url, hostnameToUse) {
   const html = buildCrawlerHtml({
     title: 'Download Divine',
-    description: 'Get Divine from the App Store, Google Play, or ZapStore.',
+    description: 'Get Divine from the App Store, Google Play, or Zapstore.',
     image: DEFAULT_OG_IMAGE,
     url: `https://${hostnameToUse}${url.pathname}`,
     ogType: 'website',

--- a/compute-js/src/crawlerHandlers.test.ts
+++ b/compute-js/src/crawlerHandlers.test.ts
@@ -29,7 +29,7 @@ describe('handleDownloadOgTags', () => {
     const html = await result!.text();
 
     expect(html).toContain('<title>Download Divine</title>');
-    expect(html).toContain('App Store, Google Play, or ZapStore');
+    expect(html).toContain('App Store, Google Play, or Zapstore');
     expect(html).toContain('https://divine.video/download');
     expect(html).toContain('https://divine.video/og.png');
   });

--- a/compute-js/src/crawlerHandlers.test.ts
+++ b/compute-js/src/crawlerHandlers.test.ts
@@ -19,9 +19,21 @@ vi.mock('fastly:kv-store', () => {
   return { KVStore: MockKVStore };
 });
 
-import { handleAtUsernameOg, handleHashtagOgTags, handleSearchOgTags, handleDiscoveryOgTags, handleApexOgTags } from './crawlerHandlers.js';
+import { handleAtUsernameOg, handleDownloadOgTags, handleHashtagOgTags, handleSearchOgTags, handleDiscoveryOgTags, handleApexOgTags } from './crawlerHandlers.js';
 
 const HEX64 = '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef';
+
+describe('handleDownloadOgTags', () => {
+  it('builds canonical download-page metadata', async () => {
+    const result = handleDownloadOgTags(new URL('https://divine.video/download'), 'divine.video');
+    const html = await result!.text();
+
+    expect(html).toContain('<title>Download Divine</title>');
+    expect(html).toContain('App Store, Google Play, or ZapStore');
+    expect(html).toContain('https://divine.video/download');
+    expect(html).toContain('https://divine.video/og.png');
+  });
+});
 
 describe('handleApexOgTags', () => {
   beforeEach(() => {

--- a/compute-js/src/index.js
+++ b/compute-js/src/index.js
@@ -20,6 +20,7 @@ import {
   handleHashtagOgTags,
   handleSearchOgTags,
   handleDiscoveryOgTags,
+  handleDownloadOgTags,
   handleApexOgTags,
 } from './crawlerHandlers.js';
 import { transformVideoApiResponse } from './videoMetadata.js';
@@ -303,6 +304,14 @@ async function handleRequest(event) {
     // Kids policy page at /kids on apex.
     if (url.pathname === '/kids') {
       const ogResponse = handleKidsPolicyOgTags(url, hostnameToUse);
+      if (ogResponse) {
+        return ogResponse;
+      }
+    }
+
+    // Device-aware app download page at /download on apex.
+    if (url.pathname === '/download') {
+      const ogResponse = handleDownloadOgTags(url, hostnameToUse);
       if (ogResponse) {
         return ogResponse;
       }

--- a/functions/[[path]].test.ts
+++ b/functions/[[path]].test.ts
@@ -245,7 +245,7 @@ describe('functions/[[path]]', () => {
     expect(response.status).toBe(200);
     expect(html).toContain('<title>Download Divine</title>');
     expect(html).toContain('property="og:url" content="https://divine.video/download"');
-    expect(html).toContain('App Store, Google Play, or ZapStore');
+    expect(html).toContain('App Store, Google Play, or Zapstore');
   });
 
   it('injects category metadata for category routes', async () => {

--- a/functions/[[path]].test.ts
+++ b/functions/[[path]].test.ts
@@ -233,6 +233,21 @@ describe('functions/[[path]]', () => {
     expect(html).toContain('name="twitter:title" content="Kids on Divine');
   });
 
+  it('injects download metadata for /download on apex', async () => {
+    const response = await onRequest({
+      request: new Request('https://divine.video/download'),
+      next: async () => new Response('not found', { status: 404 }),
+      env: {},
+    });
+
+    const html = await response.text();
+
+    expect(response.status).toBe(200);
+    expect(html).toContain('<title>Download Divine</title>');
+    expect(html).toContain('property="og:url" content="https://divine.video/download"');
+    expect(html).toContain('App Store, Google Play, or ZapStore');
+  });
+
   it('injects category metadata for category routes', async () => {
     const response = await onRequest({
       request: new Request('https://divine.video/category/dance'),

--- a/functions/[[path]].ts
+++ b/functions/[[path]].ts
@@ -5,6 +5,7 @@ import {
   buildAgeReviewPageMeta,
   buildCategoriesIndexMeta,
   buildCategoryPageMeta,
+  buildDownloadPageMeta,
   buildFamilyPageMeta,
   buildKidsPolicyPageMeta,
   buildProfilePageMeta,
@@ -221,6 +222,10 @@ async function fetchRouteMeta(url: URL): Promise<PageMeta | null> {
   // Kids policy page at /kids on apex.
   if (url.pathname === '/kids') {
     return buildKidsPolicyPageMeta(url);
+  }
+
+  if (url.pathname === '/download') {
+    return buildDownloadPageMeta(url);
   }
 
   return null;

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -48,6 +48,12 @@
     <priority>0.6</priority>
   </url>
   <url>
+    <loc>https://divine.video/download</loc>
+    <lastmod>2026-08-21</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
     <loc>https://divine.video/delete-account</loc>
     <lastmod>2026-08-15</lastmod>
     <changefreq>monthly</changefreq>

--- a/src/AppRouter.test.tsx
+++ b/src/AppRouter.test.tsx
@@ -105,6 +105,15 @@ describe('AppRouter', () => {
     expect(screen.queryByTestId('nip19-page')).not.toBeInTheDocument();
   });
 
+  it('routes the public download page outside the app shell', () => {
+    window.history.pushState({}, '', '/download');
+
+    renderRouter();
+
+    expect(screen.getByRole('heading', { name: 'Get Divine' })).toBeInTheDocument();
+    expect(screen.queryByTestId('nip19-page')).not.toBeInTheDocument();
+  });
+
   it('redirects the legacy account portability docs path to /exit', async () => {
     window.history.pushState({}, '', '/account-portability');
 

--- a/src/AppRouter.tsx
+++ b/src/AppRouter.tsx
@@ -52,6 +52,7 @@ import { SafetyToolsPage } from "./pages/family/SafetyToolsPage";
 import { AgeReviewPage } from "./pages/AgeReviewPage";
 import { KidsPolicyPage } from "./pages/KidsPolicyPage";
 import { PortabilityPage } from "./pages/PortabilityPage";
+import { DownloadPage } from "./pages/DownloadPage";
 import { ExitStartPage } from "./pages/ExitStartPage";
 import { DeleteAccountPage } from "./pages/DeleteAccountPage";
 import { Support } from "./pages/Support";
@@ -178,6 +179,7 @@ export function AppRouter() {
         <Route path="/family/safety-tools" element={<SafetyToolsPage />} />
         <Route path="/age-review" element={<AgeReviewPage />} />
         <Route path="/kids" element={<KidsPolicyPage />} />
+        <Route path="/download" element={<DownloadPage />} />
         <Route path="/exit" element={<PortabilityPage />} />
         <Route path="/exit/start" element={<ExitStartPage />} />
         <Route path="/account-portability" element={<Navigate to="/exit" replace />} />

--- a/src/components/AppFooter.test.tsx
+++ b/src/components/AppFooter.test.tsx
@@ -62,4 +62,15 @@ describe('AppFooter', () => {
       '/merch',
     );
   });
+
+  it('describes public availability without asking for an invite code', () => {
+    render(
+      <MemoryRouter>
+        <AppFooter />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByText(/Divine is live in the app stores/)).toBeInTheDocument();
+    expect(screen.queryByText(/invite code/i)).not.toBeInTheDocument();
+  });
 });

--- a/src/components/AppFooter.tsx
+++ b/src/components/AppFooter.tsx
@@ -16,7 +16,7 @@ export function AppFooter() {
             <div className="flex flex-col gap-2 lg:max-w-md">
               <div className="text-sm font-semibold text-brand-green">Divine Inspiration</div>
               <p className="text-sm text-brand-off-white mb-2">
-                Divine is now live in the app stores with invite codes. If you'd like to receive a code and hear our news, sign up here.
+                Divine is live in the app stores. Sign up here to hear what&apos;s next.
               </p>
               <HubSpotSignup />
             </div>

--- a/src/components/PWAInstallPrompt.tsx
+++ b/src/components/PWAInstallPrompt.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { useLocation } from 'react-router-dom';
 import { DownloadSimple as Download, X } from '@phosphor-icons/react';
 import { Button } from '@/components/ui/button';
-import { APP_STORE_URL, PLAY_STORE_URL } from '@/lib/mobileStoreLinks';
+import { APP_STORE_URL, detectMobilePlatform, PLAY_STORE_URL } from '@/lib/mobileStoreLinks';
 
 interface NavigatorWithStandalone extends Navigator {
   standalone?: boolean;
@@ -13,14 +13,13 @@ export function PWAInstallPrompt({ delayMs = 10000 }: { delayMs?: number } = {})
   const { t } = useTranslation();
   const location = useLocation();
   const [showPrompt, setShowPrompt] = useState(false);
-  const [isIOS, setIsIOS] = useState(false);
-  const [isAndroid, setIsAndroid] = useState(false);
+  const [platform] = useState(() => detectMobilePlatform(window.navigator.userAgent));
   const [isStandalone, setIsStandalone] = useState(false);
   const [isMobile, setIsMobile] = useState(false);
   const [hasLeftLanding, setHasLeftLanding] = useState(false);
 
-  const showAppStore = !isAndroid;
-  const showGooglePlay = !isIOS;
+  const showAppStore = platform !== 'android';
+  const showGooglePlay = platform !== 'ios';
 
   // Track when user leaves the landing page
   useEffect(() => {
@@ -56,16 +55,6 @@ export function PWAInstallPrompt({ delayMs = 10000 }: { delayMs?: number } = {})
     };
 
     checkStandalone();
-
-    // Check if iOS
-    const checkIOS = () => {
-      const userAgent = window.navigator.userAgent.toLowerCase();
-      const isIOSDevice = /iphone|ipad|ipod/.test(userAgent);
-      setIsIOS(isIOSDevice);
-      setIsAndroid(/android/.test(userAgent));
-    };
-
-    checkIOS();
 
     return () => {
       window.removeEventListener('resize', handleResize);

--- a/src/components/family/StoreBadgesCta.tsx
+++ b/src/components/family/StoreBadgesCta.tsx
@@ -87,7 +87,7 @@ export function StoreBadgesCta({
       {withSignup && (
         <div className="mt-6 max-w-md">
           <p className="text-sm text-muted-foreground mb-2">
-            Divine is now live in the app stores with invite codes. If you'd like to receive a code and hear our news, sign up here.
+            Divine is live in the app stores. Sign up here to hear what&apos;s next.
           </p>
           <HubSpotSignup />
         </div>

--- a/src/lib/mobileStoreLinks.test.ts
+++ b/src/lib/mobileStoreLinks.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from 'vitest';
-import { APP_STORE_URL, DIVINE_IOS_APP_ID, PLAY_STORE_URL } from './mobileStoreLinks';
+import {
+  APP_STORE_URL,
+  detectMobilePlatform,
+  DIVINE_IOS_APP_ID,
+  PLAY_STORE_URL,
+} from './mobileStoreLinks';
 
 describe('mobileStoreLinks', () => {
   it('points at the Divine App Store listing', () => {
@@ -18,5 +23,15 @@ describe('mobileStoreLinks', () => {
     // blocked by CSP, an ad blocker, or a slow connection.
     expect(APP_STORE_URL).toMatch(/^https:\/\/apps\.apple\.com\//);
     expect(PLAY_STORE_URL).toMatch(/^https:\/\/play\.google\.com\//);
+  });
+
+  it.each([
+    ['iPhone', 'Mozilla/5.0 (iPhone; CPU iPhone OS 18_0 like Mac OS X)', 'ios'],
+    ['iPad', 'Mozilla/5.0 (iPad; CPU OS 12_5 like Mac OS X)', 'ios'],
+    ['Android', 'Mozilla/5.0 (Linux; Android 15; Pixel 9)', 'android'],
+    ['desktop', 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)', 'other'],
+    ['modern iPadOS fallback', 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) Version/18.0 Mobile/15E148 Safari/604.1', 'other'],
+  ])('detects %s visitors as %s', (_label, userAgent, expected) => {
+    expect(detectMobilePlatform(userAgent)).toBe(expected);
   });
 });

--- a/src/lib/mobileStoreLinks.test.ts
+++ b/src/lib/mobileStoreLinks.test.ts
@@ -4,6 +4,7 @@ import {
   detectMobilePlatform,
   DIVINE_IOS_APP_ID,
   PLAY_STORE_URL,
+  ZAP_STORE_URL,
 } from './mobileStoreLinks';
 
 describe('mobileStoreLinks', () => {
@@ -23,6 +24,12 @@ describe('mobileStoreLinks', () => {
     // blocked by CSP, an ad blocker, or a slow connection.
     expect(APP_STORE_URL).toMatch(/^https:\/\/apps\.apple\.com\//);
     expect(PLAY_STORE_URL).toMatch(/^https:\/\/play\.google\.com\//);
+    expect(ZAP_STORE_URL).toMatch(/^https:\/\/zapstore\.dev\//);
+  });
+
+  it('points at the plural /apps/ Zapstore path', () => {
+    // zapstore.dev/app/<id> (singular) 404s; only /apps/<id> resolves.
+    expect(ZAP_STORE_URL).toBe('https://zapstore.dev/apps/co.openvine.app');
   });
 
   it.each([

--- a/src/lib/mobileStoreLinks.ts
+++ b/src/lib/mobileStoreLinks.ts
@@ -1,4 +1,4 @@
-// ABOUTME: Mobile app store links, shared across the sidebar, install prompt and family pages
+// ABOUTME: Mobile app store links, shared across the sidebar, install prompt, download and family pages
 // ABOUTME: Static by design — a badge for a shipped app must not depend on a network call to render
 
 export const DIVINE_IOS_APP_ID = '6747959501';
@@ -11,6 +11,12 @@ export const DIVINE_IOS_APP_ID = '6747959501';
 export const APP_STORE_URL = `https://apps.apple.com/app/id${DIVINE_IOS_APP_ID}`;
 
 export const PLAY_STORE_URL = 'https://play.google.com/store/apps/details?id=co.openvine.app&gl=us&hl=en';
+
+/**
+ * Zapstore ships the Android build only — the listing behind this URL has no
+ * iOS download, so it belongs beside Google Play rather than the App Store.
+ */
+export const ZAP_STORE_URL = 'https://zapstore.dev/apps/co.openvine.app';
 
 export type MobilePlatform = 'ios' | 'android' | 'other';
 

--- a/src/lib/mobileStoreLinks.ts
+++ b/src/lib/mobileStoreLinks.ts
@@ -11,3 +11,19 @@ export const DIVINE_IOS_APP_ID = '6747959501';
 export const APP_STORE_URL = `https://apps.apple.com/app/id${DIVINE_IOS_APP_ID}`;
 
 export const PLAY_STORE_URL = 'https://play.google.com/store/apps/details?id=co.openvine.app&gl=us&hl=en';
+
+export type MobilePlatform = 'ios' | 'android' | 'other';
+
+export function detectMobilePlatform(userAgent: string): MobilePlatform {
+  const normalizedUserAgent = userAgent.toLowerCase();
+
+  if (/iphone|ipad|ipod/.test(normalizedUserAgent)) {
+    return 'ios';
+  }
+
+  if (/android/.test(normalizedUserAgent)) {
+    return 'android';
+  }
+
+  return 'other';
+}

--- a/src/lib/seoFiles.test.ts
+++ b/src/lib/seoFiles.test.ts
@@ -43,8 +43,9 @@ describe('public sitemap.xml', () => {
     }
   });
 
-  it('links the kids policy and account portability pages', () => {
+  it('links the kids policy, download, and account portability pages', () => {
     expect(sitemap).toContain('<loc>https://divine.video/kids</loc>');
+    expect(sitemap).toContain('<loc>https://divine.video/download</loc>');
     expect(sitemap).toContain('<loc>https://divine.video/exit</loc>');
     expect(sitemap).toContain('<loc>https://divine.video/delete-account</loc>');
   });

--- a/src/lib/serverSocialMeta.test.ts
+++ b/src/lib/serverSocialMeta.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest';
 import {
   buildCategoriesIndexMeta,
   buildCategoryPageMeta,
+  buildDownloadPageMeta,
   buildProfilePageMeta,
   buildVideoPageMeta,
   decodeNpubToHex,
@@ -74,6 +75,15 @@ describe('serverSocialMeta', () => {
 
     expect(meta.title).toBe('Browse Categories - Divine');
     expect(meta.description).toContain('Explore video categories on Divine');
+  });
+
+  it('builds metadata for the public download page', () => {
+    const meta = buildDownloadPageMeta(new URL('https://divine.video/download'));
+
+    expect(meta.title).toBe('Download Divine');
+    expect(meta.description).toContain('App Store, Google Play, or ZapStore');
+    expect(meta.url).toBe('https://divine.video/download');
+    expect(meta.image).toBe('https://divine.video/og.png');
   });
 
   it('decodes npub identifiers to hex pubkeys', () => {

--- a/src/lib/serverSocialMeta.test.ts
+++ b/src/lib/serverSocialMeta.test.ts
@@ -81,7 +81,7 @@ describe('serverSocialMeta', () => {
     const meta = buildDownloadPageMeta(new URL('https://divine.video/download'));
 
     expect(meta.title).toBe('Download Divine');
-    expect(meta.description).toContain('App Store, Google Play, or ZapStore');
+    expect(meta.description).toContain('App Store, Google Play, or Zapstore');
     expect(meta.url).toBe('https://divine.video/download');
     expect(meta.image).toBe('https://divine.video/og.png');
   });

--- a/src/lib/serverSocialMeta.ts
+++ b/src/lib/serverSocialMeta.ts
@@ -334,6 +334,18 @@ export function buildKidsPolicyPageMeta(url: URL): PageMeta {
   };
 }
 
+export function buildDownloadPageMeta(url: URL): PageMeta {
+  return {
+    title: 'Download Divine',
+    description: 'Get Divine from the App Store, Google Play, or ZapStore.',
+    ogType: 'website',
+    url: url.toString(),
+    image: DEFAULT_OG_IMAGE,
+    imageAlt: 'Download the Divine mobile app',
+    twitterCard: 'summary_large_image',
+  };
+}
+
 export function getDefaultPageMeta(url: URL): PageMeta {
   return {
     title: 'Divine Web - Short-form Looping Videos on Nostr',

--- a/src/lib/serverSocialMeta.ts
+++ b/src/lib/serverSocialMeta.ts
@@ -337,7 +337,7 @@ export function buildKidsPolicyPageMeta(url: URL): PageMeta {
 export function buildDownloadPageMeta(url: URL): PageMeta {
   return {
     title: 'Download Divine',
-    description: 'Get Divine from the App Store, Google Play, or ZapStore.',
+    description: 'Get Divine from the App Store, Google Play, or Zapstore.',
     ogType: 'website',
     url: url.toString(),
     image: DEFAULT_OG_IMAGE,

--- a/src/pages/DownloadPage.test.tsx
+++ b/src/pages/DownloadPage.test.tsx
@@ -1,0 +1,55 @@
+// ABOUTME: Tests device-specific store choices on the public download page
+// ABOUTME: Keeps desktop and unrecognized devices on a safe all-store fallback
+
+import { render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { APP_STORE_URL, PLAY_STORE_URL } from "@/lib/mobileStoreLinks";
+import { TestApp } from "@/test/TestApp";
+
+import { DownloadPage } from "./DownloadPage";
+
+vi.mock("@/components/MarketingLayout", () => ({
+  MarketingLayout: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+function renderPage(userAgent: string) {
+  vi.spyOn(window.navigator, "userAgent", "get").mockReturnValue(userAgent);
+  return render(
+    <TestApp>
+      <DownloadPage />
+    </TestApp>
+  );
+}
+
+describe("DownloadPage", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("shows only the App Store as the primary choice on iOS", () => {
+    renderPage("Mozilla/5.0 (iPhone; CPU iPhone OS 18_0 like Mac OS X)");
+
+    expect(screen.getByRole("heading", { name: "Get Divine" })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Download Divine on the App Store" })).toHaveAttribute("href", APP_STORE_URL);
+    expect(screen.queryByRole("link", { name: "Get Divine on Google Play" })).not.toBeInTheDocument();
+  });
+
+  it("shows only Google Play as the primary choice on Android", () => {
+    renderPage("Mozilla/5.0 (Linux; Android 15; Pixel 9)");
+
+    expect(screen.getByRole("link", { name: "Get Divine on Google Play" })).toHaveAttribute("href", PLAY_STORE_URL);
+    expect(screen.queryByRole("link", { name: "Download Divine on the App Store" })).not.toBeInTheDocument();
+  });
+
+  it("shows both stores and ZapStore on desktop and unrecognized devices", () => {
+    renderPage("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)");
+
+    expect(screen.getByRole("link", { name: "Download Divine on the App Store" })).toHaveAttribute("href", APP_STORE_URL);
+    expect(screen.getByRole("link", { name: "Get Divine on Google Play" })).toHaveAttribute("href", PLAY_STORE_URL);
+    expect(screen.getByRole("link", { name: "Get Divine on ZapStore" })).toHaveAttribute(
+      "href",
+      "https://zapstore.dev/apps/co.openvine.app"
+    );
+  });
+});

--- a/src/pages/DownloadPage.test.tsx
+++ b/src/pages/DownloadPage.test.tsx
@@ -33,12 +33,15 @@ describe("DownloadPage", () => {
     expect(screen.getByRole("heading", { name: "Get Divine" })).toBeInTheDocument();
     expect(screen.getByRole("link", { name: "Download Divine on the App Store" })).toHaveAttribute("href", APP_STORE_URL);
     expect(screen.queryByRole("link", { name: "Get Divine on Google Play" })).not.toBeInTheDocument();
+    // Zapstore only distributes the Android build, so the link is a dead end here.
+    expect(screen.queryByRole("link", { name: "Get Divine on Zapstore" })).not.toBeInTheDocument();
   });
 
-  it("shows only Google Play as the primary choice on Android", () => {
+  it("shows Google Play and Zapstore as the choices on Android", () => {
     renderPage("Mozilla/5.0 (Linux; Android 15; Pixel 9)");
 
     expect(screen.getByRole("link", { name: "Get Divine on Google Play" })).toHaveAttribute("href", PLAY_STORE_URL);
+    expect(screen.getByRole("link", { name: "Get Divine on Zapstore" })).toHaveAttribute("href", ZAP_STORE_URL);
     expect(screen.queryByRole("link", { name: "Download Divine on the App Store" })).not.toBeInTheDocument();
   });
 

--- a/src/pages/DownloadPage.test.tsx
+++ b/src/pages/DownloadPage.test.tsx
@@ -42,12 +42,12 @@ describe("DownloadPage", () => {
     expect(screen.queryByRole("link", { name: "Download Divine on the App Store" })).not.toBeInTheDocument();
   });
 
-  it("shows both stores and ZapStore on desktop and unrecognized devices", () => {
+  it("shows both stores and Zapstore on desktop and unrecognized devices", () => {
     renderPage("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)");
 
     expect(screen.getByRole("link", { name: "Download Divine on the App Store" })).toHaveAttribute("href", APP_STORE_URL);
     expect(screen.getByRole("link", { name: "Get Divine on Google Play" })).toHaveAttribute("href", PLAY_STORE_URL);
-    expect(screen.getByRole("link", { name: "Get Divine on ZapStore" })).toHaveAttribute(
+    expect(screen.getByRole("link", { name: "Get Divine on Zapstore" })).toHaveAttribute(
       "href",
       ZAP_STORE_URL
     );

--- a/src/pages/DownloadPage.test.tsx
+++ b/src/pages/DownloadPage.test.tsx
@@ -4,7 +4,7 @@
 import { render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { APP_STORE_URL, PLAY_STORE_URL } from "@/lib/mobileStoreLinks";
+import { APP_STORE_URL, PLAY_STORE_URL, ZAP_STORE_URL } from "@/lib/mobileStoreLinks";
 import { TestApp } from "@/test/TestApp";
 
 import { DownloadPage } from "./DownloadPage";
@@ -49,7 +49,7 @@ describe("DownloadPage", () => {
     expect(screen.getByRole("link", { name: "Get Divine on Google Play" })).toHaveAttribute("href", PLAY_STORE_URL);
     expect(screen.getByRole("link", { name: "Get Divine on ZapStore" })).toHaveAttribute(
       "href",
-      "https://zapstore.dev/apps/co.openvine.app"
+      ZAP_STORE_URL
     );
   });
 });

--- a/src/pages/DownloadPage.tsx
+++ b/src/pages/DownloadPage.tsx
@@ -1,0 +1,74 @@
+// ABOUTME: Public device-aware landing page for downloading the Divine mobile app
+// ABOUTME: Offers store choices without redirecting visitors or requiring an account
+
+import { AppleLogo, DeviceMobile, GooglePlayLogo } from "@phosphor-icons/react";
+import { useHead } from "@unhead/react";
+import { useState } from "react";
+
+import { MarketingLayout } from "@/components/MarketingLayout";
+import { Button } from "@/components/ui/button";
+import {
+  APP_STORE_URL,
+  detectMobilePlatform,
+  PLAY_STORE_URL,
+} from "@/lib/mobileStoreLinks";
+
+const ZAP_STORE_URL = "https://zapstore.dev/apps/co.openvine.app";
+
+export function DownloadPage() {
+  const [platform] = useState(() => detectMobilePlatform(window.navigator.userAgent));
+  const showAppStore = platform !== "android";
+  const showGooglePlay = platform !== "ios";
+
+  useHead({
+    title: "Download Divine",
+    link: [{ rel: "canonical", href: "https://divine.video/download" }],
+    meta: [{ name: "description", content: "Get Divine from the App Store, Google Play, or ZapStore." }],
+  });
+
+  return (
+    <MarketingLayout>
+      <main className="bg-brand-dark-green text-brand-off-white">
+        <div className="container mx-auto flex min-h-[70vh] max-w-4xl flex-col items-center justify-center px-4 py-16 text-center md:py-24">
+          <div className="mb-6 flex items-center gap-2 text-xs font-semibold tracking-wide text-brand-green">
+            <DeviceMobile weight="fill" className="h-4 w-4" />
+            <span>Divine mobile app</span>
+          </div>
+          <h1 className="mb-6 font-display text-4xl font-extrabold leading-[1.05] tracking-tight text-brand-off-white md:text-6xl">
+            Get Divine
+          </h1>
+          <p className="mb-10 max-w-2xl text-lg leading-relaxed text-brand-light-green md:text-xl">
+            Six-second loops from real humans, ready for your phone.
+          </p>
+          <div className="flex flex-col items-stretch gap-4 sm:flex-row sm:items-center sm:justify-center">
+            {showAppStore && (
+              <Button asChild variant="sticker" size="lg">
+                <a href={APP_STORE_URL} target="_blank" rel="noopener noreferrer" aria-label="Download Divine on the App Store">
+                  <AppleLogo weight="fill" className="h-5 w-5" />
+                  App Store
+                </a>
+              </Button>
+            )}
+            {showGooglePlay && (
+              <Button asChild variant="sticker" size="lg">
+                <a href={PLAY_STORE_URL} target="_blank" rel="noopener noreferrer" aria-label="Get Divine on Google Play">
+                  <GooglePlayLogo weight="fill" className="h-5 w-5" />
+                  Google Play
+                </a>
+              </Button>
+            )}
+          </div>
+          <a
+            href={ZAP_STORE_URL}
+            target="_blank"
+            rel="noopener noreferrer"
+            aria-label="Get Divine on ZapStore"
+            className="mt-8 text-sm font-semibold text-brand-off-white/80 underline decoration-brand-green/70 underline-offset-4 transition-colors hover:text-brand-green"
+          >
+            Get it from ZapStore
+          </a>
+        </div>
+      </main>
+    </MarketingLayout>
+  );
+}

--- a/src/pages/DownloadPage.tsx
+++ b/src/pages/DownloadPage.tsx
@@ -11,9 +11,8 @@ import {
   APP_STORE_URL,
   detectMobilePlatform,
   PLAY_STORE_URL,
+  ZAP_STORE_URL,
 } from "@/lib/mobileStoreLinks";
-
-const ZAP_STORE_URL = "https://zapstore.dev/apps/co.openvine.app";
 
 export function DownloadPage() {
   const [platform] = useState(() => detectMobilePlatform(window.navigator.userAgent));

--- a/src/pages/DownloadPage.tsx
+++ b/src/pages/DownloadPage.tsx
@@ -22,7 +22,7 @@ export function DownloadPage() {
   useHead({
     title: "Download Divine",
     link: [{ rel: "canonical", href: "https://divine.video/download" }],
-    meta: [{ name: "description", content: "Get Divine from the App Store, Google Play, or ZapStore." }],
+    meta: [{ name: "description", content: "Get Divine from the App Store, Google Play, or Zapstore." }],
   });
 
   return (
@@ -61,10 +61,10 @@ export function DownloadPage() {
             href={ZAP_STORE_URL}
             target="_blank"
             rel="noopener noreferrer"
-            aria-label="Get Divine on ZapStore"
+            aria-label="Get Divine on Zapstore"
             className="mt-8 text-sm font-semibold text-brand-off-white/80 underline decoration-brand-green/70 underline-offset-4 transition-colors hover:text-brand-green"
           >
-            Get it from ZapStore
+            Get it from Zapstore
           </a>
         </div>
       </main>

--- a/src/pages/DownloadPage.tsx
+++ b/src/pages/DownloadPage.tsx
@@ -64,10 +64,9 @@ export function DownloadPage() {
               href={ZAP_STORE_URL}
               target="_blank"
               rel="noopener noreferrer"
-              aria-label="Get Divine on Zapstore"
               className="mt-8 text-sm font-semibold text-brand-off-white/80 underline decoration-brand-green/70 underline-offset-4 transition-colors hover:text-brand-green"
             >
-              Get it from Zapstore
+              Get Divine on Zapstore
             </a>
           )}
         </div>

--- a/src/pages/DownloadPage.tsx
+++ b/src/pages/DownloadPage.tsx
@@ -17,7 +17,9 @@ import {
 export function DownloadPage() {
   const [platform] = useState(() => detectMobilePlatform(window.navigator.userAgent));
   const showAppStore = platform !== "android";
-  const showGooglePlay = platform !== "ios";
+  // Google Play and Zapstore both hand out the Android build, so neither
+  // has anything an iOS visitor can install.
+  const showAndroidStores = platform !== "ios";
 
   useHead({
     title: "Download Divine",
@@ -48,7 +50,7 @@ export function DownloadPage() {
                 </a>
               </Button>
             )}
-            {showGooglePlay && (
+            {showAndroidStores && (
               <Button asChild variant="sticker" size="lg">
                 <a href={PLAY_STORE_URL} target="_blank" rel="noopener noreferrer" aria-label="Get Divine on Google Play">
                   <GooglePlayLogo weight="fill" className="h-5 w-5" />
@@ -57,15 +59,17 @@ export function DownloadPage() {
               </Button>
             )}
           </div>
-          <a
-            href={ZAP_STORE_URL}
-            target="_blank"
-            rel="noopener noreferrer"
-            aria-label="Get Divine on Zapstore"
-            className="mt-8 text-sm font-semibold text-brand-off-white/80 underline decoration-brand-green/70 underline-offset-4 transition-colors hover:text-brand-green"
-          >
-            Get it from Zapstore
-          </a>
+          {showAndroidStores && (
+            <a
+              href={ZAP_STORE_URL}
+              target="_blank"
+              rel="noopener noreferrer"
+              aria-label="Get Divine on Zapstore"
+              className="mt-8 text-sm font-semibold text-brand-off-white/80 underline decoration-brand-green/70 underline-offset-4 transition-colors hover:text-brand-green"
+            >
+              Get it from Zapstore
+            </a>
+          )}
         </div>
       </main>
     </MarketingLayout>

--- a/tests/visual/a11y.spec.ts
+++ b/tests/visual/a11y.spec.ts
@@ -10,6 +10,7 @@ const ROUTES = [
   '/family',
   '/age-review',
   '/kids',
+  '/download',
   `/profile/${PUBKEY}`,
   `/profile/${PUBKEY}/lists`,
   `/people-lists/${PUBKEY}/friends`,


### PR DESCRIPTION
## Summary

- Adds a public `/download` page that shows the App Store on iOS, Google Play on Android, and both choices on desktop or unknown devices. ZapStore remains available as a secondary option.
- Gives shared download links route-specific social metadata on both Cloudflare Pages and the production Fastly edge.
- Removes obsolete invite-code language from the marketing footer and family store callouts because Divine is open to the public.

## Motivation

A single Divine download link currently lands on the generic not-found experience and unfurls with generic site metadata. Recipients need a stable URL that works on any device without an automatic redirect, while messaging clients need useful server-rendered metadata before JavaScript runs.

Platform detection is now a shared, synchronous helper used by both the new page and the existing install prompt. Unknown devices safely receive every store choice. This deliberately does not add referral attribution or a video strip.

## Related Issue

- Closes #640

## Testing

- [x] `npm run test` — 287 test files, 2,341 tests, production build
- [x] `npm run -w divine-web-edge build`
- [x] `npx playwright test tests/visual/a11y.spec.ts --grep download` — light and dark WCAG 2.1 A/AA checks
- [x] Manual desktop and phone-width visual verification

## Visuals

- [x] UI change manually verified at desktop and phone widths
- [ ] No visual change
- [x] Visuals and text avoid sensitive external brand or partner names unless explicitly approved