### PR TITLE
fix(i18n): give Radix primitives the document's text direction

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
         "@radix-ui/react-collapsible": "^1.1.0",
         "@radix-ui/react-context-menu": "^2.2.1",
         "@radix-ui/react-dialog": "^1.1.2",
+        "@radix-ui/react-direction": "^1.1.1",
         "@radix-ui/react-dropdown-menu": "^2.1.1",
         "@radix-ui/react-hover-card": "^1.1.1",
         "@radix-ui/react-label": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "@radix-ui/react-collapsible": "^1.1.0",
     "@radix-ui/react-context-menu": "^2.2.1",
     "@radix-ui/react-dialog": "^1.1.2",
+    "@radix-ui/react-direction": "^1.1.1",
     "@radix-ui/react-dropdown-menu": "^2.1.1",
     "@radix-ui/react-hover-card": "^1.1.1",
     "@radix-ui/react-label": "^2.1.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -18,6 +18,7 @@ import { Toaster as Sonner } from "@/components/ui/sonner";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { NostrLoginProvider } from '@nostrify/react/login';
 import { AppProvider } from '@/components/AppProvider';
+import { LocaleDirectionProvider } from '@/components/LocaleDirectionProvider';
 import { NWCProvider } from '@/contexts/NWCContext';
 import { AppConfig } from '@/contexts/AppContext';
 import { VideoPlaybackProvider } from '@/contexts/VideoPlaybackContext';
@@ -60,30 +61,32 @@ const presetRelays = toLegacyFormat(PRESET_RELAYS);
 export function App() {
   return (
     <UnheadProvider head={head}>
-      <AppProvider storageKey="nostr:app-config" defaultConfig={defaultConfig} presetRelays={presetRelays}>
-        <QueryClientProvider client={queryClient}>
-          <NostrLoginProvider storageKey='nostr:login'>
-            <NostrProvider>
-              <DivineJWTWindowNostr />
-              <EventCachePreloader />
-              <SentryUserSync />
-              <NWCProvider>
-                <VideoPlaybackProvider>
-                  <FullscreenFeedProvider>
-                    <TooltipProvider>
-                      <Toaster />
-                      <Sonner />
-                      <Suspense>
-                        <AppRouter />
-                      </Suspense>
-                    </TooltipProvider>
-                  </FullscreenFeedProvider>
-                </VideoPlaybackProvider>
-              </NWCProvider>
-            </NostrProvider>
-          </NostrLoginProvider>
-        </QueryClientProvider>
-      </AppProvider>
+      <LocaleDirectionProvider>
+        <AppProvider storageKey="nostr:app-config" defaultConfig={defaultConfig} presetRelays={presetRelays}>
+          <QueryClientProvider client={queryClient}>
+            <NostrLoginProvider storageKey='nostr:login'>
+              <NostrProvider>
+                <DivineJWTWindowNostr />
+                <EventCachePreloader />
+                <SentryUserSync />
+                <NWCProvider>
+                  <VideoPlaybackProvider>
+                    <FullscreenFeedProvider>
+                      <TooltipProvider>
+                        <Toaster />
+                        <Sonner />
+                        <Suspense>
+                          <AppRouter />
+                        </Suspense>
+                      </TooltipProvider>
+                    </FullscreenFeedProvider>
+                  </VideoPlaybackProvider>
+                </NWCProvider>
+              </NostrProvider>
+            </NostrLoginProvider>
+          </QueryClientProvider>
+        </AppProvider>
+      </LocaleDirectionProvider>
     </UnheadProvider>
   );
 }

--- a/src/components/LocaleDirectionProvider.test.tsx
+++ b/src/components/LocaleDirectionProvider.test.tsx
@@ -1,8 +1,8 @@
-import { render, screen } from '@testing-library/react';
+import { act, render, screen } from '@testing-library/react';
 import { beforeEach, describe, expect, it } from 'vitest';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { LOCALE_STORAGE_KEY } from '@/lib/i18n/config';
-import { initializeI18n } from '@/lib/i18n';
+import { changeLanguage, initializeI18n } from '@/lib/i18n';
 import { LocaleDirectionProvider } from './LocaleDirectionProvider';
 
 function renderTabs() {
@@ -53,5 +53,24 @@ describe('LocaleDirectionProvider', () => {
     renderTabs();
 
     expect(directedAncestor()).toHaveAttribute('dir', 'ltr');
+  });
+
+  // The provider reads the locale through `useTranslation` rather than a
+  // one-shot read precisely so switching language reaches Radix without a
+  // reload. Nothing else pins that: a non-reactive read of the same locale
+  // leaves every case above green while the running app stays left-to-right
+  // until the next refresh.
+  it('follows a language change without a reload', async () => {
+    window.localStorage.setItem(LOCALE_STORAGE_KEY, 'en');
+    await initializeI18n({ force: true, languages: ['en'] });
+
+    renderTabs();
+    expect(directedAncestor()).toHaveAttribute('dir', 'ltr');
+
+    await act(async () => {
+      await changeLanguage('ar');
+    });
+
+    expect(directedAncestor()).toHaveAttribute('dir', 'rtl');
   });
 });

--- a/src/components/LocaleDirectionProvider.test.tsx
+++ b/src/components/LocaleDirectionProvider.test.tsx
@@ -1,0 +1,57 @@
+import { render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { LOCALE_STORAGE_KEY } from '@/lib/i18n/config';
+import { initializeI18n } from '@/lib/i18n';
+import { LocaleDirectionProvider } from './LocaleDirectionProvider';
+
+function renderTabs() {
+  return render(
+    <LocaleDirectionProvider>
+      <Tabs defaultValue="one">
+        <TabsList>
+          <TabsTrigger value="one">One</TabsTrigger>
+        </TabsList>
+        <TabsContent value="one">
+          <span data-testid="panel-child">content</span>
+        </TabsContent>
+      </Tabs>
+    </LocaleDirectionProvider>,
+  );
+}
+
+// Radix writes `dir` on the Tabs root rather than on the panel, and the panel
+// inherits it. Asserting on whichever ancestor actually carries the attribute
+// keeps this pinned to the rendered direction rather than to Radix's current
+// choice of which node to stamp.
+function directedAncestor(): HTMLElement {
+  return screen.getByTestId('panel-child').closest('[dir]') as HTMLElement;
+}
+
+describe('LocaleDirectionProvider', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  // Without a DirectionProvider, Radix falls back to `ltr` and stamps that on
+  // its own markup, overriding the `dir="rtl"` applyDocumentLocale puts on
+  // <html> — so every tab panel laid out left-to-right in Arabic and Urdu.
+  // Removing the provider turns both of these red.
+  it.each(['ar', 'ur'])('gives Radix the document direction in %s', async (locale) => {
+    window.localStorage.setItem(LOCALE_STORAGE_KEY, locale);
+    await initializeI18n({ force: true, languages: [locale] });
+
+    renderTabs();
+
+    expect(directedAncestor()).toHaveAttribute('dir', 'rtl');
+  });
+
+  it('leaves left-to-right locales exactly as they were', async () => {
+    window.localStorage.setItem(LOCALE_STORAGE_KEY, 'en');
+    await initializeI18n({ force: true, languages: ['en'] });
+
+    renderTabs();
+
+    expect(directedAncestor()).toHaveAttribute('dir', 'ltr');
+  });
+});

--- a/src/components/LocaleDirectionProvider.tsx
+++ b/src/components/LocaleDirectionProvider.tsx
@@ -8,8 +8,8 @@ import { DEFAULT_LOCALE, getLocaleDirection, normalizeLocale } from '@/lib/i18n/
 
 /**
  * Radix primitives resolve their direction from this provider, and default to
- * `ltr` without it — then stamp that default onto their own markup. A
- * `TabsContent` carrying `dir="ltr"` overrides the `dir="rtl"` that
+ * `ltr` without it — then stamp that default onto their own markup. A `Tabs`
+ * root carrying `dir="ltr"` overrides the `dir="rtl"` that
  * `applyDocumentLocale` puts on `<html>`, so every tab panel laid its content
  * out left-to-right in Arabic and Urdu, sponsorship disclosures included.
  *

--- a/src/components/LocaleDirectionProvider.tsx
+++ b/src/components/LocaleDirectionProvider.tsx
@@ -1,0 +1,24 @@
+// ABOUTME: Feeds the active locale's direction to every Radix primitive
+// ABOUTME: Without it they default to LTR and override the document's dir
+
+import type { ReactNode } from 'react';
+import { DirectionProvider } from '@radix-ui/react-direction';
+import { useTranslation } from 'react-i18next';
+import { DEFAULT_LOCALE, getLocaleDirection, normalizeLocale } from '@/lib/i18n/config';
+
+/**
+ * Radix primitives resolve their direction from this provider, and default to
+ * `ltr` without it — then stamp that default onto their own markup. A
+ * `TabsContent` carrying `dir="ltr"` overrides the `dir="rtl"` that
+ * `applyDocumentLocale` puts on `<html>`, so every tab panel laid its content
+ * out left-to-right in Arabic and Urdu, sponsorship disclosures included.
+ *
+ * Reads the same `normalizeLocale` → `getLocaleDirection` path that drives the
+ * document attribute, so the two can never disagree about a locale.
+ */
+export function LocaleDirectionProvider({ children }: { children: ReactNode }) {
+  const { i18n } = useTranslation();
+  const locale = normalizeLocale(i18n.language) ?? DEFAULT_LOCALE;
+
+  return <DirectionProvider dir={getLocaleDirection(locale)}>{children}</DirectionProvider>;
+}

--- a/src/test/TestApp.tsx
+++ b/src/test/TestApp.tsx
@@ -4,6 +4,7 @@ import { BrowserRouter } from 'react-router-dom';
 import { NostrLoginProvider } from '@nostrify/react/login';
 import NostrProvider from '@/components/NostrProvider';
 import { AppProvider } from '@/components/AppProvider';
+import { LocaleDirectionProvider } from '@/components/LocaleDirectionProvider';
 import { NWCProvider } from '@/contexts/NWCContext';
 import { VideoPlaybackProvider } from '@/contexts/VideoPlaybackContext';
 import { AppConfig } from '@/contexts/AppContext';
@@ -30,21 +31,23 @@ export function TestApp({ children }: TestAppProps) {
 
   return (
     <UnheadProvider head={head}>
-      <AppProvider storageKey='test-app-config' defaultConfig={defaultConfig}>
-        <QueryClientProvider client={queryClient}>
-          <NostrLoginProvider storageKey='test-login'>
-            <NostrProvider>
-              <NWCProvider>
-                <VideoPlaybackProvider>
-                  <BrowserRouter>
-                    {children}
-                  </BrowserRouter>
-                </VideoPlaybackProvider>
-              </NWCProvider>
-            </NostrProvider>
-          </NostrLoginProvider>
-        </QueryClientProvider>
-      </AppProvider>
+      <LocaleDirectionProvider>
+        <AppProvider storageKey='test-app-config' defaultConfig={defaultConfig}>
+          <QueryClientProvider client={queryClient}>
+            <NostrLoginProvider storageKey='test-login'>
+              <NostrProvider>
+                <NWCProvider>
+                  <VideoPlaybackProvider>
+                    <BrowserRouter>
+                      {children}
+                    </BrowserRouter>
+                  </VideoPlaybackProvider>
+                </NWCProvider>
+              </NostrProvider>
+            </NostrLoginProvider>
+          </QueryClientProvider>
+        </AppProvider>
+      </LocaleDirectionProvider>
     </UnheadProvider>
   );
 }


### PR DESCRIPTION
## Summary

Radix resolves direction from a `DirectionProvider` and falls back to `"ltr"` without one — then writes that fallback onto its own markup. A Tabs root carrying `dir="ltr"` overrides the `dir="rtl"` that `applyDocumentLocale` sets on `<html>`, so every tab panel laid its content out left-to-right in Arabic and Urdu.

The visible symptom was the sponsorship disclosure on a featured collection. The Urdu string leads with the brand, so it rendered brand-on-the-left and "sponsored by" on the right — the reverse of the sentence's own word order for an RTL reader.

Found while verifying #637 on its preview deploy. **Not caused by that PR** — the Urdu string was brand-first before the copy change too, so this has been latent as long as tabs and RTL locales have coexisted.

## Why a provider rather than a `dir` on Tabs

This was never a Tabs bug. `DropdownMenu`, `Select`, `Slider`, `ContextMenu` and `Toast` all resolve direction through the same context and all carry the same latent defect. One provider at the app root fixes the family; a `dir` default on the `Tabs` wrapper would fix 11 call sites and leave the rest broken.

It reads the same `normalizeLocale` → `getLocaleDirection` path that already drives the document attribute, so the two cannot disagree about a locale.

`@radix-ui/react-direction` was already resolved transitively; this adds it to `package.json` explicitly rather than leaning on that.

## Blast radius

LTR locales are byte-identical to before — `dir="ltr"` is exactly what Radix already defaulted to. Only `ar` and `ur` change, and they change from wrong to right.

`TestApp` gets the provider too, so component tests see the direction production does.

## Related Issue

- Closes #647

## Testing

- [x] `npx vitest run` — 297 files, 2455 tests, all passing
- [x] `npm test` — type-check, lint (0 errors), production build
- [x] New `LocaleDirectionProvider.test.tsx` asserts the rendered `dir` for `ar`, `ur`, and `en`
- [x] Mutation-checked: replacing the provider with a fragment turns exactly the two RTL cases red and leaves the LTR case green

## Note on verification

jsdom does no layout, so these tests pin the `dir` attribute rather than visual order. Worth an eyeball in Arabic and Urdu on the preview — both a featured collection's disclosure and one dropdown/select, since those primitives start honouring direction where they previously did not.