### PR TITLE
refactor(marketing): keep newsletter signup promises aligned

### DIFF
--- a/src/components/AppFooter.test.tsx
+++ b/src/components/AppFooter.test.tsx
@@ -77,14 +77,4 @@ describe('AppFooter', () => {
     );
   });
 
-  it('describes public availability without asking for an invite code', () => {
-    render(
-      <MemoryRouter>
-        <AppFooter />
-      </MemoryRouter>,
-    );
-
-    expect(screen.getByText(/Divine is live in the app stores/)).toBeInTheDocument();
-    expect(screen.queryByText(/invite code/i)).not.toBeInTheDocument();
-  });
 });

--- a/src/components/AppFooter.test.tsx
+++ b/src/components/AppFooter.test.tsx
@@ -14,6 +14,20 @@ vi.mock('./HubSpotSignup', () => ({
 }));
 
 describe('AppFooter', () => {
+  it('describes the signup as a newsletter without promising an invite code', () => {
+    render(
+      <MemoryRouter>
+        <AppFooter />
+      </MemoryRouter>,
+    );
+
+    expect(
+      screen.getByText('Divine is live in the App Store and on Google Play. Want our news in your inbox? Sign up here.'),
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/invite code/i)).not.toBeInTheDocument();
+    expect(screen.getByTestId('hubspot-signup')).toBeInTheDocument();
+  });
+
   it('renders a DMCA & Copyright link to /dmca', () => {
     render(
       <MemoryRouter>

--- a/src/components/AppFooter.tsx
+++ b/src/components/AppFooter.tsx
@@ -1,6 +1,7 @@
 import { SmartLink } from '@/components/SmartLink';
 import { useTranslation } from 'react-i18next';
 import { SocialLinks } from '@/components/SocialLinks';
+import { MAILING_LIST_BLURB } from '@/lib/constants/mailingListCopy';
 import { HubSpotSignup } from './HubSpotSignup';
 
 export function AppFooter() {
@@ -15,9 +16,7 @@ export function AppFooter() {
             {/* Left side - Email signup */}
             <div className="flex flex-col gap-2 lg:max-w-md">
               <div className="text-sm font-semibold text-brand-green">Divine Inspiration</div>
-              <p className="text-sm text-brand-off-white mb-2">
-                Divine is live in the app stores. Sign up here to hear what&apos;s next.
-              </p>
+              <p className="text-sm text-brand-off-white mb-2">{MAILING_LIST_BLURB}</p>
               <HubSpotSignup />
             </div>
 

--- a/src/components/family/StoreBadgesCta.test.tsx
+++ b/src/components/family/StoreBadgesCta.test.tsx
@@ -1,0 +1,31 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { StoreBadgesCta } from './StoreBadgesCta';
+
+vi.mock('@/lib/analytics', () => ({
+  trackEvent: vi.fn(),
+}));
+
+vi.mock('@/components/HubSpotSignup', () => ({
+  HubSpotSignup: () => <div data-testid="hubspot-signup" />,
+}));
+
+describe('StoreBadgesCta', () => {
+  it('renders newsletter copy without promising an invite code when signup is enabled', () => {
+    render(<StoreBadgesCta campaign="family" withSignup />);
+
+    expect(
+      screen.getByText('Divine is live in the App Store and on Google Play. Want our news in your inbox? Sign up here.'),
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/invite code/i)).not.toBeInTheDocument();
+    expect(screen.getByTestId('hubspot-signup')).toBeInTheDocument();
+  });
+
+  it('does not render the newsletter signup by default', () => {
+    render(<StoreBadgesCta campaign="family" />);
+
+    expect(screen.queryByText(/Want our news in your inbox/i)).not.toBeInTheDocument();
+    expect(screen.queryByTestId('hubspot-signup')).not.toBeInTheDocument();
+  });
+});

--- a/src/components/family/StoreBadgesCta.tsx
+++ b/src/components/family/StoreBadgesCta.tsx
@@ -1,8 +1,9 @@
 // ABOUTME: App Store / Google Play badge block for family pages, with UTM-tagged links
-// ABOUTME: Optional signup variant keeps the invite/newsletter form BELOW the badges
+// ABOUTME: Optional signup variant keeps the newsletter form BELOW the badges
 
 import { trackEvent } from "@/lib/analytics";
 import { HubSpotSignup } from "@/components/HubSpotSignup";
+import { MAILING_LIST_BLURB } from "@/lib/constants/mailingListCopy";
 import { APP_STORE_URL } from "@/lib/mobileStoreLinks";
 
 const PLAY_STORE_BASE = "https://play.google.com/store/apps/details";
@@ -27,7 +28,7 @@ interface StoreBadgesCtaProps {
   campaign: string;
   /** Short line above the badges; stays factual, no exclamation marks */
   heading?: string;
-  /** Render the invite/newsletter signup below the badges */
+  /** Render the newsletter signup below the badges */
   withSignup?: boolean;
   className?: string;
 }
@@ -86,9 +87,7 @@ export function StoreBadgesCta({
       </div>
       {withSignup && (
         <div className="mt-6 max-w-md">
-          <p className="text-sm text-muted-foreground mb-2">
-            Divine is live in the app stores. Sign up here to hear what&apos;s next.
-          </p>
+          <p className="text-sm text-muted-foreground mb-2">{MAILING_LIST_BLURB}</p>
           <HubSpotSignup />
         </div>
       )}

--- a/src/lib/constants/mailingListCopy.ts
+++ b/src/lib/constants/mailingListCopy.ts
@@ -1,0 +1,5 @@
+// ABOUTME: Shared copy for newsletter signup surfaces
+// ABOUTME: Keeps the signup promise accurate wherever the mailing-list form appears
+
+export const MAILING_LIST_BLURB =
+  'Divine is live in the App Store and on Google Play. Want our news in your inbox? Sign up here.';

--- a/tests/mobile-availability-copy.test.ts
+++ b/tests/mobile-availability-copy.test.ts
@@ -19,6 +19,9 @@ const STALE_MOBILE_COPY = [
   'Join the Beta',
 ];
 const NEWSLETTER_SURFACES = [
+  // The blurb itself lives here; the two components below only render it, so
+  // this is the file the guard actually has to watch.
+  'src/lib/constants/mailingListCopy.ts',
   'src/components/AppFooter.tsx',
   'src/components/family/StoreBadgesCta.tsx',
 ];

--- a/tests/mobile-availability-copy.test.ts
+++ b/tests/mobile-availability-copy.test.ts
@@ -18,6 +18,16 @@ const STALE_MOBILE_COPY = [
   'currently in <strong>beta testing</strong>',
   'Join the Beta',
 ];
+const NEWSLETTER_SURFACES = [
+  'src/components/AppFooter.tsx',
+  'src/components/family/StoreBadgesCta.tsx',
+];
+const STALE_INVITE_COPY = [
+  'with invite codes',
+  'receive a code',
+  'request a code',
+  'invite code',
+];
 
 function readSource(path: string) {
   return readFileSync(resolve(REPO_ROOT, path), 'utf8');
@@ -42,6 +52,14 @@ describe('mobile app availability copy', () => {
     expect(source).toContain(PLAY_STORE_URL);
 
     for (const staleCopy of STALE_MOBILE_COPY) {
+      expect(source).not.toContain(staleCopy);
+    }
+  });
+
+  it.each(NEWSLETTER_SURFACES)('%s does not promise invite codes through the newsletter', (file) => {
+    const source = readSource(file).toLowerCase();
+
+    for (const staleCopy of STALE_INVITE_COPY) {
       expect(source).not.toContain(staleCopy);
     }
   });


### PR DESCRIPTION
## Summary

- The global footer and family resources intentionally make the same newsletter promise, but previously maintained separate copies that could drift.
- Share neutral storefront and newsletter wording between both surfaces, clean up stale invite/newsletter comments, and add focused component and source-level regression coverage.
- PR #641 removed the obsolete invite-code statement independently while this work was in flight. This PR keeps the agreed explicit storefront wording and adds the single source and guardrails; it does not change mobile account-access requirements or store-link behavior.

## Motivation

- Visitors should know exactly what the newsletter form provides, and both signup surfaces should remain aligned when that promise changes.

## Related Issue

- Closes #645

## Testing

- [x] `npm run test`
- [x] `npm run test:visual`
- [ ] Manual verification completed — automated component, build, visual, and accessibility coverage exercised both affected surfaces.

## Visuals

- [ ] UI change with screenshots/video attached — copy-only change; no layout or styling changes.
- [ ] No visual change
- [x] Visuals and text avoid sensitive external brand or partner names unless explicitly approved