### PR TITLE
fix: point YouTube social link to @DivineVideoApp handle

### DIFF
--- a/src/components/SocialLinks.tsx
+++ b/src/components/SocialLinks.tsx
@@ -57,7 +57,7 @@ const SOCIAL_LINKS: readonly SocialLink[] = [
   },
   {
     name: 'YouTube',
-    href: 'https://www.youtube.com/channel/UCkAaxItWqDpTgngWAS2cAtQ',
+    href: 'https://www.youtube.com/@DivineVideoApp',
     icon: '/social-icons/youtube.svg',
     ariaLabelKey: 'socialLinks.followYoutube',
   },


### PR DESCRIPTION
## Summary

- Point the YouTube social link at the canonical handle URL `https://www.youtube.com/@DivineVideoApp` instead of the stale `/channel/UCkAaxItWqDpTgngWAS2cAtQ` URL, which no longer resolves to the official account.

## Motivation

- The old channel ID is dead, so the YouTube icon in both the sidebar and footer sent visitors to the wrong place. `SocialLinks.tsx` is the single source of truth for both rows, so one edit fixes both.

## Related Issue

- Closes #661

## Testing

- [x] `npm run test`
- [x] Manual verification completed

## Visuals

- [x] No visual change
- [x] Visuals and text avoid sensitive external brand or partner names unless explicitly approved