### PR TITLE
feat(exit): let people publish exported posts to another relay

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -193,6 +193,17 @@ copies. Sources without an advertised hash and generated HLS manifests are
 skipped. Descriptor hashes and redirect-aware `HEAD` readback results remain
 distinct from independent byte hashing.
 
+After mirroring finishes, the page can republish durable public events to one
+custom `wss://` relay. This deliberately opens and closes a standalone
+`NRelay1` connection instead of routing migration writes through the app's
+`NPool`. Only media with descriptor-and-readback verification is rewritten.
+Changed events are re-signed with their original timestamp, referenced owner
+events are prepared first so `e`, `E`, and `q` tags keep pointing at valid
+event IDs, and unchanged events retain their original ID and signature.
+Encrypted messages, ephemeral or authentication events, deletion requests,
+and vanish requests are skipped. Relay refusals remain per-event results and
+do not stop unrelated publishes.
+
 ## Linting
 
 ESLint 9 with TypeScript, React Hooks, HTML, and three custom rules in

--- a/src/components/exit/RelayDestinationForm.test.tsx
+++ b/src/components/exit/RelayDestinationForm.test.tsx
@@ -1,0 +1,35 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import { RelayDestinationForm } from "./RelayDestinationForm";
+
+const EVENT_ID = "a".repeat(64);
+
+describe("RelayDestinationForm", () => {
+  it("validates the destination beside the relay field", async () => {
+    const onStart = vi.fn();
+    render(<RelayDestinationForm state="idle" progress={null} results={null} summary={null} failure={null} onStart={onStart} />);
+    await userEvent.type(screen.getByLabelText("Relay URL"), "ws://relay.example");
+    await userEvent.click(screen.getByRole("button", { name: "Publish my posts" }));
+    expect(screen.getByRole("alert")).toHaveTextContent("Use a secure wss:// relay URL.");
+    expect(onStart).not.toHaveBeenCalled();
+  });
+
+  it("shows an honest summary and the full event identifier", async () => {
+    render(
+      <RelayDestinationForm
+        state="complete"
+        progress={null}
+        results={[{ event_id: EVENT_ID, published_event_id: EVENT_ID, kind: 1, status: "unchanged", remaining_media_urls: 1 }]}
+        summary={{ published: 0, unchanged: 1, failed: 0, skipped: 0, remainingMediaUrls: 1 }}
+        failure={null}
+        onStart={vi.fn()}
+      />,
+    );
+    expect(screen.getByRole("status")).toHaveTextContent("0 rewritten, 1 unchanged, 0 failed, and 0 skipped");
+    expect(screen.getByRole("status")).toHaveTextContent("1 media link still points to the original location");
+    await userEvent.click(screen.getByText("Event results"));
+    expect(screen.getByText(EVENT_ID)).toBeInTheDocument();
+  });
+});

--- a/src/components/exit/RelayDestinationForm.tsx
+++ b/src/components/exit/RelayDestinationForm.tsx
@@ -1,0 +1,119 @@
+// ABOUTME: Collects a destination relay and reports per-event republication outcomes
+// ABOUTME: Keeps relay validation and migration limitations visible beside the action
+
+import { ArrowClockwise, Broadcast, CheckCircle, WarningCircle } from "@phosphor-icons/react";
+import { useState } from "react";
+
+import { TransferProgress } from "@/components/exit/TransferProgress";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { DestinationError } from "@/lib/exit/destination";
+import { normalizeRelayDestinationUrl } from "@/lib/exit/relayDestination";
+import type { PublishProgress, PublishResult, PublishSummary } from "@/lib/exit/relayPublisher";
+
+interface RelayDestinationFormProps {
+  state: "idle" | "running" | "complete" | "failed";
+  progress: PublishProgress | null;
+  results: PublishResult[] | null;
+  summary: PublishSummary | null;
+  failure: string | null;
+  onStart(destination: string): Promise<void>;
+}
+
+function progressLabel(result: PublishResult): string {
+  switch (result.status) {
+    case "published": return "Rewritten, signed, and published";
+    case "unchanged": return result.reason ?? "Original signed event published unchanged";
+    case "skipped": return result.reason ?? "Skipped";
+    default: return result.reason ?? "Could not publish";
+  }
+}
+
+export function RelayDestinationForm({ state, progress, results, summary, failure, onStart }: RelayDestinationFormProps) {
+  const [destination, setDestination] = useState("");
+  const [validationFailure, setValidationFailure] = useState<string | null>(null);
+
+  function submit() {
+    try {
+      const normalized = normalizeRelayDestinationUrl(destination);
+      setDestination(normalized);
+      setValidationFailure(null);
+      void onStart(normalized);
+    } catch (error) {
+      setValidationFailure(error instanceof DestinationError ? error.message : "Enter a valid relay URL.");
+    }
+  }
+
+  return (
+    <Card variant="brand" accent="orange">
+      <CardHeader><CardTitle>Publish your posts to another relay</CardTitle></CardHeader>
+      <CardContent className="space-y-5">
+        <p className="text-base leading-relaxed text-muted-foreground">
+          Enter a relay you trust. Media links with confirmed destination copies will be updated; anything that could not be copied keeps its original link.
+        </p>
+        <div className="space-y-2">
+          <label htmlFor="relay-destination" className="text-sm font-semibold text-foreground">Relay URL</label>
+          <Input
+            id="relay-destination"
+            type="url"
+            inputMode="url"
+            placeholder="wss://relay.example"
+            value={destination}
+            disabled={state === "running"}
+            aria-describedby={validationFailure ? "relay-destination-error" : undefined}
+            aria-invalid={Boolean(validationFailure)}
+            onChange={(event) => setDestination(event.target.value)}
+          />
+          {validationFailure && <p id="relay-destination-error" className="text-sm text-destructive" role="alert">{validationFailure}</p>}
+        </div>
+        <Button type="button" variant="sticker" disabled={state === "running" || !destination.trim()} onClick={submit}>
+          {state === "running" ? <ArrowClockwise className="h-4 w-4 animate-spin" aria-hidden="true" /> : <Broadcast className="h-4 w-4" aria-hidden="true" />}
+          {state === "running" ? "Publishing posts" : "Publish my posts"}
+        </Button>
+        {progress && (
+          <TransferProgress
+            completed={progress.completed}
+            total={progress.total}
+            itemLabel="Event"
+            label={progressLabel(progress.result)}
+            url={progress.result.event_id}
+          />
+        )}
+        {state === "failed" && failure && (
+          <div className="flex items-start gap-3" role="alert">
+            <WarningCircle weight="fill" className="mt-1 h-5 w-5 flex-shrink-0 text-destructive" />
+            <p className="text-base leading-relaxed text-muted-foreground">{failure}</p>
+          </div>
+        )}
+        {state === "complete" && summary && (
+          <div className="space-y-4">
+            <div className="flex items-start gap-3" role="status">
+              <CheckCircle weight="fill" className="mt-1 h-5 w-5 flex-shrink-0 text-brand-dark-green dark:text-brand-green" />
+              <div>
+                <p className="font-semibold text-foreground">Relay publish finished.</p>
+                <p className="text-base leading-relaxed text-muted-foreground">
+                  {summary.published} rewritten, {summary.unchanged} unchanged, {summary.failed} failed, and {summary.skipped} skipped.
+                  {summary.remainingMediaUrls > 0 ? ` ${summary.remainingMediaUrls} media link${summary.remainingMediaUrls === 1 ? "" : "s"} still point${summary.remainingMediaUrls === 1 ? "s" : ""} to the original location.` : ""}
+                </p>
+              </div>
+            </div>
+            {results && results.length > 0 && (
+              <details className="rounded-lg border border-brand-dark-green/15 p-4 dark:border-brand-green/25">
+                <summary className="cursor-pointer font-semibold text-foreground">Event results</summary>
+                <ul className="mt-3 space-y-3">
+                  {results.map((result) => (
+                    <li key={result.event_id} className="text-sm text-muted-foreground">
+                      <span className="font-semibold text-foreground">{progressLabel(result)}</span>
+                      <span className="block break-all">{result.event_id}</span>
+                    </li>
+                  ))}
+                </ul>
+              </details>
+            )}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/exit/TransferProgress.tsx
+++ b/src/components/exit/TransferProgress.tsx
@@ -1,15 +1,16 @@
 // ABOUTME: Presents one item of progress for archive downloads and destination mirrors
 // ABOUTME: Keeps transfer status layout consistent without coupling unrelated result types
 
-export function TransferProgress({ completed, total, label, url }: {
+export function TransferProgress({ completed, total, label, url, itemLabel = "Media" }: {
   completed: number;
   total: number;
   label: string;
   url: string;
+  itemLabel?: string;
 }) {
   return (
     <div className="rounded-lg border border-brand-dark-green/15 p-4 dark:border-brand-green/25" aria-live="polite">
-      <p className="font-semibold text-foreground">Media {completed} of {total}</p>
+      <p className="font-semibold text-foreground">{itemLabel} {completed} of {total}</p>
       <p className="text-sm text-muted-foreground">{label}: <span className="break-all">{url}</span></p>
     </div>
   );

--- a/src/hooks/useDestinationMirror.test.ts
+++ b/src/hooks/useDestinationMirror.test.ts
@@ -56,6 +56,7 @@ describe("useDestinationMirror", () => {
 
     expect(fetcher.mock.calls[0][1]?.signal?.aborted).toBe(true);
     expect(result.current.summary).toBeNull();
+    expect(result.current.results).toBeNull();
     expect(result.current.failure).toBeNull();
   });
 });

--- a/src/hooks/useDestinationMirror.ts
+++ b/src/hooks/useDestinationMirror.ts
@@ -10,6 +10,7 @@ import {
   mirrorArchiveMedia,
   summarizeMirrorResults,
   type MirrorProgress,
+  type MirrorResult,
   type MirrorSummary,
 } from "@/lib/exit/mirrorClient";
 
@@ -19,6 +20,7 @@ export function useDestinationMirror(input: { files: ArchiveFiles | null; signer
   const [state, setState] = useState<DestinationMirrorState>("idle");
   const [progress, setProgress] = useState<MirrorProgress | null>(null);
   const [summary, setSummary] = useState<MirrorSummary | null>(null);
+  const [results, setResults] = useState<MirrorResult[] | null>(null);
   const [failure, setFailure] = useState<string | null>(null);
   const activeController = useRef<AbortController | null>(null);
   const archivePubkey = input.files?.["manifest.json"].pubkey;
@@ -28,6 +30,7 @@ export function useDestinationMirror(input: { files: ArchiveFiles | null; signer
     setState("idle");
     setProgress(null);
     setSummary(null);
+    setResults(null);
     setFailure(null);
     return () => activeController.current?.abort();
   }, [archivePubkey]);
@@ -40,6 +43,7 @@ export function useDestinationMirror(input: { files: ArchiveFiles | null; signer
     setState("running");
     setProgress(null);
     setSummary(null);
+    setResults(null);
     setFailure(null);
     try {
       const results = await mirrorArchiveMedia({
@@ -50,6 +54,7 @@ export function useDestinationMirror(input: { files: ArchiveFiles | null; signer
         onProgress: setProgress,
       });
       if (controller.signal.aborted) return;
+      setResults(results);
       setSummary(summarizeMirrorResults(results));
       setState("complete");
     } catch (error) {
@@ -61,5 +66,5 @@ export function useDestinationMirror(input: { files: ArchiveFiles | null; signer
     }
   }
 
-  return { state, progress, summary, failure, start };
+  return { state, progress, results, summary, failure, start };
 }

--- a/src/hooks/useDestinationRepublish.test.ts
+++ b/src/hooks/useDestinationRepublish.test.ts
@@ -1,0 +1,57 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { fixturePubkey, makeFixtureEvent, otherFixturePubkey } from "@/lib/exit/__fixtures__/exportFixtures";
+import { FixtureSigner } from "@/lib/exit/__fixtures__/fixtureSigner";
+import { buildArchiveFiles } from "@/lib/exit/archive";
+import { publishArchiveEvents } from "@/lib/exit/relayPublisher";
+
+import { useDestinationRepublish } from "./useDestinationRepublish";
+
+vi.mock("@/lib/exit/relayPublisher", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/exit/relayPublisher")>();
+  return { ...actual, publishArchiveEvents: vi.fn() };
+});
+
+function files(pubkey: string) {
+  return buildArchiveFiles({ events: [makeFixtureEvent({ pubkey })], pubkey, sourceEndpoint: "https://api.divine.video", pageCount: 1, failures: [] });
+}
+
+const signer = new FixtureSigner();
+const mirrorResults = [];
+
+describe("useDestinationRepublish", () => {
+  beforeEach(() => vi.mocked(publishArchiveEvents).mockReset());
+
+  it("completes with a publish summary", async () => {
+    vi.mocked(publishArchiveEvents).mockResolvedValue([
+      { event_id: "1".repeat(64), published_event_id: "1".repeat(64), kind: 1, status: "unchanged", remaining_media_urls: 0 },
+    ]);
+    const { result } = renderHook(() => useDestinationRepublish({ files: files(fixturePubkey), mirrorResults, signer }));
+    await act(async () => result.current.start("wss://relay.example"));
+    expect(result.current.state).toBe("complete");
+    expect(result.current.summary).toMatchObject({ published: 0, unchanged: 1, skipped: 0, failed: 0 });
+  });
+
+  it("aborts and resets when the account changes", async () => {
+    let publishSignal: AbortSignal | undefined;
+    vi.mocked(publishArchiveEvents).mockImplementation((options) => new Promise((resolve) => {
+      if (!options) {
+        resolve([]);
+        return;
+      }
+      publishSignal = options.signal;
+      options.signal?.addEventListener("abort", () => resolve([]), { once: true });
+    }));
+    const { result, rerender } = renderHook(
+      ({ archive }) => useDestinationRepublish({ files: archive, mirrorResults, signer }),
+      { initialProps: { archive: files(fixturePubkey) } },
+    );
+    act(() => { void result.current.start("wss://relay.example"); });
+    await waitFor(() => expect(result.current.state).toBe("running"));
+    rerender({ archive: files(otherFixturePubkey) });
+    await waitFor(() => expect(result.current.state).toBe("idle"));
+    expect(publishSignal?.aborted).toBe(true);
+    expect(result.current.results).toBeNull();
+  });
+});

--- a/src/hooks/useDestinationRepublish.ts
+++ b/src/hooks/useDestinationRepublish.ts
@@ -1,0 +1,75 @@
+// ABOUTME: Orchestrates destination relay republication for the account exit flow
+// ABOUTME: Aborts active work and clears relay results when its archive or mirror changes
+
+import type { NostrSigner } from "@nostrify/nostrify";
+import { useEffect, useRef, useState } from "react";
+
+import type { ArchiveFiles } from "@/lib/exit/archive";
+import type { MirrorResult } from "@/lib/exit/mirrorClient";
+import {
+  publishArchiveEvents,
+  summarizePublishResults,
+  type PublishProgress,
+  type PublishResult,
+  type PublishSummary,
+} from "@/lib/exit/relayPublisher";
+
+type DestinationRepublishState = "idle" | "running" | "complete" | "failed";
+
+export function useDestinationRepublish(input: {
+  files: ArchiveFiles | null;
+  mirrorResults: MirrorResult[] | null;
+  signer: NostrSigner | null | undefined;
+}) {
+  const [state, setState] = useState<DestinationRepublishState>("idle");
+  const [progress, setProgress] = useState<PublishProgress | null>(null);
+  const [results, setResults] = useState<PublishResult[] | null>(null);
+  const [summary, setSummary] = useState<PublishSummary | null>(null);
+  const [failure, setFailure] = useState<string | null>(null);
+  const activeController = useRef<AbortController | null>(null);
+  const archivePubkey = input.files?.["manifest.json"].pubkey;
+
+  useEffect(() => {
+    activeController.current?.abort();
+    setState("idle");
+    setProgress(null);
+    setResults(null);
+    setSummary(null);
+    setFailure(null);
+    return () => activeController.current?.abort();
+  }, [archivePubkey, input.mirrorResults]);
+
+  async function start(destination: string) {
+    if (!input.files || !input.mirrorResults || !input.signer) return;
+    const controller = new AbortController();
+    activeController.current?.abort();
+    activeController.current = controller;
+    setState("running");
+    setProgress(null);
+    setResults(null);
+    setSummary(null);
+    setFailure(null);
+    try {
+      const publishResults = await publishArchiveEvents({
+        destination,
+        events: input.files["events.json"],
+        mirrorResults: input.mirrorResults,
+        signer: input.signer,
+        signal: controller.signal,
+        onProgress: setProgress,
+      });
+      if (controller.signal.aborted) return;
+      setResults(publishResults);
+      setSummary(summarizePublishResults(publishResults));
+      setState("complete");
+    } catch (error) {
+      if (controller.signal.aborted) return;
+      setFailure(error instanceof Error ? error.message : "The relay publish stopped. Try again.");
+      setState("failed");
+    } finally {
+      if (activeController.current === controller) activeController.current = null;
+    }
+  }
+
+  return { state, progress, results, summary, failure, start };
+}

--- a/src/lib/exit/destination.ts
+++ b/src/lib/exit/destination.ts
@@ -11,7 +11,10 @@ export type DestinationErrorCode =
   | "unreachable"
   | "auth-required"
   | "no-mirror-support"
-  | "rate-limited";
+  | "rate-limited"
+  | "invalid-relay-url"
+  | "insecure-relay-scheme"
+  | "private-relay-host";
 
 export class DestinationError extends Error {
   constructor(

--- a/src/lib/exit/eventRewrite.test.ts
+++ b/src/lib/exit/eventRewrite.test.ts
@@ -1,0 +1,124 @@
+import type { NostrEvent } from "@nostrify/nostrify";
+import { describe, expect, it } from "vitest";
+
+import type { MirrorResult } from "./mirrorClient";
+import {
+  buildDestinationUrlMap,
+  referencedEventIds,
+  republishSkipReason,
+  rewriteEventMedia,
+  rewriteEventReferences,
+} from "./eventRewrite";
+
+const PUBKEY = "a".repeat(64);
+const ID = "b".repeat(64);
+const SOURCE = `https://media.divine.video/${"c".repeat(64)}.mp4`;
+const DESTINATION = `https://blossom.example/${"c".repeat(64)}`;
+
+function event(overrides: Partial<NostrEvent> = {}): NostrEvent {
+  return {
+    id: ID,
+    pubkey: PUBKEY,
+    sig: "d".repeat(128),
+    kind: 34236,
+    created_at: 1_700_000_000,
+    content: `Watch ${SOURCE}`,
+    tags: [["url", SOURCE], ["title", "A loop"]],
+    ...overrides,
+  };
+}
+
+function mirror(verification: MirrorResult["verification"] = "descriptor-verified"): MirrorResult {
+  return {
+    references: [{ event_id: ID, tag: "url", url: SOURCE, sha256: "c".repeat(64) }],
+    source_url: SOURCE,
+    destination_url: DESTINATION,
+    expected_sha256: "c".repeat(64),
+    destination_sha256: "c".repeat(64),
+    byte_size: 10,
+    verification,
+  };
+}
+
+describe("buildDestinationUrlMap", () => {
+  it("uses only descriptor-verified results and maps every grouped source", () => {
+    const verified = mirror();
+    verified.references.push({ event_id: "e".repeat(64), tag: "thumb", url: `${SOURCE}?thumb=1`, sha256: "c".repeat(64) });
+    const map = buildDestinationUrlMap([verified, mirror("unverified"), mirror("hash-mismatch")]);
+    expect([...map.entries()]).toEqual([
+      [SOURCE, DESTINATION],
+      [`${SOURCE}?thumb=1`, DESTINATION],
+    ]);
+  });
+});
+
+describe("rewriteEventMedia", () => {
+  it("rewrites direct tags and exact content occurrences while preserving event fields", () => {
+    const original = event();
+    const result = rewriteEventMedia(original, new Map([[SOURCE, DESTINATION]]));
+    expect(result).toEqual({
+      changed: true,
+      remainingMediaUrls: 0,
+      template: {
+        kind: 34236,
+        created_at: original.created_at,
+        content: `Watch ${DESTINATION}`,
+        tags: [["url", DESTINATION], ["title", "A loop"]],
+      },
+    });
+    expect(original.tags[0][1]).toBe(SOURCE);
+  });
+
+  it("rewrites both imeta encodings without changing order or unrelated values", () => {
+    const pairSource = `${SOURCE}?pair=1`;
+    const original = event({
+      content: "unchanged",
+      tags: [
+        ["imeta", `url ${SOURCE}`, "m video/mp4", `image ${pairSource}`, `x ${"c".repeat(64)}`],
+        ["imeta", "url", pairSource, "m", "video/mp4", "fallback", SOURCE],
+      ],
+    });
+    const result = rewriteEventMedia(original, new Map([[SOURCE, DESTINATION], [pairSource, `${DESTINATION}?pair=1`]]));
+    expect(result.template.tags).toEqual([
+      ["imeta", `url ${DESTINATION}`, "m video/mp4", `image ${DESTINATION}?pair=1`, `x ${"c".repeat(64)}`],
+      ["imeta", "url", `${DESTINATION}?pair=1`, "m", "video/mp4", "fallback", DESTINATION],
+    ]);
+  });
+
+  it("leaves unmapped URLs unchanged and reports them", () => {
+    const result = rewriteEventMedia(event({ content: "unchanged" }), new Map());
+    expect(result.changed).toBe(false);
+    expect(result.remainingMediaUrls).toBe(1);
+  });
+});
+
+describe("event references", () => {
+  it("finds full reference ids in tags and repost payloads", () => {
+    const referenced = event({ id: "e".repeat(64) });
+    const repost = event({ kind: 16, content: JSON.stringify(referenced), tags: [["e", ID], ["q", ID]] });
+    expect(referencedEventIds(repost)).toEqual([ID, "e".repeat(64)]);
+  });
+
+  it("remaps e, E, and q tags plus serialized repost content", () => {
+    const old = event();
+    const replacement = event({ id: "f".repeat(64), sig: "1".repeat(128) });
+    const repost = event({ kind: 16, content: JSON.stringify(old), tags: [["E", ID], ["q", ID, "wss://relay.example"]] });
+    const result = rewriteEventReferences(
+      { kind: repost.kind, created_at: repost.created_at, content: repost.content, tags: repost.tags },
+      new Map([[ID, replacement]]),
+    );
+    expect(result.changed).toBe(true);
+    expect(result.template.tags).toEqual([["E", replacement.id], ["q", replacement.id, "wss://relay.example"]]);
+    expect(JSON.parse(result.template.content)).toEqual(replacement);
+  });
+});
+
+describe("republishSkipReason", () => {
+  it.each([4, 14, 1059, 5, 62, 22242, 24133, 24242, 27235])("skips non-portable kind %s", (kind) => {
+    expect(republishSkipReason(kind)).not.toBeNull();
+  });
+
+  it.each([0, 1, 3, 7, 16, 1111, 10002, 30005, 34236])("allows durable public kind %s", (kind) => {
+    expect(republishSkipReason(kind)).toBeNull();
+  });
+});

--- a/src/lib/exit/eventRewrite.test.ts
+++ b/src/lib/exit/eventRewrite.test.ts
@@ -114,7 +114,7 @@ describe("event references", () => {
 });
 
 describe("republishSkipReason", () => {
-  it.each([4, 14, 1059, 5, 62, 22242, 24133, 24242, 27235])("skips non-portable kind %s", (kind) => {
+  it.each([4, 13, 14, 15, 1059, 5, 62, 22242, 24133, 24242, 27235])("skips non-portable kind %s", (kind) => {
     expect(republishSkipReason(kind)).not.toBeNull();
   });
 

--- a/src/lib/exit/eventRewrite.ts
+++ b/src/lib/exit/eventRewrite.ts
@@ -15,7 +15,10 @@ export interface EventRewrite {
 
 const URL_TAGS = new Set(["url", "image", "thumb", "thumbnail"]);
 const IMETA_URL_KEYS = new Set(["url", "image", "thumb", "thumbnail", "fallback"]);
-const PRIVATE_MESSAGE_KINDS = new Set([4, 14, 1059]);
+// 4 is a NIP-04 direct message; 13 is the NIP-59 seal, which carries the
+// sender's real pubkey and so is the one of these an owner export can return;
+// 14 and 15 are NIP-17 chat and file messages; 1059 is the NIP-59 gift wrap.
+const PRIVATE_MESSAGE_KINDS = new Set([4, 13, 14, 15, 1059]);
 const DESTRUCTIVE_KINDS = new Set([5, 62]);
 
 export function buildDestinationUrlMap(results: MirrorResult[]): Map<string, string> {

--- a/src/lib/exit/eventRewrite.ts
+++ b/src/lib/exit/eventRewrite.ts
@@ -1,0 +1,147 @@
+// ABOUTME: Rewrites exported event media and references for a destination relay
+// ABOUTME: Keeps unchanged signed events intact and identifies events unsafe to republish
+
+import type { NostrEvent } from "@nostrify/nostrify";
+
+import type { MirrorResult } from "./mirrorClient";
+
+export type EventTemplate = Omit<NostrEvent, "id" | "pubkey" | "sig">;
+
+export interface EventRewrite {
+  template: EventTemplate;
+  changed: boolean;
+  remainingMediaUrls: number;
+}
+
+const URL_TAGS = new Set(["url", "image", "thumb", "thumbnail"]);
+const IMETA_URL_KEYS = new Set(["url", "image", "thumb", "thumbnail", "fallback"]);
+const PRIVATE_MESSAGE_KINDS = new Set([4, 14, 1059]);
+const DESTRUCTIVE_KINDS = new Set([5, 62]);
+
+export function buildDestinationUrlMap(results: MirrorResult[]): Map<string, string> {
+  const urls = new Map<string, string>();
+  for (const result of results) {
+    if (result.verification !== "descriptor-verified" || !result.destination_url) continue;
+    for (const reference of result.references) {
+      urls.set(reference.url, result.destination_url);
+    }
+  }
+  return urls;
+}
+
+export function republishSkipReason(kind: number): string | null {
+  if (PRIVATE_MESSAGE_KINDS.has(kind)) return "Encrypted private messages stay on their original relays.";
+  if (kind >= 20_000 && kind < 30_000) return "Temporary authentication and ephemeral events are not portable posts.";
+  if (DESTRUCTIVE_KINDS.has(kind)) return "Deletion and vanish requests are not replayed during a move.";
+  return null;
+}
+
+function replaceExact(value: string, urls: ReadonlyMap<string, string>): string {
+  return urls.get(value) ?? value;
+}
+
+function rewriteImeta(tag: string[], urls: ReadonlyMap<string, string>): string[] {
+  if (tag[1]?.includes(" ")) {
+    return tag.map((value, index) => {
+      if (index === 0) return value;
+      const [key, ...body] = value.split(" ");
+      if (!IMETA_URL_KEYS.has(key)) return value;
+      const original = body.join(" ");
+      const replacement = replaceExact(original, urls);
+      return replacement === original ? value : `${key} ${replacement}`;
+    });
+  }
+
+  return tag.map((value, index) => {
+    if (index < 2 || index % 2 !== 0) return value;
+    const key = tag[index - 1];
+    return IMETA_URL_KEYS.has(key) ? replaceExact(value, urls) : value;
+  });
+}
+
+function countRemainingMediaUrls(tags: string[][], urls: ReadonlyMap<string, string>): number {
+  let count = 0;
+  for (const tag of tags) {
+    if (URL_TAGS.has(tag[0]) && tag[1] && !urls.has(tag[1])) count += 1;
+    if (tag[0] !== "imeta") continue;
+    if (tag[1]?.includes(" ")) {
+      count += tag.slice(1).filter((value) => {
+        const [key, ...body] = value.split(" ");
+        return IMETA_URL_KEYS.has(key) && body.length > 0 && !urls.has(body.join(" "));
+      }).length;
+    } else {
+      for (let index = 1; index < tag.length; index += 2) {
+        if (IMETA_URL_KEYS.has(tag[index]) && tag[index + 1] && !urls.has(tag[index + 1])) count += 1;
+      }
+    }
+  }
+  return count;
+}
+
+export function rewriteEventMedia(event: NostrEvent, urls: ReadonlyMap<string, string>): EventRewrite {
+  const tags = event.tags.map((tag) => {
+    if (URL_TAGS.has(tag[0]) && tag[1]) {
+      const rewritten = [...tag];
+      rewritten[1] = replaceExact(tag[1], urls);
+      return rewritten;
+    }
+    return tag[0] === "imeta" ? rewriteImeta(tag, urls) : [...tag];
+  });
+  let content = event.content;
+  for (const [source, destination] of urls) {
+    content = content.split(source).join(destination);
+  }
+  const changed = content !== event.content || tags.some((tag, index) =>
+    tag.some((value, part) => value !== event.tags[index][part]) || tag.length !== event.tags[index].length
+  );
+  return {
+    template: { kind: event.kind, created_at: event.created_at, content, tags },
+    changed,
+    remainingMediaUrls: countRemainingMediaUrls(event.tags, urls),
+  };
+}
+
+export function referencedEventIds(event: NostrEvent): string[] {
+  const ids = event.tags
+    .filter((tag) => (tag[0] === "e" || tag[0] === "E" || tag[0] === "q") && tag[1])
+    .map((tag) => tag[1]);
+  if (event.kind === 6 || event.kind === 16) {
+    try {
+      const repost = JSON.parse(event.content) as Partial<NostrEvent>;
+      if (typeof repost.id === "string") ids.push(repost.id);
+    } catch {
+      // Non-JSON generic repost content is valid and has nothing to remap here.
+    }
+  }
+  return [...new Set(ids)];
+}
+
+export function rewriteEventReferences(
+  template: EventTemplate,
+  idMap: ReadonlyMap<string, NostrEvent>,
+): { template: EventTemplate; changed: boolean } {
+  let changed = false;
+  const tags = template.tags.map((tag) => {
+    if ((tag[0] === "e" || tag[0] === "E" || tag[0] === "q") && idMap.has(tag[1])) {
+      changed = true;
+      const rewritten = [...tag];
+      rewritten[1] = idMap.get(tag[1])!.id;
+      return rewritten;
+    }
+    return tag;
+  });
+  let content = template.content;
+  if (template.kind === 6 || template.kind === 16) {
+    try {
+      const repost = JSON.parse(content) as NostrEvent;
+      const replacement = idMap.get(repost.id);
+      if (replacement) {
+        content = JSON.stringify(replacement);
+        changed = true;
+      }
+    } catch {
+      // Non-JSON generic repost content is valid and has nothing to remap here.
+    }
+  }
+  return { template: { ...template, tags, content }, changed };
+}

--- a/src/lib/exit/relayDestination.test.ts
+++ b/src/lib/exit/relayDestination.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+
+import { DestinationError } from "./destination";
+import { normalizeRelayDestinationUrl } from "./relayDestination";
+
+describe("normalizeRelayDestinationUrl", () => {
+  it("normalizes a public secure relay and preserves its path and query", () => {
+    expect(normalizeRelayDestinationUrl(" WSS://Relay.Example/nostr?tenant=one ")).toBe(
+      "wss://relay.example/nostr?tenant=one",
+    );
+  });
+
+  it.each([
+    ["not a url", "invalid-relay-url"],
+    ["ws://relay.example", "insecure-relay-scheme"],
+    ["https://relay.example", "insecure-relay-scheme"],
+    ["wss://user:pass@relay.example", "embedded-credentials"],
+    ["wss://relay.example/#hidden", "fragment-not-allowed"],
+    ["wss://localhost/relay", "private-relay-host"],
+    ["wss://127.0.0.1/relay", "private-relay-host"],
+    ["wss://http//evil.example", "private-relay-host"],
+  ])("rejects %s", (value, code) => {
+    expect(() => normalizeRelayDestinationUrl(value)).toThrowError(
+      expect.objectContaining<Partial<DestinationError>>({ code: code as DestinationError["code"] }),
+    );
+  });
+});

--- a/src/lib/exit/relayDestination.ts
+++ b/src/lib/exit/relayDestination.ts
@@ -1,0 +1,32 @@
+// ABOUTME: Validates user-provided relay destinations for account republication
+// ABOUTME: Preserves legitimate relay paths while rejecting unsafe remote endpoints
+
+import { isRemoteSuppliedRelayUrlAllowed } from "@/lib/relayUrlPolicy";
+
+import { DestinationError } from "./destination";
+
+export function normalizeRelayDestinationUrl(value: string): string {
+  let destination: URL;
+  try {
+    destination = new URL(value.trim());
+  } catch {
+    throw new DestinationError("invalid-relay-url", "Enter a complete relay URL.");
+  }
+
+  if (destination.protocol !== "wss:") {
+    throw new DestinationError("insecure-relay-scheme", "Use a secure wss:// relay URL.");
+  }
+  if (destination.username || destination.password) {
+    throw new DestinationError("embedded-credentials", "Remove the username and password from this URL.");
+  }
+  if (destination.hash) {
+    throw new DestinationError("fragment-not-allowed", "Remove the fragment from this URL.");
+  }
+  if (!isRemoteSuppliedRelayUrlAllowed(destination.toString())) {
+    throw new DestinationError("private-relay-host", "Use a public relay address, not a private or local host.");
+  }
+
+  destination.protocol = "wss:";
+  destination.hostname = destination.hostname.toLowerCase();
+  return destination.toString();
+}

--- a/src/lib/exit/relayPublisher.test.ts
+++ b/src/lib/exit/relayPublisher.test.ts
@@ -1,0 +1,241 @@
+import type { NostrEvent, NostrSigner } from "@nostrify/nostrify";
+import { describe, expect, it, vi } from "vitest";
+
+import type { MirrorResult } from "./mirrorClient";
+import { publishArchiveEvents, summarizePublishResults } from "./relayPublisher";
+
+const PUBKEY = "a".repeat(64);
+const SOURCE = `https://media.divine.video/${"b".repeat(64)}.mp4`;
+const DESTINATION_MEDIA = `https://blossom.example/${"b".repeat(64)}`;
+const RELAY = "wss://relay.example/nostr";
+
+function makeEvent(idChar: string, overrides: Partial<NostrEvent> = {}): NostrEvent {
+  return {
+    id: idChar.repeat(64),
+    pubkey: PUBKEY,
+    sig: idChar.repeat(128),
+    kind: 1,
+    created_at: 1_700_000_000,
+    content: "hello",
+    tags: [],
+    ...overrides,
+  };
+}
+
+function makeSigner(): NostrSigner & { signEvent: ReturnType<typeof vi.fn> } {
+  let counter = 0;
+  return {
+    getPublicKey: vi.fn().mockResolvedValue(PUBKEY),
+    nip04: undefined,
+    nip44: undefined,
+    signEvent: vi.fn(async (template: Omit<NostrEvent, "id" | "pubkey" | "sig">) => {
+      counter += 1;
+      return { ...template, id: counter.toString(16).padStart(64, "0"), pubkey: PUBKEY, sig: counter.toString(16).repeat(128).slice(0, 128) };
+    }),
+  } as unknown as NostrSigner & { signEvent: ReturnType<typeof vi.fn> };
+}
+
+function mirrorResult(): MirrorResult {
+  return {
+    references: [{ event_id: "1".repeat(64), tag: "url", url: SOURCE, sha256: "b".repeat(64) }],
+    source_url: SOURCE,
+    destination_url: DESTINATION_MEDIA,
+    expected_sha256: "b".repeat(64),
+    destination_sha256: "b".repeat(64),
+    byte_size: 10,
+    verification: "descriptor-verified",
+  };
+}
+
+function fakeRelay(responses: Array<Error | "ok"> = []) {
+  const published: NostrEvent[] = [];
+  const close = vi.fn().mockResolvedValue(undefined);
+  return {
+    published,
+    close,
+    event: vi.fn(async (event: NostrEvent) => {
+      published.push(event);
+      const response = responses.shift() ?? "ok";
+      if (response instanceof Error) throw response;
+    }),
+  };
+}
+
+describe("publishArchiveEvents", () => {
+  it("publishes unchanged signed events without asking the signer", async () => {
+    const signer = makeSigner();
+    const relay = fakeRelay();
+    const original = makeEvent("1");
+    const results = await publishArchiveEvents({
+      destination: RELAY,
+      events: [original],
+      mirrorResults: [],
+      signer,
+      relayFactory: () => relay,
+    });
+    expect(relay.published).toEqual([original]);
+    expect(signer.signEvent).not.toHaveBeenCalled();
+    expect(results[0]).toMatchObject({ status: "unchanged", event_id: original.id, published_event_id: original.id });
+    expect(relay.close).toHaveBeenCalledOnce();
+  });
+
+  it("rewrites, signs, and publishes referenced events before forward dependants", async () => {
+    const signer = makeSigner();
+    const relay = fakeRelay();
+    const video = makeEvent("1", { kind: 34236, content: SOURCE, tags: [["url", SOURCE]] });
+    const comment = makeEvent("2", { kind: 1111, tags: [["E", video.id], ["e", video.id]] });
+    const reply = makeEvent("3", { kind: 1111, tags: [["E", video.id], ["e", comment.id]] });
+    const results = await publishArchiveEvents({
+      destination: RELAY,
+      events: [reply, comment, video],
+      mirrorResults: [mirrorResult()],
+      signer,
+      relayFactory: () => relay,
+    });
+    expect(relay.published.map((event) => event.kind)).toEqual([34236, 1111, 1111]);
+    expect(relay.published[1].tags).toEqual([["E", relay.published[0].id], ["e", relay.published[0].id]]);
+    expect(relay.published[2].tags).toEqual([["E", relay.published[0].id], ["e", relay.published[1].id]]);
+    expect(results.every((result) => result.status === "published")).toBe(true);
+  });
+
+  it("replaces serialized repost content with the newly signed referenced event", async () => {
+    const signer = makeSigner();
+    const relay = fakeRelay();
+    const video = makeEvent("1", { kind: 34236, content: SOURCE, tags: [["url", SOURCE]] });
+    const repost = makeEvent("2", { kind: 16, content: JSON.stringify(video), tags: [["e", video.id]] });
+    await publishArchiveEvents({ destination: RELAY, events: [repost, video], mirrorResults: [mirrorResult()], signer, relayFactory: () => relay });
+    expect(JSON.parse(relay.published[1].content)).toEqual(relay.published[0]);
+  });
+
+  it("reports circular owner references instead of publishing dangling replacements", async () => {
+    const first = makeEvent("1", { tags: [["e", "2".repeat(64)]] });
+    const second = makeEvent("2", { tags: [["e", first.id]] });
+    const relay = fakeRelay();
+    const results = await publishArchiveEvents({ destination: RELAY, events: [first, second], mirrorResults: [], signer: makeSigner(), relayFactory: () => relay });
+    expect(results).toHaveLength(2);
+    expect(results.every((result) => result.status === "failed" && result.reason?.includes("circular reference"))).toBe(true);
+    expect(relay.event).not.toHaveBeenCalled();
+  });
+
+  it("skips encrypted, ephemeral, and destructive events", async () => {
+    const signer = makeSigner();
+    const relay = fakeRelay();
+    const results = await publishArchiveEvents({
+      destination: RELAY,
+      events: [makeEvent("1", { kind: 4 }), makeEvent("2", { kind: 22242 }), makeEvent("3", { kind: 5 })],
+      mirrorResults: [],
+      signer,
+      relayFactory: () => relay,
+    });
+    expect(results.map((result) => result.status)).toEqual(["skipped", "skipped", "skipped"]);
+    expect(relay.event).not.toHaveBeenCalled();
+  });
+
+  it("counts duplicate refusals as success", async () => {
+    const relay = fakeRelay([new Error("duplicate: already stored")]);
+    const results = await publishArchiveEvents({ destination: RELAY, events: [makeEvent("1")], mirrorResults: [], signer: makeSigner(), relayFactory: () => relay });
+    expect(results[0]).toMatchObject({ status: "unchanged", reason: "The relay already has this event." });
+  });
+
+  it("backs off and retries a bounded rate limit", async () => {
+    const relay = fakeRelay([new Error("rate-limited: slow down"), "ok"]);
+    const wait = vi.fn().mockResolvedValue(undefined);
+    const results = await publishArchiveEvents({ destination: RELAY, events: [makeEvent("1")], mirrorResults: [], signer: makeSigner(), relayFactory: () => relay, wait });
+    expect(relay.event).toHaveBeenCalledTimes(2);
+    expect(wait).toHaveBeenCalledWith(1000, undefined);
+    expect(results[0].status).toBe("unchanged");
+  });
+
+  it.each([
+    ["blocked: policy", "blocked this event"],
+    ["restricted: members only", "restricts this event"],
+    ["invalid: bad tags", "event is invalid"],
+    ["pow: 24 bits", "requires proof of work"],
+    ["unrecognized response", "unrecognized response"],
+  ])("reports %s clearly and continues", async (message, expected) => {
+    const relay = fakeRelay([new Error(message), "ok"]);
+    const results = await publishArchiveEvents({ destination: RELAY, events: [makeEvent("1"), makeEvent("2")], mirrorResults: [], signer: makeSigner(), relayFactory: () => relay });
+    expect(results[0]).toMatchObject({ status: "failed" });
+    expect(results[0].reason).toContain(expected);
+    expect(results[1].status).toBe("unchanged");
+  });
+
+  it("times out a relay that never returns a valid OK and closes it", async () => {
+    const close = vi.fn().mockResolvedValue(undefined);
+    const relay = {
+      close,
+      event: vi.fn((_event: NostrEvent, options?: { signal?: AbortSignal }) => new Promise<void>((_resolve, reject) => {
+        options?.signal?.addEventListener("abort", () => reject(new DOMException("aborted", "AbortError")), { once: true });
+      })),
+    };
+    const results = await publishArchiveEvents({ destination: RELAY, events: [makeEvent("1")], mirrorResults: [], signer: makeSigner(), relayFactory: () => relay, eventTimeoutMs: 1 });
+    expect(results[0]).toMatchObject({ status: "failed", reason: "The relay did not answer before the publish timed out." });
+    expect(close).toHaveBeenCalledOnce();
+  });
+
+  it("passes a NIP-42 callback that signs the full relay URL and challenge", async () => {
+    const signer = makeSigner();
+    const relay = fakeRelay();
+    let auth: ((challenge: string) => Promise<NostrEvent>) | undefined;
+    await publishArchiveEvents({
+      destination: RELAY,
+      events: [makeEvent("1")],
+      mirrorResults: [],
+      signer,
+      relayFactory: (_url, options) => {
+        auth = options.auth;
+        return relay;
+      },
+    });
+    await auth!("full challenge value");
+    expect(signer.signEvent).toHaveBeenCalledWith(expect.objectContaining({
+      kind: 22242,
+      tags: [["relay", RELAY], ["challenge", "full challenge value"]],
+    }));
+  });
+
+  it("stops clearly when the signer refuses NIP-42 relay access", async () => {
+    const signer = makeSigner();
+    signer.signEvent.mockRejectedValueOnce(new Error("not allowed"));
+    const close = vi.fn().mockResolvedValue(undefined);
+    await expect(publishArchiveEvents({
+      destination: RELAY,
+      events: [makeEvent("1")],
+      mirrorResults: [],
+      signer,
+      relayFactory: (_url, options) => ({
+        close,
+        event: vi.fn((_event, publishOptions) => new Promise<void>((_resolve, reject) => {
+          publishOptions?.signal?.addEventListener("abort", () => reject(new DOMException("aborted", "AbortError")), { once: true });
+          void options.auth("challenge").catch(() => undefined);
+        })),
+      }),
+    })).rejects.toMatchObject({
+      code: "auth-required",
+      message: "Your signer refused the relay's access request.",
+    });
+    expect(close).toHaveBeenCalledOnce();
+  });
+
+  it("keeps signer refusal local to the changed event", async () => {
+    const signer = makeSigner();
+    signer.signEvent.mockRejectedValueOnce(new Error("not allowed"));
+    const relay = fakeRelay();
+    const changed = makeEvent("1", { kind: 34236, content: SOURCE, tags: [["url", SOURCE]] });
+    const unchanged = makeEvent("2");
+    const results = await publishArchiveEvents({ destination: RELAY, events: [changed, unchanged], mirrorResults: [mirrorResult()], signer, relayFactory: () => relay });
+    expect(results.find((result) => result.event_id === changed.id)).toMatchObject({ status: "failed", reason: expect.stringContaining("signer refused") });
+    expect(relay.published).toEqual([unchanged]);
+  });
+});
+
+describe("summarizePublishResults", () => {
+  it("reports every terminal state and remaining media URL", () => {
+    expect(summarizePublishResults([
+      { event_id: "1".repeat(64), published_event_id: "a".repeat(64), kind: 1, status: "published", remaining_media_urls: 2 },
+      { event_id: "2".repeat(64), published_event_id: "2".repeat(64), kind: 1, status: "unchanged", remaining_media_urls: 0 },
+      { event_id: "3".repeat(64), published_event_id: null, kind: 4, status: "skipped", remaining_media_urls: 0 },
+      { event_id: "4".repeat(64), published_event_id: null, kind: 1, status: "failed", remaining_media_urls: 1 },
+    ])).toEqual({ published: 1, unchanged: 1, skipped: 1, failed: 1, remainingMediaUrls: 3 });
+  });
+});

--- a/src/lib/exit/relayPublisher.test.ts
+++ b/src/lib/exit/relayPublisher.test.ts
@@ -217,6 +217,32 @@ describe("publishArchiveEvents", () => {
     expect(close).toHaveBeenCalledOnce();
   });
 
+  it("republishes after a NIP-42 relay answers the first events with auth-required", async () => {
+    const published: NostrEvent[] = [];
+    let authenticated = false;
+    const results = await publishArchiveEvents({
+      destination: RELAY,
+      events: [makeEvent("1"), makeEvent("2")],
+      mirrorResults: [],
+      signer: makeSigner(),
+      wait: vi.fn().mockResolvedValue(undefined),
+      relayFactory: (_url, options) => {
+        // A NIP-42 relay challenges on connect. The signer answers it while the
+        // first events are already on the wire, so those come back refused.
+        void options.auth("challenge").then(() => { authenticated = true; });
+        return {
+          close: vi.fn().mockResolvedValue(undefined),
+          event: vi.fn(async (event: NostrEvent) => {
+            if (!authenticated) throw new Error("auth-required: we only accept events from authenticated users");
+            published.push(event);
+          }),
+        };
+      },
+    });
+    expect(published).toHaveLength(2);
+    expect(results.map((result) => result.status)).toEqual(["unchanged", "unchanged"]);
+  });
+
   it("keeps signer refusal local to the changed event", async () => {
     const signer = makeSigner();
     signer.signEvent.mockRejectedValueOnce(new Error("not allowed"));

--- a/src/lib/exit/relayPublisher.test.ts
+++ b/src/lib/exit/relayPublisher.test.ts
@@ -194,26 +194,34 @@ describe("publishArchiveEvents", () => {
     }));
   });
 
-  it("stops clearly when the signer refuses NIP-42 relay access", async () => {
+  it("preserves completed results when the signer refuses NIP-42 relay access", async () => {
     const signer = makeSigner();
     signer.signEvent.mockRejectedValueOnce(new Error("not allowed"));
     const close = vi.fn().mockResolvedValue(undefined);
-    await expect(publishArchiveEvents({
+    let publishCount = 0;
+    const results = await publishArchiveEvents({
       destination: RELAY,
-      events: [makeEvent("1")],
+      events: [makeEvent("1"), makeEvent("2"), makeEvent("3")],
       mirrorResults: [],
       signer,
       relayFactory: (_url, options) => ({
         close,
-        event: vi.fn((_event, publishOptions) => new Promise<void>((_resolve, reject) => {
-          publishOptions?.signal?.addEventListener("abort", () => reject(new DOMException("aborted", "AbortError")), { once: true });
-          void options.auth("challenge").catch(() => undefined);
-        })),
+        event: vi.fn((_event, publishOptions) => {
+          publishCount += 1;
+          if (publishCount === 1) return Promise.resolve();
+          return new Promise<void>((_resolve, reject) => {
+            publishOptions?.signal?.addEventListener("abort", () => reject(new DOMException("aborted", "AbortError")), { once: true });
+            void options.auth("challenge").catch(() => undefined);
+          });
+        }),
       }),
-    })).rejects.toMatchObject({
-      code: "auth-required",
-      message: "Your signer refused the relay's access request.",
     });
+    expect(results.map((result) => result.status)).toEqual(["unchanged", "failed", "failed"]);
+    expect(results.slice(1)).toEqual(expect.arrayContaining([
+      expect.objectContaining({ reason: "Your signer refused the relay's access request." }),
+    ]));
+    expect(summarizePublishResults(results)).toMatchObject({ unchanged: 1, failed: 2 });
+    expect(publishCount).toBe(2);
     expect(close).toHaveBeenCalledOnce();
   });
 

--- a/src/lib/exit/relayPublisher.ts
+++ b/src/lib/exit/relayPublisher.ts
@@ -1,0 +1,316 @@
+// ABOUTME: Re-signs changed archive events and publishes them to one destination relay
+// ABOUTME: Orders referenced events first while isolating signer and relay failures per event
+
+import { NRelay1, type NostrEvent, type NostrSigner } from "@nostrify/nostrify";
+
+import {
+  buildDestinationUrlMap,
+  referencedEventIds,
+  republishSkipReason,
+  rewriteEventMedia,
+  rewriteEventReferences,
+} from "./eventRewrite";
+import { DestinationError } from "./destination";
+import type { MirrorResult } from "./mirrorClient";
+import { normalizeRelayDestinationUrl } from "./relayDestination";
+
+export type PublishStatus = "published" | "unchanged" | "skipped" | "failed";
+
+export interface PublishResult {
+  event_id: string;
+  published_event_id: string | null;
+  kind: number;
+  status: PublishStatus;
+  remaining_media_urls: number;
+  reason?: string;
+}
+
+export interface PublishProgress {
+  completed: number;
+  total: number;
+  result: PublishResult;
+}
+
+export interface PublishSummary {
+  published: number;
+  unchanged: number;
+  skipped: number;
+  failed: number;
+  remainingMediaUrls: number;
+}
+
+interface RelayConnection {
+  event(event: NostrEvent, options?: { signal?: AbortSignal }): Promise<void>;
+  close(): Promise<void>;
+}
+
+interface RelayFactoryOptions {
+  auth(challenge: string): Promise<NostrEvent>;
+}
+
+export interface PublishArchiveOptions {
+  destination: string;
+  events: NostrEvent[];
+  mirrorResults: MirrorResult[];
+  signer: NostrSigner;
+  signal?: AbortSignal;
+  relayFactory?: (url: string, options: RelayFactoryOptions) => RelayConnection;
+  wait?: (milliseconds: number, signal?: AbortSignal) => Promise<void>;
+  eventTimeoutMs?: number;
+  maxRateLimitRetries?: number;
+  onProgress?(progress: PublishProgress): void;
+}
+
+interface PreparedEvent {
+  original: NostrEvent;
+  event: NostrEvent;
+  changed: boolean;
+  remainingMediaUrls: number;
+}
+
+interface RelayAuthState {
+  failure: string | null;
+  currentPublish: AbortController | null;
+}
+
+const HEX_64 = /^[0-9a-f]{64}$/i;
+const DEFAULT_EVENT_TIMEOUT_MS = 15_000;
+
+function defaultWait(milliseconds: number, signal?: AbortSignal): Promise<void> {
+  return new Promise((resolve, reject) => {
+    if (signal?.aborted) {
+      reject(new DOMException("Republish cancelled", "AbortError"));
+      return;
+    }
+    const timeout = window.setTimeout(resolve, milliseconds);
+    const abort = () => {
+      window.clearTimeout(timeout);
+      reject(new DOMException("Republish cancelled", "AbortError"));
+    };
+    signal?.addEventListener("abort", abort, { once: true });
+  });
+}
+
+function relayRefusal(error: unknown): { code: string; message: string; retry: boolean; duplicate: boolean } {
+  if (error instanceof DOMException && error.name === "AbortError") {
+    return { code: "timeout", message: "The relay did not answer before the publish timed out.", retry: false, duplicate: false };
+  }
+  const raw = error instanceof Error ? error.message.trim() : "";
+  const separator = raw.indexOf(":");
+  const prefix = (separator === -1 ? "" : raw.slice(0, separator)).toLowerCase();
+  const detail = (separator === -1 ? raw : raw.slice(separator + 1)).replace(/\s+/g, " ").trim().slice(0, 200);
+  switch (prefix) {
+    case "duplicate": return { code: prefix, message: "The relay already has this event.", retry: false, duplicate: true };
+    case "rate-limited": return { code: prefix, message: "The relay is accepting events too slowly.", retry: true, duplicate: false };
+    case "blocked": return { code: prefix, message: `The relay blocked this event.${detail ? ` ${detail}` : ""}`, retry: false, duplicate: false };
+    case "restricted": return { code: prefix, message: `The relay restricts this event.${detail ? ` ${detail}` : ""}`, retry: false, duplicate: false };
+    case "invalid": return { code: prefix, message: `The relay says this event is invalid.${detail ? ` ${detail}` : ""}`, retry: false, duplicate: false };
+    case "pow": return { code: prefix, message: `The relay requires proof of work.${detail ? ` ${detail}` : ""}`, retry: false, duplicate: false };
+    default: return { code: "relay-error", message: raw || "The relay returned a response this tool could not read.", retry: false, duplicate: false };
+  }
+}
+
+function publishSignal(parent: AbortSignal | undefined, timeoutMs: number, authState: RelayAuthState): { signal: AbortSignal; dispose(): void } {
+  const timeout = new AbortController();
+  const currentPublish = new AbortController();
+  authState.currentPublish = currentPublish;
+  const handle = window.setTimeout(() => timeout.abort(), timeoutMs);
+  const signals = [timeout.signal, currentPublish.signal];
+  if (parent) signals.push(parent);
+  return {
+    signal: AbortSignal.any(signals),
+    dispose: () => {
+      window.clearTimeout(handle);
+      if (authState.currentPublish === currentPublish) authState.currentPublish = null;
+    },
+  };
+}
+
+async function createRelayAuth(signer: NostrSigner, relay: string, challenge: string): Promise<NostrEvent> {
+  return signer.signEvent({
+    kind: 22242,
+    created_at: Math.floor(Date.now() / 1000),
+    content: "",
+    tags: [["relay", relay], ["challenge", challenge]],
+  });
+}
+
+async function prepareEvents(options: PublishArchiveOptions): Promise<{
+  events: PreparedEvent[];
+  results: PublishResult[];
+}> {
+  const originals = new Map(options.events.map((event) => [event.id, event]));
+  const destinationUrls = buildDestinationUrlMap(options.mirrorResults);
+  const replacements = new Map<string, NostrEvent>();
+  const prepared = new Map<string, PreparedEvent>();
+  const settled = new Set<string>();
+  const visiting = new Set<string>();
+  const stack: string[] = [];
+  const cyclic = new Set<string>();
+  const events: PreparedEvent[] = [];
+  const results: PublishResult[] = [];
+
+  async function prepare(original: NostrEvent): Promise<PreparedEvent | null> {
+    if (options.signal?.aborted) throw new DOMException("Republish cancelled", "AbortError");
+    const existing = prepared.get(original.id);
+    if (existing) return existing;
+    if (settled.has(original.id)) return null;
+    if (visiting.has(original.id)) {
+      const cycleStart = stack.indexOf(original.id);
+      for (const id of stack.slice(cycleStart)) cyclic.add(id);
+      return null;
+    }
+    const skipReason = republishSkipReason(original.kind);
+    if (skipReason) {
+      settled.add(original.id);
+      results.push({ event_id: original.id, published_event_id: null, kind: original.kind, status: "skipped", remaining_media_urls: 0, reason: skipReason });
+      return null;
+    }
+
+    visiting.add(original.id);
+    stack.push(original.id);
+    for (const reference of referencedEventIds(original)) {
+      const dependency = originals.get(reference);
+      if (dependency) await prepare(dependency);
+    }
+    visiting.delete(original.id);
+    stack.pop();
+
+    if (cyclic.has(original.id)) {
+      settled.add(original.id);
+      results.push({
+        event_id: original.id,
+        published_event_id: null,
+        kind: original.kind,
+        status: "failed",
+        remaining_media_urls: 0,
+        reason: "This event belongs to a circular reference chain that cannot be safely rewritten.",
+      });
+      return null;
+    }
+
+    const media = rewriteEventMedia(original, destinationUrls);
+    const references = rewriteEventReferences(media.template, replacements);
+    const changed = media.changed || references.changed;
+    let event = original;
+    if (changed) {
+      try {
+        event = await options.signer.signEvent(references.template);
+        if (event.pubkey !== original.pubkey || !HEX_64.test(event.id)) {
+          throw new Error("The signer returned an event for a different account.");
+        }
+      } catch (error) {
+        settled.add(original.id);
+        const reason = error instanceof Error && error.message
+          ? `Your signer refused this event. ${error.message}`
+          : "Your signer refused this event.";
+        results.push({ event_id: original.id, published_event_id: null, kind: original.kind, status: "failed", remaining_media_urls: media.remainingMediaUrls, reason });
+        return null;
+      }
+    }
+    const value = { original, event, changed, remainingMediaUrls: media.remainingMediaUrls };
+    prepared.set(original.id, value);
+    settled.add(original.id);
+    if (changed) replacements.set(original.id, event);
+    events.push(value);
+    return value;
+  }
+
+  for (const event of options.events) await prepare(event);
+  return { events, results };
+}
+
+async function publishOne(
+  relay: RelayConnection,
+  prepared: PreparedEvent,
+  options: PublishArchiveOptions,
+  authState: RelayAuthState,
+): Promise<PublishResult> {
+  const wait = options.wait ?? defaultWait;
+  for (let attempt = 0; ; attempt += 1) {
+    if (options.signal?.aborted) throw new DOMException("Republish cancelled", "AbortError");
+    const timed = publishSignal(options.signal, options.eventTimeoutMs ?? DEFAULT_EVENT_TIMEOUT_MS, authState);
+    try {
+      await relay.event(prepared.event, { signal: timed.signal });
+      return {
+        event_id: prepared.original.id,
+        published_event_id: prepared.event.id,
+        kind: prepared.original.kind,
+        status: prepared.changed ? "published" : "unchanged",
+        remaining_media_urls: prepared.remainingMediaUrls,
+      };
+    } catch (error) {
+      if (options.signal?.aborted) throw new DOMException("Republish cancelled", "AbortError");
+      if (authState.failure) throw new DestinationError("auth-required", authState.failure);
+      const refusal = relayRefusal(error);
+      if (refusal.duplicate) {
+        return {
+          event_id: prepared.original.id,
+          published_event_id: prepared.event.id,
+          kind: prepared.original.kind,
+          status: prepared.changed ? "published" : "unchanged",
+          remaining_media_urls: prepared.remainingMediaUrls,
+          reason: refusal.message,
+        };
+      }
+      if (refusal.retry && attempt < (options.maxRateLimitRetries ?? 2)) {
+        await wait(1000 * 2 ** attempt, options.signal);
+        continue;
+      }
+      return {
+        event_id: prepared.original.id,
+        published_event_id: null,
+        kind: prepared.original.kind,
+        status: "failed",
+        remaining_media_urls: prepared.remainingMediaUrls,
+        reason: refusal.message,
+      };
+    } finally {
+      timed.dispose();
+    }
+  }
+}
+
+export async function publishArchiveEvents(options: PublishArchiveOptions): Promise<PublishResult[]> {
+  const destination = normalizeRelayDestinationUrl(options.destination);
+  const preparation = await prepareEvents(options);
+  const results = [...preparation.results];
+  if (preparation.events.length === 0) return results;
+  const relayFactory = options.relayFactory ?? ((url, relayOptions) => new NRelay1(url, {
+    auth: relayOptions.auth,
+    backoff: false,
+    idleTimeout: false,
+  }));
+  const authState: RelayAuthState = { failure: null, currentPublish: null };
+  const relay = relayFactory(destination, {
+    auth: async (challenge) => {
+      try {
+        return await createRelayAuth(options.signer, destination, challenge);
+      } catch {
+        authState.failure = "Your signer refused the relay's access request.";
+        authState.currentPublish?.abort();
+        throw new DestinationError("auth-required", authState.failure);
+      }
+    },
+  });
+  try {
+    for (const event of preparation.events) {
+      const result = await publishOne(relay, event, options, authState);
+      results.push(result);
+      options.onProgress?.({ completed: results.length, total: options.events.length, result });
+    }
+  } finally {
+    await relay.close();
+  }
+  return results;
+}
+
+export function summarizePublishResults(results: PublishResult[]): PublishSummary {
+  return {
+    published: results.filter((result) => result.status === "published").length,
+    unchanged: results.filter((result) => result.status === "unchanged").length,
+    skipped: results.filter((result) => result.status === "skipped").length,
+    failed: results.filter((result) => result.status === "failed").length,
+    remainingMediaUrls: results.reduce((total, result) => total + result.remaining_media_urls, 0),
+  };
+}

--- a/src/lib/exit/relayPublisher.ts
+++ b/src/lib/exit/relayPublisher.ts
@@ -71,6 +71,7 @@ interface PreparedEvent {
 interface RelayAuthState {
   failure: string | null;
   currentPublish: AbortController | null;
+  handshake: Promise<void> | null;
 }
 
 const HEX_64 = /^[0-9a-f]{64}$/i;
@@ -102,6 +103,7 @@ function relayRefusal(error: unknown): { code: string; message: string; retry: b
   switch (prefix) {
     case "duplicate": return { code: prefix, message: "The relay already has this event.", retry: false, duplicate: true };
     case "rate-limited": return { code: prefix, message: "The relay is accepting events too slowly.", retry: true, duplicate: false };
+    case "auth-required": return { code: prefix, message: "The relay wanted proof of your account before accepting this event.", retry: true, duplicate: false };
     case "blocked": return { code: prefix, message: `The relay blocked this event.${detail ? ` ${detail}` : ""}`, retry: false, duplicate: false };
     case "restricted": return { code: prefix, message: `The relay restricts this event.${detail ? ` ${detail}` : ""}`, retry: false, duplicate: false };
     case "invalid": return { code: prefix, message: `The relay says this event is invalid.${detail ? ` ${detail}` : ""}`, retry: false, duplicate: false };
@@ -254,6 +256,10 @@ async function publishOne(
         };
       }
       if (refusal.retry && attempt < (options.maxRateLimitRetries ?? 2)) {
+        // A NIP-42 relay challenges on connect and refuses whatever is already
+        // on the wire. Nostrify answers the challenge but never resends those
+        // events, so wait for the signature to settle and send them again.
+        if (refusal.code === "auth-required") await authState.handshake;
         await wait(1000 * 2 ** attempt, options.signal);
         continue;
       }
@@ -281,11 +287,13 @@ export async function publishArchiveEvents(options: PublishArchiveOptions): Prom
     backoff: false,
     idleTimeout: false,
   }));
-  const authState: RelayAuthState = { failure: null, currentPublish: null };
+  const authState: RelayAuthState = { failure: null, currentPublish: null, handshake: null };
   const relay = relayFactory(destination, {
     auth: async (challenge) => {
+      const handshake = createRelayAuth(options.signer, destination, challenge);
+      authState.handshake = handshake.then(() => undefined, () => undefined);
       try {
-        return await createRelayAuth(options.signer, destination, challenge);
+        return await handshake;
       } catch {
         authState.failure = "Your signer refused the relay's access request.";
         authState.currentPublish?.abort();

--- a/src/lib/exit/relayPublisher.ts
+++ b/src/lib/exit/relayPublisher.ts
@@ -229,8 +229,17 @@ async function publishOne(
   authState: RelayAuthState,
 ): Promise<PublishResult> {
   const wait = options.wait ?? defaultWait;
+  const authenticationFailure = (): PublishResult => ({
+    event_id: prepared.original.id,
+    published_event_id: null,
+    kind: prepared.original.kind,
+    status: "failed",
+    remaining_media_urls: prepared.remainingMediaUrls,
+    reason: authState.failure ?? "The relay's access request could not be signed.",
+  });
   for (let attempt = 0; ; attempt += 1) {
     if (options.signal?.aborted) throw new DOMException("Republish cancelled", "AbortError");
+    if (authState.failure) return authenticationFailure();
     const timed = publishSignal(options.signal, options.eventTimeoutMs ?? DEFAULT_EVENT_TIMEOUT_MS, authState);
     try {
       await relay.event(prepared.event, { signal: timed.signal });
@@ -243,7 +252,7 @@ async function publishOne(
       };
     } catch (error) {
       if (options.signal?.aborted) throw new DOMException("Republish cancelled", "AbortError");
-      if (authState.failure) throw new DestinationError("auth-required", authState.failure);
+      if (authState.failure) return authenticationFailure();
       const refusal = relayRefusal(error);
       if (refusal.duplicate) {
         return {

--- a/src/lib/exit/relayPublisher.ts
+++ b/src/lib/exit/relayPublisher.ts
@@ -259,7 +259,11 @@ async function publishOne(
         // A NIP-42 relay challenges on connect and refuses whatever is already
         // on the wire. Nostrify answers the challenge but never resends those
         // events, so wait for the signature to settle and send them again.
-        if (refusal.code === "auth-required") await authState.handshake;
+        // Bounded by the per-event timeout so a signer that never answers
+        // cannot stall the run.
+        if (refusal.code === "auth-required" && authState.handshake) {
+          await Promise.race([authState.handshake, wait(options.eventTimeoutMs ?? DEFAULT_EVENT_TIMEOUT_MS, options.signal)]);
+        }
         await wait(1000 * 2 ** attempt, options.signal);
         continue;
       }

--- a/src/pages/ExitStartPage.test.tsx
+++ b/src/pages/ExitStartPage.test.tsx
@@ -159,6 +159,8 @@ describe("ExitStartPage", () => {
 
     await waitFor(() => expect(screen.getByText("Destination copy finished.")).toBeInTheDocument());
     expect(screen.getByRole("status")).toHaveTextContent("1 mirrored, 0 failed, 0 skipped, and 0 unverified.");
+    expect(screen.getByRole("heading", { name: "Move your posts" })).toBeInTheDocument();
+    expect(screen.getByLabelText("Relay URL")).toBeInTheDocument();
   });
 
   it("explains the media limitation when direct file saving is unavailable", async () => {

--- a/src/pages/ExitStartPage.tsx
+++ b/src/pages/ExitStartPage.tsx
@@ -4,6 +4,7 @@
 import {
   Archive,
   ArrowClockwise,
+  Broadcast,
   CheckCircle,
   Copy,
   DownloadSimple,
@@ -15,11 +16,12 @@ import { useHead } from "@unhead/react";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { Link } from "react-router-dom";
 
-import { LocalNsecBanner } from "@/components/auth/LocalNsecBanner";
+import { DestinationForm } from "@/components/exit/DestinationForm";
 import { KeySafetyNotice } from "@/components/exit/KeySafetyNotice";
 import { MediaProgressList } from "@/components/exit/MediaProgressList";
-import { DestinationForm } from "@/components/exit/DestinationForm";
+import { RelayDestinationForm } from "@/components/exit/RelayDestinationForm";
 import { LoginArea } from "@/components/auth/LoginArea";
+import { LocalNsecBanner } from "@/components/auth/LocalNsecBanner";
 import { MarketingLayout } from "@/components/MarketingLayout";
 import { SectionHero } from "@/components/static-pages";
 import { Button } from "@/components/ui/button";
@@ -28,6 +30,7 @@ import { getFunnelcakeBaseUrl } from "@/config/api";
 import { useCurrentUser } from "@/hooks/useCurrentUser";
 import { useArchiveMediaExport } from "@/hooks/useArchiveMediaExport";
 import { useDestinationMirror } from "@/hooks/useDestinationMirror";
+import { useDestinationRepublish } from "@/hooks/useDestinationRepublish";
 import { buildArchiveFiles, serializeArchiveFiles, type ArchiveFiles } from "@/lib/exit/archive";
 import { exportOwnerEvents, OwnerExportError, type ExportProgress } from "@/lib/exit/ownerExportClient";
 import { createZip } from "@/lib/exit/zip";
@@ -98,6 +101,11 @@ export function ExitStartPage() {
   currentPubkey.current = user?.pubkey;
   const mediaExport = useArchiveMediaExport({ files: archiveFiles, signer });
   const destinationMirror = useDestinationMirror({ files: archiveFiles, signer });
+  const destinationRepublish = useDestinationRepublish({
+    files: archiveFiles,
+    mirrorResults: destinationMirror.results,
+    signer,
+  });
 
   useEffect(() => {
     activeExport.current?.abort();
@@ -423,6 +431,25 @@ export function ExitStartPage() {
               summary={destinationMirror.summary}
               failure={destinationMirror.failure}
               onStart={destinationMirror.start}
+            />
+          </section>
+        )}
+
+        {archiveFiles && signer && destinationMirror.state === "complete" && destinationMirror.results && (
+          <section>
+            <SectionHero
+              eyebrow="Choose a relay"
+              icon={<Broadcast weight="fill" className="h-7 w-7" />}
+              title="Move your posts"
+              lead="Publish your public posts to another relay. Private messages, temporary authentication events, and deletion requests stay where they are."
+            />
+            <RelayDestinationForm
+              state={destinationRepublish.state}
+              progress={destinationRepublish.progress}
+              results={destinationRepublish.results}
+              summary={destinationRepublish.summary}
+              failure={destinationRepublish.failure}
+              onStart={destinationRepublish.start}
             />
           </section>
         )}


### PR DESCRIPTION
## Summary

- Lets a person continue an account move by entering a custom destination relay after their media copy finishes.
- Rewrites only media URLs whose destination copy was confirmed, re-signs changed events with their original timestamps, and publishes unchanged events with their existing signatures.
- Keeps comments, reactions, and reposts connected by remapping references to newly signed owner events before publishing them.
- Reports every event outcome without letting an event-specific refusal stop unrelated posts.

## Motivation

A downloadable archive and a copied media catalog do not make a creator’s posts available on new infrastructure. The destination relay also needs signed events that point at the copied media. This adds that missing migration side effect while keeping private messages, temporary authentication events, and destructive requests off the new relay.

The publisher uses one explicit destination connection, supports NIP-42 relay authentication, retries bounded rate limits, and treats malformed or missing relay responses as per-event timeouts. Media that was skipped or could not be verified keeps its original URL and is counted in the final summary.

This deliberately does not publish discovery pointers, verify addressable-event readback, mirror generated HLS manifests, change Divine-hosted content, or remap NIP-27 event links embedded in post text. Embedded-link remapping is tracked in #658; the other portability work remains under the epic.

## Related Issue

- Closes #595
- Part of #592
- Follow-up: #658

## Testing

- [x] `npm run test` — 304 test files and 2,535 tests passed after rebasing onto current main; type-check, lint, and production build completed
- [x] `npm run test:visual` — 27 Playwright visual and accessibility checks passed before the review-only logic fix; no UI changed afterward
- [x] Focused fake-relay coverage for success, duplicate, bounded rate-limit retry, refusal prefixes, timeout/malformed response, NIP-42 success and refusal, partial-result preservation, signer refusal, cleanup, forward and nested reference remapping, repost payloads, and circular references

## Visuals

- [ ] UI change with screenshots/video attached
- [ ] No visual change
- [x] Visuals and text avoid sensitive external brand or partner names unless explicitly approved

The new relay section follows the existing destination card and progress patterns. `/exit/start` is authenticated and is not part of the repository’s visual baseline, so this PR adds component and page interaction coverage instead of a new snapshot.
