### PR TITLE
test(exit): match production export failure responses

### DIFF
--- a/src/lib/exit/__fixtures__/fixtureFetch.ts
+++ b/src/lib/exit/__fixtures__/fixtureFetch.ts
@@ -13,6 +13,17 @@ function jsonResponse(body: unknown, status = 200, headers?: HeadersInit): Respo
   });
 }
 
+function rateLimitResponse(): Response {
+  return new Response("Too Many Requests! Wait for 0s", {
+    status: 429,
+    headers: {
+      "content-type": "text/plain; charset=utf-8",
+      "retry-after": "0",
+      "x-ratelimit-after": "0"
+    }
+  });
+}
+
 export function createFixtureFetch(scenario: FixtureScenario): typeof fetch {
   let requestCount = 0;
 
@@ -37,19 +48,19 @@ export function createFixtureFetch(scenario: FixtureScenario): typeof fetch {
     }
 
     if (scenario === "bad-cursor") {
-      return jsonResponse({ error: "malformed cursor" }, 400);
+      return jsonResponse({ error: "Invalid cursor format" }, 400);
     }
 
     if (scenario === "expired-cursor") {
-      return jsonResponse({ error: "expired cursor token" }, 400);
+      return jsonResponse({ error: "Invalid or expired cursor" }, 400);
     }
 
     if (scenario === "rate-limit" && requestCount === 1) {
-      return jsonResponse({ error: "slow down" }, 429, { "retry-after": "0" });
+      return rateLimitResponse();
     }
 
     if (scenario === "always-rate-limit") {
-      return jsonResponse({ error: "slow down" }, 429, { "retry-after": "0" });
+      return rateLimitResponse();
     }
 
     if (scenario === "empty") {

--- a/src/lib/exit/ownerExportClient.test.ts
+++ b/src/lib/exit/ownerExportClient.test.ts
@@ -84,6 +84,29 @@ describe("exportOwnerEvents", () => {
     expect(sleeps.every((ms) => ms >= 1000)).toBe(true);
   });
 
+  it("accepts Funnelcake's plain-text throttling response and Retry-After headers", async () => {
+    const fixtureFetch = createFixtureFetch("rate-limit");
+    const responses: Response[] = [];
+
+    const result = await exportOwnerEvents({
+      endpointBase: "https://api.divine.video",
+      pubkey: fixturePubkey,
+      signer: new FixtureSigner(),
+      fetcher: async (input, init) => {
+        const response = await fixtureFetch(input, init);
+        responses.push(response.clone());
+        return response;
+      },
+      sleep: async () => undefined
+    });
+
+    expect(result.events).toHaveLength(1);
+    expect(responses[0].status).toBe(429);
+    expect(responses[0].headers.get("retry-after")).toBe("0");
+    expect(responses[0].headers.get("x-ratelimit-after")).toBe("0");
+    await expect(responses[0].text()).resolves.toBe("Too Many Requests! Wait for 0s");
+  });
+
   it("caps a large Retry-After so the export cannot stall for hours", async () => {
     const sleeps: number[] = [];
     let requests = 0;
@@ -140,7 +163,6 @@ describe("exportOwnerEvents", () => {
 
   it.each([
     ["bad-cursor", "bad-cursor"],
-    ["expired-cursor", "expired-cursor"],
     ["auth-failure", "auth-required"],
     ["pubkey-mismatch", "pubkey-mismatch"],
     ["network-failure", "network-failure"],
@@ -154,6 +176,26 @@ describe("exportOwnerEvents", () => {
         fetcher: createFixtureFetch(scenario)
       })
     ).rejects.toMatchObject({ code });
+  });
+
+  it("keeps cursor fixtures aligned with Funnelcake's response prose", async () => {
+    const url = `https://api.divine.video/api/users/${fixturePubkey}/export/events?limit=500`;
+    const badCursorResponse = await createFixtureFetch("bad-cursor")(url);
+    const expiredCursorResponse = await createFixtureFetch("expired-cursor")(url);
+
+    await expect(badCursorResponse.json()).resolves.toEqual({ error: "Invalid cursor format" });
+    await expect(expiredCursorResponse.json()).resolves.toEqual({ error: "Invalid or expired cursor" });
+  });
+
+  it("maps Funnelcake's unresolved-cursor response to expired-cursor", async () => {
+    await expect(
+      exportOwnerEvents({
+        endpointBase: "https://api.divine.video",
+        pubkey: fixturePubkey,
+        signer: new FixtureSigner(),
+        fetcher: createFixtureFetch("expired-cursor")
+      })
+    ).rejects.toMatchObject({ code: "expired-cursor" });
   });
 
   it("surfaces rate limit failure copy when retries are exhausted", async () => {


### PR DESCRIPTION
## Summary

- Align owner-export cursor fixtures with the error messages Funnelcake currently returns.
- Model throttling as the plain-text response with both retry headers and verify the existing client retries successfully.
- Pin the unresolved-cursor response to the existing expired-cursor user state.

> Avoid naming corporate partners, customers, or other sensitive external brands in this PR title or body. Use generic descriptors unless a maintainer explicitly approves the public reference.

## Motivation

- The previous fixtures exercised the right branches but used invented response prose and an incomplete throttling shape. Keeping them aligned with the server contract makes the exit-path tests meaningful without sending an artificial request burst to production.
- This is test-only and does not change runtime export behavior or add a fallback for headers the server currently supplies.

## Related Issue

- Closes #632

## Testing

- [x] `npm run test`
- [x] Manual verification completed: red/green check confirmed the new assertions fail with the old fixtures and pass with the corrected fixtures.

## Visuals

- [ ] UI change with screenshots/video attached
- [x] No visual change
- [x] Visuals and text avoid sensitive external brand or partner names unless explicitly approved