### PR TITLE
fix(dm): authenticate NIP-42 AUTH challenges for gift-wrap reads

### DIFF
--- a/src/lib/dm.test.ts
+++ b/src/lib/dm.test.ts
@@ -5,15 +5,45 @@ import { generateSecretKey, getPublicKey, verifyEvent } from 'nostr-tools/pure';
 // fetchDmMessages builds its own NPool internally, so the relay is stubbed at
 // the module boundary. Everything inside — unwrapping, verification, NIP-44
 // decryption — stays real.
-const relayStub = vi.hoisted(() => ({ events: [] as unknown[] }));
+const relayStub = vi.hoisted(() => ({
+  events: [] as unknown[],
+  // Every NRelay1 the pool opened, with the options it was constructed with.
+  // The `auth` option is the whole point of the NIP-42 wiring, so the stub has
+  // to expose it rather than swallow it.
+  opened: [] as { url: string; opts: { auth?: (challenge: string) => Promise<NostrEvent> } }[],
+}));
 
 vi.mock('@nostrify/nostrify', async () => {
   const actual = await vi.importActual<typeof import('@nostrify/nostrify')>('@nostrify/nostrify');
   return {
     ...actual,
-    NRelay1: class {},
+    NRelay1: class {
+      constructor(url: string, opts: { auth?: (challenge: string) => Promise<NostrEvent> } = {}) {
+        relayStub.opened.push({ url, opts });
+      }
+    },
     NPool: class {
-      async query() {
+      private connections = new Map<string, { event(): Promise<void> }>();
+
+      constructor(private opts: { open(url: string): unknown }) {}
+
+      // The real NPool opens one relay per routed url, once, and caches it.
+      // Mirroring that is what makes the `open` factory — and therefore the
+      // `auth` option it builds — observable from a test.
+      relay(url: string) {
+        let connection = this.connections.get(url);
+        if (!connection) {
+          this.opts.open(url);
+          connection = { event: async () => {} };
+          this.connections.set(url, connection);
+        }
+        return connection;
+      }
+
+      async query(_filters: unknown, opts?: { relays?: string[] }) {
+        for (const url of opts?.relays ?? []) {
+          this.relay(url);
+        }
         return relayStub.events;
       }
 
@@ -35,6 +65,7 @@ import {
   groupDmConversations,
   makeDmAuthCallback,
   probeBunkerNip44,
+  publishDmMessages,
   unwrapDmGiftWrap,
 } from '@/lib/dm';
 
@@ -228,6 +259,51 @@ describe('makeDmAuthCallback', () => {
 
     expect(settled).toBeInstanceOf(Promise);
     await expect(settled).rejects.toThrow(/without a signer/);
+  });
+});
+
+describe('DM relay pool NIP-42 wiring', () => {
+  const RELAY_URL = 'wss://relay.example';
+
+  it('gives the gift-wrap read connection an auth callback bound to the reader', async () => {
+    // The helper being correct in isolation proves nothing about the read
+    // path: the gate only lifts if the pool that issues the kind-1059 REQ is
+    // the one carrying the callback. Dropping `auth` from createRelayPool, or
+    // no longer threading the signer into it, must fail here.
+    const recipient = createTestSigner();
+    relayStub.opened = [];
+
+    await fetchWithStubbedRelay([], recipient);
+
+    const connection = relayStub.opened.find((relay) => relay.url === RELAY_URL);
+    expect(connection?.opts.auth).toBeTypeOf('function');
+
+    const authEvent = await connection!.opts.auth!('challenge-from-relay');
+
+    expect(authEvent.kind).toBe(22242);
+    expect(authEvent.pubkey).toBe(recipient.pubkey);
+    expect(authEvent.tags).toEqual(
+      expect.arrayContaining([
+        ['relay', RELAY_URL],
+        ['challenge', 'challenge-from-relay'],
+      ]),
+    );
+  });
+
+  it('leaves the publish connection unauthenticated so gift wraps stay anonymous', async () => {
+    // NIP-59 signs each wrap with a throwaway key precisely so the relay
+    // cannot tell who sent it. Authenticating the write connection would hand
+    // the relay the sender's real pubkey alongside the wrap and undo that, so
+    // the signer must not reach the publish pool.
+    relayStub.opened = [];
+
+    await publishDmMessages([RELAY_URL], [createDmTestWrap('a'.repeat(64))]);
+
+    const connection = relayStub.opened.find((relay) => relay.url === RELAY_URL);
+    expect(connection).toBeDefined();
+    await expect(connection!.opts.auth!('challenge-from-relay')).rejects.toThrow(
+      /without a signer/,
+    );
   });
 });
 

--- a/src/lib/dm.test.ts
+++ b/src/lib/dm.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 import { NSecSigner, type NostrEvent, type NostrSigner } from '@nostrify/nostrify';
-import { generateSecretKey, getPublicKey } from 'nostr-tools/pure';
+import { generateSecretKey, getPublicKey, verifyEvent } from 'nostr-tools/pure';
 
 // fetchDmMessages builds its own NPool internally, so the relay is stubbed at
 // the module boundary. Everything inside — unwrapping, verification, NIP-44
@@ -33,6 +33,7 @@ import {
   fetchDmMessages,
   getDmMessagePreview,
   groupDmConversations,
+  makeDmAuthCallback,
   probeBunkerNip44,
   unwrapDmGiftWrap,
 } from '@/lib/dm';
@@ -192,6 +193,41 @@ describe('fetchDmMessages deduplication', () => {
 
     expect(result.messages).toHaveLength(2);
     expect(result.messages[0].rumorId).not.toBe(result.messages[1].rumorId);
+  });
+});
+
+describe('makeDmAuthCallback', () => {
+  const RELAY_URL = 'wss://relay.divine.video';
+  const CHALLENGE = 'server-challenge-string';
+
+  it('signs a verifiable kind-22242 AUTH event bound to the relay url and challenge', async () => {
+    // NIP-42: the recipient proves identity to the gated relay by returning a
+    // signed kind-22242 event carrying the relay url and the challenge. Without
+    // it the relay serves nothing for the kind-1059 inbox read.
+    const { signer, pubkey } = createTestSigner();
+
+    const authEvent = await makeDmAuthCallback(RELAY_URL, signer)(CHALLENGE);
+
+    expect(authEvent.kind).toBe(22242);
+    expect(authEvent.pubkey).toBe(pubkey);
+    expect(authEvent.content).toBe('');
+    expect(authEvent.tags).toEqual(
+      expect.arrayContaining([
+        ['relay', RELAY_URL],
+        ['challenge', CHALLENGE],
+      ]),
+    );
+    expect(verifyEvent(authEvent)).toBe(true);
+  });
+
+  it('rejects without throwing synchronously when there is no signer', async () => {
+    // NRelay1 runs the callback as `auth(challenge).then(...).catch(() => {})`,
+    // so a synchronous throw would escape its `.catch`. A logged-out pool must
+    // reject asynchronously, leaving the connection unauthenticated.
+    const settled = makeDmAuthCallback(RELAY_URL, undefined)(CHALLENGE);
+
+    expect(settled).toBeInstanceOf(Promise);
+    await expect(settled).rejects.toThrow(/without a signer/);
   });
 });
 

--- a/src/lib/dm.ts
+++ b/src/lib/dm.ts
@@ -1,7 +1,7 @@
 import { NPool, NRelay1, type NostrEvent, type NostrFilter, type NostrSigner } from '@nostrify/nostrify';
 import { bytesToHex } from '@noble/hashes/utils';
 import { sha256 } from '@noble/hashes/sha256';
-import { finalizeEvent, generateSecretKey, nip44, verifyEvent } from 'nostr-tools';
+import { finalizeEvent, generateSecretKey, nip42, nip44, verifyEvent } from 'nostr-tools';
 
 import { PRESET_RELAYS, PROFILE_RELAYS, getRelayUrls } from '@/config/relays';
 import { DIVINE_MODERATION_PUBKEY } from '@/lib/officialAccounts';
@@ -195,9 +195,42 @@ function getDirectMessageRelayUrls(): string[] {
   ]);
 }
 
-function createRelayPool(relayUrls: string[]): NPool<NRelay1> {
+/**
+ * Build the `auth` callback an {@link NRelay1} uses to answer a relay's
+ * NIP-42 AUTH challenge with a signed kind-22242 event.
+ *
+ * The Divine relay gates kind-1059 (NIP-17 gift wrap) reads to the
+ * authenticated recipient: until the connection answers the challenge, the
+ * relay returns nothing for the inbox query. With a single default relay and
+ * no EOSE, that read then hangs to its abort timeout and surfaces as a
+ * permanently empty inbox — so signing the challenge is what lets a recipient
+ * read their own gift wraps at all.
+ *
+ * When no signer is available (logged-out) the callback rejects: there is no
+ * identity to authenticate with, so the connection stays unauthenticated
+ * rather than sending a bogus AUTH. NRelay1 runs this as
+ * `auth(challenge).then(...).catch(() => {})`, so the rejection is swallowed
+ * and a missing signer degrades to "unauthenticated", never an uncaught error.
+ */
+export function makeDmAuthCallback(
+  relayUrl: string,
+  signer: NostrSigner | undefined,
+): (challenge: string) => Promise<NostrEvent> {
+  return async (challenge: string) => {
+    if (!signer) {
+      throw new Error('[DM] Cannot answer a NIP-42 AUTH challenge without a signer');
+    }
+    return signer.signEvent(nip42.makeAuthEvent(relayUrl, challenge));
+  };
+}
+
+function createRelayPool(relayUrls: string[], signer?: NostrSigner): NPool<NRelay1> {
   return new NPool({
-    open: (url) => new NRelay1(url, { idleTimeout: false }),
+    open: (url) =>
+      new NRelay1(url, {
+        idleTimeout: false,
+        auth: makeDmAuthCallback(url, signer),
+      }),
     reqRouter: (filters) => new Map(relayUrls.map((url) => [url, filters])),
     eventRouter: () => relayUrls,
   });
@@ -600,7 +633,7 @@ export async function fetchDmMessages(input: FetchDmMessagesInput): Promise<Fetc
     return { messages: [], fetchedCount: 0, decryptFailures: 0, malformedCount: 0 };
   }
 
-  const pool = createRelayPool(normalizedRelays);
+  const pool = createRelayPool(normalizedRelays, signer);
 
   try {
     const events = await pool.query(


### PR DESCRIPTION
## Summary

Answer **NIP-42 AUTH** challenges when reading NIP-17 gift wraps (kind 1059), so DM reads keep working once `relay.divine.video` gates 1059 reads to the authenticated recipient.

Part of the rollout for divinevideo/divine-funnelcake#591 (relay-side NIP-42 gate).

## Motivation

The Divine relay is adding NIP-42 AUTH that gates kind-1059 reads to the p-tagged recipient (funnelcake#591). Today divine-web passes **no `auth` callback** to nostrify's `NRelay1` (`22242` appears nowhere in `src/`). Once the relay enables the gate, the DM read would hang to its 15 s `AbortSignal` and be swallowed as an empty result — an **empty DM inbox rendered as a normal empty state, forever** (this app defaults to the single `relay.divine.video`). This is the most exposed consumer of the gap.

## What changed (`src/lib/dm.ts`, +helper + test)

- New `makeDmAuthCallback(relayUrl, signer?)` returns the nostrify `auth` callback: `signer.signEvent(nip42.makeAuthEvent(relayUrl, challenge))` (kind 22242, tags `[["relay",url],["challenge",challenge]]`). With no signer it rejects asynchronously (nostrify's `NRelay1` swallows a rejected `auth` promise, so public reads stay usable).
- `createRelayPool(relayUrls, signer?)` passes `auth` into the `open` factory; `fetchDmMessages` (the gated 1059 read) now threads the already-in-scope `input.signer`.
- The read path always has a signer (`useDmMessages` gates on `signer?.nip44`), so AUTH is always answerable there. Writes are intentionally **not** authenticated — the relay gate is read-only.

## Test / validation

- `npx tsc -p tsconfig.app.json --noEmit` → clean
- `npx eslint src/lib/dm.ts src/lib/dm.test.ts` → clean
- `npx vitest run src/lib/dm.test.ts src/hooks/useDirectMessages.test.ts src/pages/MessagesPage.test.tsx` → **51/51** (2 new tests: a real NSecSigner produces a signature-verified kind-22242 event with the right tags; the no-signer case rejects without throwing synchronously)
- `npx vite build` → clean

**Inert today** — the callback only fires when the relay sends an `AUTH` challenge, and funnelcake cannot send one: its `ClientMessage` enum has no AUTH variant, its `RelayMessage` enum has no Auth variant, and NIP-11 hardcodes `auth_required: false`. funnelcake#591 is still open with nothing implemented, so this is safe to merge in any order relative to the relay work.

**It does not yet make a gated read succeed.** nostrify's `NRelay1` sends the REQ the instant the socket opens — before it can have signed a challenge that arrives on that same open — and it never re-issues a REQ after answering AUTH. Probed against a local relay: with `CLOSED "auth-required: …"` the read returns 0 events and hangs to the abort signal (`NRelay1.req` breaks on CLOSED without yielding it, so `NPool` never sees an EOSE either); with a relay that silently serves nothing the read returns 0 events immediately. Client→relay order is `REQ, AUTH, CLOSE`. Answering the challenge is a necessary building block, but the REQ-ordering half needs funnelcake#591 to define what the relay actually does with an unauthenticated 1059 REQ.

## Visual change

None — network/auth behavior only.

