### PR TITLE
fix(edge): stop browser cache entries from breaking link previews

### DIFF
--- a/.github/workflows/og-audit.yml
+++ b/.github/workflows/og-audit.yml
@@ -4,15 +4,10 @@
 name: OG/Twitter Card parity audit
 
 on:
-  push:
+  workflow_run:
+    workflows: ['Deploy to Production']
+    types: [completed]
     branches: [main]
-    paths:
-      - 'compute-js/**'
-      - 'functions/**'
-      - 'src/lib/serverSocialMeta.ts'
-      - 'scripts/verify-og-tags.sh'
-      - '.github/workflows/og-audit.yml'
-      - 'package.json'
   schedule:
     - cron: '0 6 * * *'
   workflow_dispatch:
@@ -22,12 +17,15 @@ permissions:
 
 jobs:
   audit-production:
+    if: github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success'
     name: Audit production (divine.video)
     runs-on: ubuntu-24.04
     timeout-minutes: 5
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || github.sha }}
 
       - name: Run OG parity audit against production
         id: audit-prod
@@ -41,12 +39,15 @@ jobs:
         run: echo "::warning::Scheduled production OG audit failed. This monitors live production state and is warning-only on schedule."
 
   audit-cloudflare-production:
+    if: github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success'
     name: Audit Cloudflare production (latest main-branch deployment)
     runs-on: ubuntu-24.04
     timeout-minutes: 8
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || github.sha }}
 
       - name: Install wrangler
         run: npm install -g wrangler@4.31.0

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -137,6 +137,8 @@ On Fastly, some routes are not served from
 identifiable by the `x-divine-edge: template` response header — and that shell
 boots the same SPA bundle. `/` and `/discovery/hot` go through it today;
 [`compute-js/src/index.js`](./compute-js/src/index.js) can route more.
+These template responses vary by both the original host and user agent so they
+cannot replace the crawler-specific Open Graph response in the edge cache.
 
 The CSP therefore exists as **two copies**: the meta tag in `index.html` and
 `SHELL_CSP` in `shell.js`. They must stay byte-identical. A directive present

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -137,8 +137,10 @@ On Fastly, some routes are not served from
 identifiable by the `x-divine-edge: template` response header — and that shell
 boots the same SPA bundle. `/` and `/discovery/hot` go through it today;
 [`compute-js/src/index.js`](./compute-js/src/index.js) can route more.
-These template responses vary by both the original host and user agent so they
-cannot replace the crawler-specific Open Graph response in the edge cache.
+Templates with a distinct crawler response vary by both the original host and
+user agent so one response cannot replace the other in the edge cache. Bare
+vanity-subdomain profiles vary only by original host because crawlers and
+browsers receive the same HTML there.
 
 The CSP therefore exists as **two copies**: the meta tag in `index.html` and
 `SHELL_CSP` in `shell.js`. They must stay byte-identical. A directive present

--- a/compute-js/src/crawlerHandlers.js
+++ b/compute-js/src/crawlerHandlers.js
@@ -5,6 +5,7 @@ import { KVStore } from 'fastly:kv-store';
 import { buildCrawlerHtml, cleanText, truncateText } from './ogTags.js';
 import { hexToNpub, decodeNpubToHex } from './bech32.js';
 import { transformVideoApiResponse } from './videoMetadata.js';
+import { HOST_DEPENDENT_CRAWLER_VARY } from './templateCachePolicy.js';
 
 const FUNNELCAKE_API_URL = 'https://relay.divine.video';
 const DEFAULT_OG_IMAGE = 'https://divine.video/og.png';
@@ -27,7 +28,7 @@ export function handleDownloadOgTags(url, hostnameToUse) {
     headers: {
       'Content-Type': 'text/html; charset=utf-8',
       'Cache-Control': 'public, max-age=300',
-      'Vary': 'User-Agent',
+      'Vary': HOST_DEPENDENT_CRAWLER_VARY,
     },
   });
 }

--- a/compute-js/src/crawlerHandlers.test.ts
+++ b/compute-js/src/crawlerHandlers.test.ts
@@ -32,6 +32,7 @@ describe('handleDownloadOgTags', () => {
     expect(html).toContain('App Store, Google Play, or Zapstore');
     expect(html).toContain('https://divine.video/download');
     expect(html).toContain('https://divine.video/og.png');
+    expect(result!.headers.get('Vary')).toBe('X-Original-Host, User-Agent');
   });
 });
 

--- a/compute-js/src/index.js
+++ b/compute-js/src/index.js
@@ -35,7 +35,6 @@ import {
 import {
   createEdgeTemplateHeaders,
   HOST_DEPENDENT_CRAWLER_VARY,
-  shouldVaryTemplateByUserAgent,
 } from './templateCachePolicy.js';
 import { renderFeedPage, renderVideoPage, renderProfilePage, renderSearchPage } from './templates/pages.js';
 
@@ -1008,7 +1007,7 @@ async function handleSubdomainProfile(subdomain, url, request, originalHostname,
     headers: createEdgeTemplateHeaders({
       cacheControl: 'public, s-maxage=60, stale-while-revalidate=300',
       subdomain,
-      varyByUserAgent: shouldVaryTemplateByUserAgent(url.pathname, isVanitySubdomain),
+      varyByUserAgent: !isVanitySubdomain,
     }),
   });
 }

--- a/compute-js/src/index.js
+++ b/compute-js/src/index.js
@@ -133,7 +133,7 @@ async function handleRequest(event) {
     // Subdomain profile - serve SPA with injected user data
     console.log('Handling subdomain profile for:', subdomain);
     try {
-      return await handleSubdomainProfile(subdomain, url, request, hostnameToUse);
+      return await handleSubdomainProfile(subdomain, url, request, hostnameToUse, true);
     } catch (err) {
       console.error('Subdomain profile error:', err.message, err.stack);
       return new Response('Profile not found', { status: 404 });
@@ -160,7 +160,7 @@ async function handleRequest(event) {
       }
     }
     try {
-      return await handleSubdomainProfile(username, url, request, hostnameToUse);
+      return await handleSubdomainProfile(username, url, request, hostnameToUse, false);
     } catch (err) {
       console.error('@username profile error:', err.message, err.stack);
       // Fall through to SPA handler which will render the client-side @username route
@@ -899,7 +899,7 @@ async function handleSubdomainNip05(subdomain) {
  * Handle subdomain profile requests (e.g., alice.dvine.video/)
  * Serves the SPA directly with injected user data instead of redirecting.
  */
-async function handleSubdomainProfile(subdomain, url, request, originalHostname) {
+async function handleSubdomainProfile(subdomain, url, request, originalHostname, isVanitySubdomain) {
   // Check if this is a static asset request - let publisherServer handle it
   const assetExtensions = ['.js', '.css', '.png', '.jpg', '.jpeg', '.gif', '.svg', '.ico', '.webp', '.avif', '.woff', '.woff2', '.ttf', '.otf', '.json', '.webmanifest', '.map'];
   const isAsset = assetExtensions.some(ext => url.pathname.endsWith(ext)) || url.pathname.startsWith('/assets/');
@@ -1008,7 +1008,7 @@ async function handleSubdomainProfile(subdomain, url, request, originalHostname)
     headers: createEdgeTemplateHeaders({
       cacheControl: 'public, s-maxage=60, stale-while-revalidate=300',
       subdomain,
-      varyByUserAgent: shouldVaryTemplateByUserAgent(url.pathname),
+      varyByUserAgent: shouldVaryTemplateByUserAgent(url.pathname, isVanitySubdomain),
     }),
   });
 }

--- a/compute-js/src/index.js
+++ b/compute-js/src/index.js
@@ -32,6 +32,7 @@ import {
   applyEmbedWidgetHeaders,
   isEmbedWidgetPath,
 } from './embedWidget.js';
+import { EDGE_TEMPLATE_VARY } from './templateCachePolicy.js';
 import { renderFeedPage, renderVideoPage, renderProfilePage, renderSearchPage } from './templates/pages.js';
 
 const publisherServer = PublisherServer.fromStaticPublishRc(rc);
@@ -1003,7 +1004,7 @@ async function handleSubdomainProfile(subdomain, url, request, originalHostname)
     headers: {
       'Content-Type': 'text/html; charset=utf-8',
       'Cache-Control': 'public, s-maxage=60, stale-while-revalidate=300',
-      'Vary': 'X-Original-Host',
+      'Vary': EDGE_TEMPLATE_VARY,
       'X-Divine-Subdomain': subdomain,
       'X-Divine-Edge': 'template',
     },
@@ -1191,7 +1192,7 @@ async function handleVideoPage(request, videoId, url, funnelcakeTarget) {
           headers: {
             'Content-Type': 'text/html; charset=utf-8',
             'Cache-Control': 'public, s-maxage=60, stale-while-revalidate=300',
-            'Vary': 'X-Original-Host',
+            'Vary': EDGE_TEMPLATE_VARY,
             'X-Divine-Edge': 'template',
           },
         });
@@ -1234,7 +1235,7 @@ async function handleVideoPage(request, videoId, url, funnelcakeTarget) {
     headers: {
       'Content-Type': 'text/html; charset=utf-8',
       'Cache-Control': 'public, s-maxage=60, stale-while-revalidate=300',
-      'Vary': 'X-Original-Host',
+      'Vary': EDGE_TEMPLATE_VARY,
       'X-Divine-Edge': 'template',
     },
   });
@@ -1263,7 +1264,7 @@ async function handleFeedPage(feedType, funnelcakeTarget) {
           headers: {
             'Content-Type': 'text/html; charset=utf-8',
             'Cache-Control': 'public, s-maxage=60, stale-while-revalidate=300',
-            'Vary': 'X-Original-Host',
+            'Vary': EDGE_TEMPLATE_VARY,
             'X-Divine-Edge': 'template',
           },
         });
@@ -1306,7 +1307,7 @@ async function handleFeedPage(feedType, funnelcakeTarget) {
     headers: {
       'Content-Type': 'text/html; charset=utf-8',
       'Cache-Control': 'public, s-maxage=60, stale-while-revalidate=300',
-      'Vary': 'X-Original-Host',
+      'Vary': EDGE_TEMPLATE_VARY,
       'X-Divine-Edge': 'template',
     },
   });
@@ -1340,7 +1341,7 @@ async function handleSearchPage(query, funnelcakeTarget) {
       headers: {
         'Content-Type': 'text/html; charset=utf-8',
         'Cache-Control': 'public, s-maxage=30, stale-while-revalidate=60',
-        'Vary': 'X-Original-Host',
+        'Vary': EDGE_TEMPLATE_VARY,
         'X-Divine-Edge': 'template',
       },
     });

--- a/compute-js/src/index.js
+++ b/compute-js/src/index.js
@@ -32,7 +32,11 @@ import {
   applyEmbedWidgetHeaders,
   isEmbedWidgetPath,
 } from './embedWidget.js';
-import { EDGE_TEMPLATE_VARY } from './templateCachePolicy.js';
+import {
+  createEdgeTemplateHeaders,
+  HOST_DEPENDENT_CRAWLER_VARY,
+  shouldVaryTemplateByUserAgent,
+} from './templateCachePolicy.js';
 import { renderFeedPage, renderVideoPage, renderProfilePage, renderSearchPage } from './templates/pages.js';
 
 const publisherServer = PublisherServer.fromStaticPublishRc(rc);
@@ -1001,13 +1005,11 @@ async function handleSubdomainProfile(subdomain, url, request, originalHostname)
 
   return new Response(profileHtml, {
     status: 200,
-    headers: {
-      'Content-Type': 'text/html; charset=utf-8',
-      'Cache-Control': 'public, s-maxage=60, stale-while-revalidate=300',
-      'Vary': EDGE_TEMPLATE_VARY,
-      'X-Divine-Subdomain': subdomain,
-      'X-Divine-Edge': 'template',
-    },
+    headers: createEdgeTemplateHeaders({
+      cacheControl: 'public, s-maxage=60, stale-while-revalidate=300',
+      subdomain,
+      varyByUserAgent: shouldVaryTemplateByUserAgent(url.pathname),
+    }),
   });
 }
 
@@ -1189,12 +1191,9 @@ async function handleVideoPage(request, videoId, url, funnelcakeTarget) {
         console.log(`Video page cache hit, id: ${videoId}, age: ${age}s`);
         return new Response(parsed.html, {
           status: 200,
-          headers: {
-            'Content-Type': 'text/html; charset=utf-8',
-            'Cache-Control': 'public, s-maxage=60, stale-while-revalidate=300',
-            'Vary': EDGE_TEMPLATE_VARY,
-            'X-Divine-Edge': 'template',
-          },
+          headers: createEdgeTemplateHeaders({
+            cacheControl: 'public, s-maxage=60, stale-while-revalidate=300',
+          }),
         });
       }
     }
@@ -1232,12 +1231,9 @@ async function handleVideoPage(request, videoId, url, funnelcakeTarget) {
 
   return new Response(html, {
     status: 200,
-    headers: {
-      'Content-Type': 'text/html; charset=utf-8',
-      'Cache-Control': 'public, s-maxage=60, stale-while-revalidate=300',
-      'Vary': EDGE_TEMPLATE_VARY,
-      'X-Divine-Edge': 'template',
-    },
+    headers: createEdgeTemplateHeaders({
+      cacheControl: 'public, s-maxage=60, stale-while-revalidate=300',
+    }),
   });
 }
 
@@ -1261,12 +1257,9 @@ async function handleFeedPage(feedType, funnelcakeTarget) {
         console.log(`Feed page cache hit, type: ${feedType}, age: ${age}s`);
         return new Response(parsed.html, {
           status: 200,
-          headers: {
-            'Content-Type': 'text/html; charset=utf-8',
-            'Cache-Control': 'public, s-maxage=60, stale-while-revalidate=300',
-            'Vary': EDGE_TEMPLATE_VARY,
-            'X-Divine-Edge': 'template',
-          },
+          headers: createEdgeTemplateHeaders({
+            cacheControl: 'public, s-maxage=60, stale-while-revalidate=300',
+          }),
         });
       }
     }
@@ -1304,12 +1297,9 @@ async function handleFeedPage(feedType, funnelcakeTarget) {
 
   return new Response(html, {
     status: 200,
-    headers: {
-      'Content-Type': 'text/html; charset=utf-8',
-      'Cache-Control': 'public, s-maxage=60, stale-while-revalidate=300',
-      'Vary': EDGE_TEMPLATE_VARY,
-      'X-Divine-Edge': 'template',
-    },
+    headers: createEdgeTemplateHeaders({
+      cacheControl: 'public, s-maxage=60, stale-while-revalidate=300',
+    }),
   });
 }
 
@@ -1338,12 +1328,9 @@ async function handleSearchPage(query, funnelcakeTarget) {
 
     return new Response(html, {
       status: 200,
-      headers: {
-        'Content-Type': 'text/html; charset=utf-8',
-        'Cache-Control': 'public, s-maxage=30, stale-while-revalidate=60',
-        'Vary': EDGE_TEMPLATE_VARY,
-        'X-Divine-Edge': 'template',
-      },
+      headers: createEdgeTemplateHeaders({
+        cacheControl: 'public, s-maxage=30, stale-while-revalidate=60',
+      }),
     });
   } catch (e) {
     console.error('Search page error:', e.message);
@@ -1500,7 +1487,7 @@ function handleFamilyOgTags(url, hostnameToUse) {
       headers: {
         'Content-Type': 'text/html; charset=utf-8',
         'Cache-Control': 'public, max-age=300',
-        'Vary': 'User-Agent',
+        'Vary': HOST_DEPENDENT_CRAWLER_VARY,
       },
     });
   } catch (err) {
@@ -1529,7 +1516,7 @@ function handleAgeReviewOgTags(url, hostnameToUse) {
       headers: {
         'Content-Type': 'text/html; charset=utf-8',
         'Cache-Control': 'public, max-age=300',
-        'Vary': 'User-Agent',
+        'Vary': HOST_DEPENDENT_CRAWLER_VARY,
       },
     });
   } catch (err) {
@@ -1558,7 +1545,7 @@ function handleKidsPolicyOgTags(url, hostnameToUse) {
       headers: {
         'Content-Type': 'text/html; charset=utf-8',
         'Cache-Control': 'public, max-age=300',
-        'Vary': 'User-Agent',
+        'Vary': HOST_DEPENDENT_CRAWLER_VARY,
       },
     });
   } catch (err) {

--- a/compute-js/src/templateCachePolicy.js
+++ b/compute-js/src/templateCachePolicy.js
@@ -3,8 +3,8 @@ const CRAWLER_VARY = `${ORIGINAL_HOST_VARY}, User-Agent`;
 
 export const HOST_DEPENDENT_CRAWLER_VARY = CRAWLER_VARY;
 
-export function shouldVaryTemplateByUserAgent(pathname) {
-  return pathname.startsWith('/@');
+export function shouldVaryTemplateByUserAgent(pathname, isVanitySubdomain) {
+  return !isVanitySubdomain && pathname.startsWith('/@');
 }
 
 export function createEdgeTemplateHeaders({

--- a/compute-js/src/templateCachePolicy.js
+++ b/compute-js/src/templateCachePolicy.js
@@ -1,1 +1,27 @@
-export const EDGE_TEMPLATE_VARY = 'X-Original-Host, User-Agent';
+const ORIGINAL_HOST_VARY = 'X-Original-Host';
+const CRAWLER_VARY = `${ORIGINAL_HOST_VARY}, User-Agent`;
+
+export const HOST_DEPENDENT_CRAWLER_VARY = CRAWLER_VARY;
+
+export function shouldVaryTemplateByUserAgent(pathname) {
+  return pathname.startsWith('/@');
+}
+
+export function createEdgeTemplateHeaders({
+  cacheControl,
+  subdomain,
+  varyByUserAgent = true,
+}) {
+  const headers = new Headers({
+    'Content-Type': 'text/html; charset=utf-8',
+    'Cache-Control': cacheControl,
+    'Vary': varyByUserAgent ? CRAWLER_VARY : ORIGINAL_HOST_VARY,
+    'X-Divine-Edge': 'template',
+  });
+
+  if (subdomain) {
+    headers.set('X-Divine-Subdomain', subdomain);
+  }
+
+  return headers;
+}

--- a/compute-js/src/templateCachePolicy.js
+++ b/compute-js/src/templateCachePolicy.js
@@ -1,0 +1,1 @@
+export const EDGE_TEMPLATE_VARY = 'X-Original-Host, User-Agent';

--- a/compute-js/src/templateCachePolicy.js
+++ b/compute-js/src/templateCachePolicy.js
@@ -3,10 +3,6 @@ const CRAWLER_VARY = `${ORIGINAL_HOST_VARY}, User-Agent`;
 
 export const HOST_DEPENDENT_CRAWLER_VARY = CRAWLER_VARY;
 
-export function shouldVaryTemplateByUserAgent(pathname, isVanitySubdomain) {
-  return !isVanitySubdomain && pathname.startsWith('/@');
-}
-
 export function createEdgeTemplateHeaders({
   cacheControl,
   subdomain,

--- a/compute-js/src/templateCachePolicy.test.js
+++ b/compute-js/src/templateCachePolicy.test.js
@@ -1,0 +1,25 @@
+import { readFileSync } from 'node:fs';
+
+import { describe, expect, it } from 'vitest';
+
+import { EDGE_TEMPLATE_VARY } from './templateCachePolicy.js';
+
+describe('edge template cache policy', () => {
+  it('separates crawler responses from browser responses', () => {
+    expect(EDGE_TEMPLATE_VARY.split(/,\s*/)).toEqual(
+      expect.arrayContaining(['X-Original-Host', 'User-Agent']),
+    );
+  });
+
+  it('applies the policy to every edge-templated response', () => {
+    const indexSource = readFileSync('compute-js/src/index.js', 'utf8');
+    const templateHeaderBlocks = [
+      ...indexSource.matchAll(/headers: \{([\s\S]*?)'X-Divine-Edge': 'template'/g),
+    ];
+
+    expect(templateHeaderBlocks).toHaveLength(6);
+    for (const [, headers] of templateHeaderBlocks) {
+      expect(headers).toContain("'Vary': EDGE_TEMPLATE_VARY");
+    }
+  });
+});

--- a/compute-js/src/templateCachePolicy.test.js
+++ b/compute-js/src/templateCachePolicy.test.js
@@ -28,8 +28,9 @@ describe('edge template cache policy', () => {
   });
 
   it('varies apex username profiles but not bare vanity profiles by user agent', () => {
-    expect(shouldVaryTemplateByUserAgent('/@creator')).toBe(true);
-    expect(shouldVaryTemplateByUserAgent('/')).toBe(false);
+    expect(shouldVaryTemplateByUserAgent('/@creator', false)).toBe(true);
+    expect(shouldVaryTemplateByUserAgent('/', true)).toBe(false);
+    expect(shouldVaryTemplateByUserAgent('/@another-creator', true)).toBe(false);
   });
 
   it('varies host-dependent crawler responses by host and user agent', () => {

--- a/compute-js/src/templateCachePolicy.test.js
+++ b/compute-js/src/templateCachePolicy.test.js
@@ -3,7 +3,6 @@ import { describe, expect, it } from 'vitest';
 import {
   createEdgeTemplateHeaders,
   HOST_DEPENDENT_CRAWLER_VARY,
-  shouldVaryTemplateByUserAgent,
 } from './templateCachePolicy.js';
 
 describe('edge template cache policy', () => {
@@ -25,12 +24,6 @@ describe('edge template cache policy', () => {
 
     expect(headers.get('Vary')).toBe('X-Original-Host');
     expect(headers.get('X-Divine-Subdomain')).toBe('creator');
-  });
-
-  it('varies apex username profiles but not bare vanity profiles by user agent', () => {
-    expect(shouldVaryTemplateByUserAgent('/@creator', false)).toBe(true);
-    expect(shouldVaryTemplateByUserAgent('/', true)).toBe(false);
-    expect(shouldVaryTemplateByUserAgent('/@another-creator', true)).toBe(false);
   });
 
   it('varies host-dependent crawler responses by host and user agent', () => {

--- a/compute-js/src/templateCachePolicy.test.js
+++ b/compute-js/src/templateCachePolicy.test.js
@@ -1,25 +1,38 @@
-import { readFileSync } from 'node:fs';
-
 import { describe, expect, it } from 'vitest';
 
-import { EDGE_TEMPLATE_VARY } from './templateCachePolicy.js';
+import {
+  createEdgeTemplateHeaders,
+  HOST_DEPENDENT_CRAWLER_VARY,
+  shouldVaryTemplateByUserAgent,
+} from './templateCachePolicy.js';
 
 describe('edge template cache policy', () => {
-  it('separates crawler responses from browser responses', () => {
-    expect(EDGE_TEMPLATE_VARY.split(/,\s*/)).toEqual(
-      expect.arrayContaining(['X-Original-Host', 'User-Agent']),
-    );
+  it('separates crawler responses from browser responses by default', () => {
+    const headers = createEdgeTemplateHeaders({ cacheControl: 'public, max-age=60' });
+
+    expect(headers.get('Vary')).toBe('X-Original-Host, User-Agent');
+    expect(headers.get('Cache-Control')).toBe('public, max-age=60');
+    expect(headers.get('Content-Type')).toBe('text/html; charset=utf-8');
+    expect(headers.get('X-Divine-Edge')).toBe('template');
   });
 
-  it('applies the policy to every edge-templated response', () => {
-    const indexSource = readFileSync('compute-js/src/index.js', 'utf8');
-    const templateHeaderBlocks = [
-      ...indexSource.matchAll(/headers: \{([\s\S]*?)'X-Divine-Edge': 'template'/g),
-    ];
+  it('does not vary bare vanity profiles by user agent', () => {
+    const headers = createEdgeTemplateHeaders({
+      cacheControl: 'public, max-age=60',
+      subdomain: 'creator',
+      varyByUserAgent: false,
+    });
 
-    expect(templateHeaderBlocks).toHaveLength(6);
-    for (const [, headers] of templateHeaderBlocks) {
-      expect(headers).toContain("'Vary': EDGE_TEMPLATE_VARY");
-    }
+    expect(headers.get('Vary')).toBe('X-Original-Host');
+    expect(headers.get('X-Divine-Subdomain')).toBe('creator');
+  });
+
+  it('varies apex username profiles but not bare vanity profiles by user agent', () => {
+    expect(shouldVaryTemplateByUserAgent('/@creator')).toBe(true);
+    expect(shouldVaryTemplateByUserAgent('/')).toBe(false);
+  });
+
+  it('varies host-dependent crawler responses by host and user agent', () => {
+    expect(HOST_DEPENDENT_CRAWLER_VARY).toBe('X-Original-Host, User-Agent');
   });
 });


### PR DESCRIPTION
## Summary

- Keeps browser-rendered edge pages and social-crawler previews in separate cache variants only where their HTML differs.
- Keeps bare vanity-subdomain profiles on one host-scoped cache object because browsers and crawlers receive identical HTML there.
- Keeps host-derived crawler canonicals separate across the supported apex domains.
- Runs the live parity audit only after the matching production deployment finishes successfully, while preserving scheduled and manual audits.

## Motivation

The live parity workflow failed while crawler requests to the homepage intermittently received the generic browser page. The edge-rendered HTML responses varied by original host but not user agent, so a cached browser response could be reused for a social crawler and hide route-specific Open Graph metadata. The push-triggered audit also started before Fastly and Cloudflare had finished deploying the commit it checked.

The first fix varied every edge template by raw user agent. Review found that bare vanity-subdomain profiles have no separate crawler response, so that variance only let callers force cache misses and two Funnelcake requests. The cache policy is now applied through a tested header helper: templates vary by user agent where crawler HTML differs, while bare vanity profiles remain host-only. Host-dependent crawler responses vary by both original host and user agent so their canonical URLs cannot cross apex-domain cache entries.

This does not change page content, crawler metadata, or cache lifetimes. The dedicated `/@username` crawler response remains because its canonical URL, fallback description, and Twitter card differ from the full profile template.

## Related Issue

- N/A

## Testing

- [x] `npm run test` - 305 files, 2,540 tests
- [x] Focused cache-policy and crawler-handler tests - 30 tests
- [x] `actionlint .github/workflows/og-audit.yml`

## Visuals

- [ ] UI change with screenshots/video attached
- [x] No visual change
- [x] Visuals and text avoid sensitive external brand or partner names unless explicitly approved
