### PR TITLE
fix(i18n): use a full-width colon in the Japanese sponsorship disclosure

### DIFF
--- a/src/lib/i18n/locales/ja/common.json
+++ b/src/lib/i18n/locales/ja/common.json
@@ -70,7 +70,7 @@
     "hot": "人気",
     "new": "新着",
     "featured": "注目",
-    "sponsoredBy": "提供: <bdi>{{sponsorName}}</bdi>",
+    "sponsoredBy": "提供：<bdi>{{sponsorName}}</bdi>",
     "tags": "タグ",
     "verifiedOnly": "人が作成",
     "verifiedOnlyHint": "ProofMode 検証済みの動画のみ表示しています",

--- a/src/pages/DiscoveryPage.test.tsx
+++ b/src/pages/DiscoveryPage.test.tsx
@@ -502,6 +502,34 @@ describe('DiscoveryPage', () => {
     expect(disclosure.querySelector('bdi')).toHaveTextContent('Acme Bikes');
   });
 
+  // The ASCII colon and space this replaced (#648) came in with the locale-wide
+  // rewrite in #637 and nothing caught it: parity, placeholder and
+  // not-English checks all pass on either punctuation. Asserting the rendered
+  // text is what pins it, since the full-width colon carries its own spacing
+  // and there is no separator character to look for.
+  it('sets the Japanese disclosure with a full-width colon', async () => {
+    window.localStorage.setItem(LOCALE_STORAGE_KEY, 'ja');
+    await initializeI18n({ force: true, languages: ['ja'] });
+    mockFeaturedTab.current = {
+      id: 'ft_1234abcd',
+      slug: 'seasonal-theme',
+      label: 'Especial',
+      pillLabel: null,
+      sponsorName: 'Acme Bikes',
+    };
+
+    render(
+      <MemoryRouter initialEntries={['/discovery/seasonal-theme']}>
+        <Routes>
+          <Route path="/discovery/:tab" element={<DiscoveryPage />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    const disclosure = getPartnershipDisclosure('提供：Acme Bikes');
+    expect(disclosure.querySelector('bdi')).toHaveTextContent('Acme Bikes');
+  });
+
   it('names every tab trigger when labels are visually hidden on mobile', () => {
     mockFeaturedTab.current = {
       id: 'ft_1234abcd',


### PR DESCRIPTION
## Summary

`提供: <bdi>{{sponsorName}}</bdi>` → `提供：<bdi>{{sponsorName}}</bdi>`

`提供` is the right term — it is the standard Japanese sponsor credit, the same one broadcast sponsorship uses. Only the punctuation was off: the string carried an ASCII colon plus a space, which reads as a Latin typographic import beside CJK text. Full-width `：` is what sets correctly there, and it carries its own trailing space visually.

Introduced with #637, which rewrote this string across every locale. Cosmetic — the disclosure was legible and correct as it stood, so this is typography, not a disclosure defect.

## Related Issue

- Closes #648

## Testing

- [x] `npx vitest run src/lib/i18n/locales.test.ts` (6 tests)
- [x] `npx vitest run src/pages/DiscoveryPage.test.tsx` (27 tests)
- [x] `npx tsc -p tsconfig.app.json --noEmit`, `npx eslint`

The key sits under `MUST_BE_TRANSLATED_PREFIXES`, but those checks do not actually cover this edit: parity proves the key exists in every locale, the placeholder check counts interpolations, and `MUST_BE_TRANSLATED_PREFIXES` only proves the value differs from English. An ASCII colon satisfies all three — reverting this one character and rerunning both suites leaves all 32 tests green, which is how #637 introduced the defect unnoticed. Review added `DiscoveryPage.test.tsx` → "sets the Japanese disclosure with a full-width colon" (commit b61e6d5), which asserts the rendered text and does fail on that revert.

## Note on review

Neither the term nor the punctuation here has had a native-speaker pass. `LOCALIZATION_STYLE_GUIDE.md` permits shipping without one where no speaker is available and asks that it be said out loud rather than left implied — so: `ja` 提供 and `ko` 협찬 are believed correct on the strength of being the conventional broadcast credits, and nobody who reads those languages has checked them.
