### PR TITLE
feat(discovery): publish destination relay and media pointers

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -194,15 +194,23 @@ skipped. Descriptor hashes and redirect-aware `HEAD` readback results remain
 distinct from independent byte hashing.
 
 After mirroring finishes, the page can republish durable public events to one
-custom `wss://` relay. This deliberately opens and closes a standalone
-`NRelay1` connection instead of routing migration writes through the app's
-`NPool`. Only media with descriptor-and-readback verification is rewritten.
+custom `wss://` relay. Migration writes use a standalone authenticated relay
+session instead of the app's `NPool`; the same session primitive also publishes
+the discovery pointers described below. Only media with
+descriptor-and-readback verification is rewritten.
 Changed events are re-signed with their original timestamp, referenced owner
 events are prepared first so `e`, `E`, and `q` tags keep pointing at valid
 event IDs, and unchanged events retain their original ID and signature.
 Encrypted messages, ephemeral or authentication events, deletion requests,
 and vanish requests are skipped. Relay refusals remain per-event results and
 do not stop unrelated publishes.
+
+Once at least one event is present at the destination relay, the page can publish
+destination-only discovery metadata there: a NIP-65 kind-10002 relay list and a
+BUD-03 kind-10063 Blossom server list. Each pointer is signed and reported
+independently. Replacement timestamps explicitly exceed the owner's archived
+pointer, and a future-dated archived pointer blocks that one publication rather
+than relying on relay tie-breaking or guessing the destination's clock policy.
 
 ## Linting
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -209,8 +209,9 @@ Once at least one event is present at the destination relay, the page can publis
 destination-only discovery metadata there: a NIP-65 kind-10002 relay list and a
 BUD-03 kind-10063 Blossom server list. Each pointer is signed and reported
 independently. Replacement timestamps explicitly exceed the owner's archived
-pointer, and a future-dated archived pointer blocks that one publication rather
-than relying on relay tie-breaking or guessing the destination's clock policy.
+pointer, and a pointer that would require more than one second of future clock
+skew blocks that publication rather than relying on relay tie-breaking or
+guessing the destination's clock policy.
 
 ## Linting
 

--- a/src/components/exit/DiscoveryPointerForm.test.tsx
+++ b/src/components/exit/DiscoveryPointerForm.test.tsx
@@ -53,7 +53,7 @@ describe("DiscoveryPointerForm", () => {
 
     expect(await screen.findByText("Relay list: published")).toBeInTheDocument();
     expect(screen.getByText("Blossom server list: published")).toBeInTheDocument();
-    expect(screen.getByText("Compatible third-party clients should now find your new home automatically.")).toBeInTheDocument();
+    expect(screen.getByText("Compatible third-party clients that check your destination relay should now find your new home automatically.")).toBeInTheDocument();
   });
 
   it("keeps a failed pointer separate from a successful one", async () => {

--- a/src/components/exit/DiscoveryPointerForm.test.tsx
+++ b/src/components/exit/DiscoveryPointerForm.test.tsx
@@ -1,0 +1,70 @@
+import type { NostrEvent, NostrSigner } from "@nostrify/nostrify";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { buildArchiveFiles } from "@/lib/exit/archive";
+import { fixturePubkey, makeFixtureEvent } from "@/lib/exit/__fixtures__/exportFixtures";
+import { openDestinationRelay } from "@/lib/exit/relayConnection";
+
+import { DiscoveryPointerForm } from "./DiscoveryPointerForm";
+
+vi.mock("@/lib/exit/relayConnection", () => ({ openDestinationRelay: vi.fn() }));
+
+const files = buildArchiveFiles({
+  events: [makeFixtureEvent()],
+  pubkey: fixturePubkey,
+  sourceEndpoint: "https://api.divine.video",
+  pageCount: 1,
+  failures: [],
+});
+
+const signer = {
+  signEvent: vi.fn(async (template: Omit<NostrEvent, "id" | "pubkey" | "sig">) => ({
+    ...template,
+    id: "a".repeat(64),
+    pubkey: fixturePubkey,
+    sig: "b".repeat(128),
+  })),
+} as unknown as NostrSigner;
+
+describe("DiscoveryPointerForm", () => {
+  const publish = vi.fn();
+
+  beforeEach(() => {
+    publish.mockReset().mockResolvedValue({ status: "accepted" });
+    vi.mocked(openDestinationRelay).mockReturnValue({ publish, close: vi.fn().mockResolvedValue(undefined) });
+  });
+
+  function renderForm() {
+    render(
+      <DiscoveryPointerForm
+        files={files}
+        relayDestination="wss://relay.example/"
+        blossomDestination="https://blossom.example"
+        signer={signer}
+      />,
+    );
+  }
+
+  it("reports each pointer and confirms automatic discovery after both succeed", async () => {
+    renderForm();
+    await userEvent.click(screen.getByRole("button", { name: "Publish destination pointers" }));
+
+    expect(await screen.findByText("Relay list: published")).toBeInTheDocument();
+    expect(screen.getByText("Blossom server list: published")).toBeInTheDocument();
+    expect(screen.getByText("Compatible third-party clients should now find your new home automatically.")).toBeInTheDocument();
+  });
+
+  it("keeps a failed pointer separate from a successful one", async () => {
+    publish
+      .mockResolvedValueOnce({ status: "failed", code: "blocked", message: "The relay blocked this event." })
+      .mockResolvedValueOnce({ status: "accepted" });
+    renderForm();
+    await userEvent.click(screen.getByRole("button", { name: "Publish destination pointers" }));
+
+    expect(await screen.findByText("Relay list: not published")).toBeInTheDocument();
+    expect(screen.getByText("Blossom server list: published")).toBeInTheDocument();
+    expect(screen.getByText(/Fix the failed pointer before relying on automatic discovery/)).toBeInTheDocument();
+  });
+});

--- a/src/components/exit/DiscoveryPointerForm.tsx
+++ b/src/components/exit/DiscoveryPointerForm.tsx
@@ -1,0 +1,61 @@
+// ABOUTME: Publishes and reports destination relay and Blossom discovery pointers
+// ABOUTME: Keeps each pointer outcome visible without changing earlier migration summaries
+
+import { ArrowClockwise, CheckCircle, MapPin, WarningCircle } from "@phosphor-icons/react";
+import type { NostrSigner } from "@nostrify/nostrify";
+
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { useDiscoveryPointers } from "@/hooks/useDiscoveryPointers";
+import type { ArchiveFiles } from "@/lib/exit/archive";
+
+interface DiscoveryPointerFormProps {
+  files: ArchiveFiles;
+  relayDestination: string;
+  blossomDestination: string;
+  signer: NostrSigner;
+}
+
+export function DiscoveryPointerForm(props: DiscoveryPointerFormProps) {
+  const pointers = useDiscoveryPointers(props);
+  const successful = pointers.results.filter((result) => result.status === "published" || result.status === "duplicate").length;
+
+  return (
+    <Card variant="brand" accent="violet">
+      <CardHeader><CardTitle>Point apps at your new home</CardTitle></CardHeader>
+      <CardContent className="space-y-5">
+        <p className="text-base leading-relaxed text-muted-foreground">
+          Check the media and post results above first. Publishing these pointers tells compatible apps where to find your posts and files.
+        </p>
+        <dl className="space-y-3 rounded-lg border border-brand-dark-green/15 p-4 dark:border-brand-green/25">
+          <div><dt className="text-sm font-semibold text-foreground">Relay</dt><dd className="break-all text-sm text-muted-foreground">{props.relayDestination}</dd></div>
+          <div><dt className="text-sm font-semibold text-foreground">Blossom server</dt><dd className="break-all text-sm text-muted-foreground">{props.blossomDestination}</dd></div>
+        </dl>
+        <Button type="button" variant="sticker" disabled={pointers.state === "running"} onClick={() => void pointers.start()}>
+          {pointers.state === "running" ? <ArrowClockwise className="h-4 w-4 animate-spin" aria-hidden="true" /> : <MapPin className="h-4 w-4" aria-hidden="true" />}
+          {pointers.state === "running" ? "Publishing pointers" : "Publish destination pointers"}
+        </Button>
+        {pointers.state === "complete" && (
+          <div className="space-y-4">
+            <ul className="space-y-3">
+              {pointers.results.map((result) => {
+                const ok = result.status === "published" || result.status === "duplicate";
+                return (
+                  <li key={result.kind} className="flex items-start gap-3">
+                    {ok ? <CheckCircle weight="fill" className="mt-1 h-5 w-5 flex-shrink-0 text-brand-dark-green dark:text-brand-green" /> : <WarningCircle weight="fill" className="mt-1 h-5 w-5 flex-shrink-0 text-destructive" />}
+                    <div><p className="font-semibold text-foreground">{result.label}: {ok ? "published" : "not published"}</p>{result.reason && <p className="text-sm text-muted-foreground">{result.reason}</p>}</div>
+                  </li>
+                );
+              })}
+            </ul>
+            <p className="text-base leading-relaxed text-muted-foreground" role="status">
+              {successful === 2
+                ? "Compatible third-party clients should now find your new home automatically."
+                : "Some old discovery pointers may still advertise Divine. Fix the failed pointer before relying on automatic discovery."}
+            </p>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/exit/DiscoveryPointerForm.tsx
+++ b/src/components/exit/DiscoveryPointerForm.tsx
@@ -50,7 +50,7 @@ export function DiscoveryPointerForm(props: DiscoveryPointerFormProps) {
             </ul>
             <p className="text-base leading-relaxed text-muted-foreground" role="status">
               {successful === 2
-                ? "Compatible third-party clients should now find your new home automatically."
+                ? "Compatible third-party clients that check your destination relay should now find your new home automatically."
                 : "Some old discovery pointers may still advertise Divine. Fix the failed pointer before relying on automatic discovery."}
             </p>
           </div>

--- a/src/hooks/useDestinationMirror.test.ts
+++ b/src/hooks/useDestinationMirror.test.ts
@@ -30,6 +30,7 @@ describe("useDestinationMirror", () => {
     });
 
     expect(result.current.state).toBe("failed");
+    expect(result.current.destination).toBeNull();
     expect(result.current.failure).toBe(
       "Blossom servers answer at the domain root. Use https://blossom.example instead.",
     );
@@ -58,5 +59,6 @@ describe("useDestinationMirror", () => {
     expect(result.current.summary).toBeNull();
     expect(result.current.results).toBeNull();
     expect(result.current.failure).toBeNull();
+    expect(result.current.destination).toBeNull();
   });
 });

--- a/src/hooks/useDestinationMirror.test.ts
+++ b/src/hooks/useDestinationMirror.test.ts
@@ -36,6 +36,16 @@ describe("useDestinationMirror", () => {
     );
   });
 
+  it("does not retain a destination when the copy fails", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response(null, { status: 401 })));
+    const { result } = renderHook(() => useDestinationMirror({ files: files(fixturePubkey), signer }));
+
+    await act(async () => result.current.start("https://blossom.example"));
+
+    expect(result.current.state).toBe("failed");
+    expect(result.current.destination).toBeNull();
+  });
+
   it("aborts active work and clears its state when the account changes", async () => {
     const fetcher = vi.fn((_input: RequestInfo | URL, init?: RequestInit) => new Promise<Response>((_resolve, reject) => {
       init?.signal?.addEventListener("abort", () => reject(new DOMException("Mirror cancelled", "AbortError")), { once: true });

--- a/src/hooks/useDestinationMirror.ts
+++ b/src/hooks/useDestinationMirror.ts
@@ -22,6 +22,7 @@ export function useDestinationMirror(input: { files: ArchiveFiles | null; signer
   const [summary, setSummary] = useState<MirrorSummary | null>(null);
   const [results, setResults] = useState<MirrorResult[] | null>(null);
   const [failure, setFailure] = useState<string | null>(null);
+  const [destination, setDestination] = useState<string | null>(null);
   const activeController = useRef<AbortController | null>(null);
   const archivePubkey = input.files?.["manifest.json"].pubkey;
 
@@ -32,6 +33,7 @@ export function useDestinationMirror(input: { files: ArchiveFiles | null; signer
     setSummary(null);
     setResults(null);
     setFailure(null);
+    setDestination(null);
     return () => activeController.current?.abort();
   }, [archivePubkey]);
 
@@ -45,9 +47,12 @@ export function useDestinationMirror(input: { files: ArchiveFiles | null; signer
     setSummary(null);
     setResults(null);
     setFailure(null);
+    setDestination(null);
     try {
+      const normalizedDestination = normalizeDestinationUrl(destinationValue);
+      setDestination(normalizedDestination);
       const results = await mirrorArchiveMedia({
-        destination: normalizeDestinationUrl(destinationValue),
+        destination: normalizedDestination,
         references: input.files["media.json"],
         signer: input.signer,
         signal: controller.signal,
@@ -66,5 +71,5 @@ export function useDestinationMirror(input: { files: ArchiveFiles | null; signer
     }
   }
 
-  return { state, progress, results, summary, failure, start };
+  return { state, progress, results, summary, failure, destination, start };
 }

--- a/src/hooks/useDestinationMirror.ts
+++ b/src/hooks/useDestinationMirror.ts
@@ -50,7 +50,6 @@ export function useDestinationMirror(input: { files: ArchiveFiles | null; signer
     setDestination(null);
     try {
       const normalizedDestination = normalizeDestinationUrl(destinationValue);
-      setDestination(normalizedDestination);
       const results = await mirrorArchiveMedia({
         destination: normalizedDestination,
         references: input.files["media.json"],
@@ -61,6 +60,7 @@ export function useDestinationMirror(input: { files: ArchiveFiles | null; signer
       if (controller.signal.aborted) return;
       setResults(results);
       setSummary(summarizeMirrorResults(results));
+      setDestination(normalizedDestination);
       setState("complete");
     } catch (error) {
       if (controller.signal.aborted) return;

--- a/src/hooks/useDestinationRepublish.test.ts
+++ b/src/hooks/useDestinationRepublish.test.ts
@@ -31,6 +31,7 @@ describe("useDestinationRepublish", () => {
     await act(async () => result.current.start("wss://relay.example"));
     expect(result.current.state).toBe("complete");
     expect(result.current.summary).toMatchObject({ published: 0, unchanged: 1, skipped: 0, failed: 0 });
+    expect(result.current.destination).toBe("wss://relay.example/");
   });
 
   it("aborts and resets when the account changes", async () => {
@@ -53,5 +54,6 @@ describe("useDestinationRepublish", () => {
     await waitFor(() => expect(result.current.state).toBe("idle"));
     expect(publishSignal?.aborted).toBe(true);
     expect(result.current.results).toBeNull();
+    expect(result.current.destination).toBeNull();
   });
 });

--- a/src/hooks/useDestinationRepublish.ts
+++ b/src/hooks/useDestinationRepublish.ts
@@ -13,6 +13,7 @@ import {
   type PublishResult,
   type PublishSummary,
 } from "@/lib/exit/relayPublisher";
+import { normalizeRelayDestinationUrl } from "@/lib/exit/relayDestination";
 
 type DestinationRepublishState = "idle" | "running" | "complete" | "failed";
 
@@ -26,6 +27,7 @@ export function useDestinationRepublish(input: {
   const [results, setResults] = useState<PublishResult[] | null>(null);
   const [summary, setSummary] = useState<PublishSummary | null>(null);
   const [failure, setFailure] = useState<string | null>(null);
+  const [destination, setDestination] = useState<string | null>(null);
   const activeController = useRef<AbortController | null>(null);
   const archivePubkey = input.files?.["manifest.json"].pubkey;
 
@@ -36,10 +38,11 @@ export function useDestinationRepublish(input: {
     setResults(null);
     setSummary(null);
     setFailure(null);
+    setDestination(null);
     return () => activeController.current?.abort();
   }, [archivePubkey, input.mirrorResults]);
 
-  async function start(destination: string) {
+  async function start(destinationValue: string) {
     if (!input.files || !input.mirrorResults || !input.signer) return;
     const controller = new AbortController();
     activeController.current?.abort();
@@ -49,9 +52,12 @@ export function useDestinationRepublish(input: {
     setResults(null);
     setSummary(null);
     setFailure(null);
+    setDestination(null);
     try {
+      const normalizedDestination = normalizeRelayDestinationUrl(destinationValue);
+      setDestination(normalizedDestination);
       const publishResults = await publishArchiveEvents({
-        destination,
+        destination: normalizedDestination,
         events: input.files["events.json"],
         mirrorResults: input.mirrorResults,
         signer: input.signer,
@@ -71,5 +77,5 @@ export function useDestinationRepublish(input: {
     }
   }
 
-  return { state, progress, results, summary, failure, start };
+  return { state, progress, results, summary, failure, destination, start };
 }

--- a/src/hooks/useDestinationRepublish.ts
+++ b/src/hooks/useDestinationRepublish.ts
@@ -55,7 +55,6 @@ export function useDestinationRepublish(input: {
     setDestination(null);
     try {
       const normalizedDestination = normalizeRelayDestinationUrl(destinationValue);
-      setDestination(normalizedDestination);
       const publishResults = await publishArchiveEvents({
         destination: normalizedDestination,
         events: input.files["events.json"],
@@ -67,6 +66,7 @@ export function useDestinationRepublish(input: {
       if (controller.signal.aborted) return;
       setResults(publishResults);
       setSummary(summarizePublishResults(publishResults));
+      setDestination(normalizedDestination);
       setState("complete");
     } catch (error) {
       if (controller.signal.aborted) return;

--- a/src/hooks/useDiscoveryPointers.test.ts
+++ b/src/hooks/useDiscoveryPointers.test.ts
@@ -1,6 +1,6 @@
 import type { NostrEvent, NostrSigner } from "@nostrify/nostrify";
 import { act, renderHook } from "@testing-library/react";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { buildArchiveFiles } from "@/lib/exit/archive";
 import { fixturePubkey, makeFixtureEvent } from "@/lib/exit/__fixtures__/exportFixtures";
@@ -24,6 +24,10 @@ describe("useDiscoveryPointers", () => {
     publish.mockReset().mockResolvedValue({ status: "accepted" });
     close.mockReset().mockResolvedValue(undefined);
     vi.mocked(openDestinationRelay).mockReset().mockReturnValue({ publish, close });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
   });
 
   it("keeps a signer refusal local to one pointer", async () => {

--- a/src/hooks/useDiscoveryPointers.test.ts
+++ b/src/hooks/useDiscoveryPointers.test.ts
@@ -23,7 +23,7 @@ describe("useDiscoveryPointers", () => {
   beforeEach(() => {
     publish.mockReset().mockResolvedValue({ status: "accepted" });
     close.mockReset().mockResolvedValue(undefined);
-    vi.mocked(openDestinationRelay).mockReturnValue({ publish, close });
+    vi.mocked(openDestinationRelay).mockReset().mockReturnValue({ publish, close });
   });
 
   it("keeps a signer refusal local to one pointer", async () => {
@@ -54,5 +54,49 @@ describe("useDiscoveryPointers", () => {
     await act(async () => result.current.start());
     expect(result.current.results.every((item) => item.status === "signing-failed")).toBe(true);
     expect(publish).not.toHaveBeenCalled();
+  });
+
+  it("reports future-dated pointers without opening a relay connection", async () => {
+    vi.spyOn(Date, "now").mockReturnValue(20_000);
+    const futureFiles = buildArchiveFiles({
+      events: [
+        makeFixtureEvent({ kind: 10_002, created_at: 21 }),
+        makeFixtureEvent({ id: "2".repeat(64), kind: 10_063, created_at: 21 }),
+      ],
+      pubkey: fixturePubkey,
+      sourceEndpoint: "https://api.divine.video",
+      pageCount: 1,
+      failures: [],
+    });
+    const testSigner = signer(async (template) => ({ ...template, id: "a".repeat(64), pubkey: fixturePubkey, sig: "b".repeat(128) }));
+    const { result } = renderHook(() => useDiscoveryPointers({ files: futureFiles, relayDestination: "wss://relay.example/", blossomDestination: "https://blossom.example", signer: testSigner }));
+
+    await act(async () => result.current.start());
+
+    expect(result.current.results.map((item) => item.status)).toEqual(["blocked", "blocked"]);
+    expect(testSigner.signEvent).not.toHaveBeenCalled();
+    expect(openDestinationRelay).not.toHaveBeenCalled();
+  });
+
+  it("resolves cleanly when an active publication is cancelled", async () => {
+    const testSigner = signer(async (template) => ({ ...template, id: "a".repeat(64), pubkey: fixturePubkey, sig: "b".repeat(128) }));
+    vi.mocked(openDestinationRelay).mockImplementation((options) => ({
+      publish: () => new Promise((_resolve, reject) => {
+        if (options.signal?.aborted) {
+          reject(new DOMException("Relay publish cancelled", "AbortError"));
+          return;
+        }
+        options.signal?.addEventListener("abort", () => reject(new DOMException("Relay publish cancelled", "AbortError")), { once: true });
+      }),
+      close,
+    }));
+    const { result, unmount } = renderHook(() => useDiscoveryPointers({ files, relayDestination: "wss://relay.example/", blossomDestination: "https://blossom.example", signer: testSigner }));
+    let startPromise: Promise<void> | undefined;
+    act(() => { startPromise = result.current.start(); });
+
+    unmount();
+
+    await expect(startPromise).resolves.toBeUndefined();
+    expect(close).toHaveBeenCalledOnce();
   });
 });

--- a/src/hooks/useDiscoveryPointers.test.ts
+++ b/src/hooks/useDiscoveryPointers.test.ts
@@ -99,4 +99,20 @@ describe("useDiscoveryPointers", () => {
     await expect(startPromise).resolves.toBeUndefined();
     expect(close).toHaveBeenCalledOnce();
   });
+
+  it("reports a relay connection that cannot start", async () => {
+    const testSigner = signer(async (template) => ({ ...template, id: "a".repeat(64), pubkey: fixturePubkey, sig: "b".repeat(128) }));
+    vi.mocked(openDestinationRelay).mockImplementation(() => {
+      throw new DOMException("The port is blocked", "SecurityError");
+    });
+    const { result } = renderHook(() => useDiscoveryPointers({ files, relayDestination: "wss://relay.example/", blossomDestination: "https://blossom.example", signer: testSigner }));
+
+    await act(async () => result.current.start());
+
+    expect(result.current.state).toBe("complete");
+    expect(result.current.results).toEqual(expect.arrayContaining([
+      expect.objectContaining({ status: "publish-failed", reason: expect.stringContaining("could not start") }),
+    ]));
+    expect(testSigner.signEvent).not.toHaveBeenCalled();
+  });
 });

--- a/src/hooks/useDiscoveryPointers.test.ts
+++ b/src/hooks/useDiscoveryPointers.test.ts
@@ -1,0 +1,58 @@
+import type { NostrEvent, NostrSigner } from "@nostrify/nostrify";
+import { act, renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { buildArchiveFiles } from "@/lib/exit/archive";
+import { fixturePubkey, makeFixtureEvent } from "@/lib/exit/__fixtures__/exportFixtures";
+import { openDestinationRelay } from "@/lib/exit/relayConnection";
+
+import { useDiscoveryPointers } from "./useDiscoveryPointers";
+
+vi.mock("@/lib/exit/relayConnection", () => ({ openDestinationRelay: vi.fn() }));
+
+const files = buildArchiveFiles({ events: [makeFixtureEvent()], pubkey: fixturePubkey, sourceEndpoint: "https://api.divine.video", pageCount: 1, failures: [] });
+
+function signer(sign: (template: Omit<NostrEvent, "id" | "pubkey" | "sig">) => Promise<NostrEvent>): NostrSigner {
+  return { signEvent: vi.fn(sign) } as unknown as NostrSigner;
+}
+
+describe("useDiscoveryPointers", () => {
+  const publish = vi.fn();
+  const close = vi.fn();
+
+  beforeEach(() => {
+    publish.mockReset().mockResolvedValue({ status: "accepted" });
+    close.mockReset().mockResolvedValue(undefined);
+    vi.mocked(openDestinationRelay).mockReturnValue({ publish, close });
+  });
+
+  it("keeps a signer refusal local to one pointer", async () => {
+    let calls = 0;
+    const testSigner = signer(async (template) => {
+      calls += 1;
+      if (calls === 1) throw new Error("not allowed");
+      return { ...template, id: "a".repeat(64), pubkey: fixturePubkey, sig: "b".repeat(128) };
+    });
+    const { result } = renderHook(() => useDiscoveryPointers({ files, relayDestination: "wss://relay.example/", blossomDestination: "https://blossom.example", signer: testSigner }));
+    await act(async () => result.current.start());
+    expect(result.current.results.map((item) => item.status)).toEqual(["signing-failed", "published"]);
+    expect(publish).toHaveBeenCalledOnce();
+    expect(close).toHaveBeenCalledOnce();
+  });
+
+  it("reports relay failures independently", async () => {
+    const testSigner = signer(async (template) => ({ ...template, id: "a".repeat(64), pubkey: fixturePubkey, sig: "b".repeat(128) }));
+    publish.mockResolvedValueOnce({ status: "failed", code: "blocked", message: "blocked" }).mockResolvedValueOnce({ status: "accepted" });
+    const { result } = renderHook(() => useDiscoveryPointers({ files, relayDestination: "wss://relay.example/", blossomDestination: "https://blossom.example", signer: testSigner }));
+    await act(async () => result.current.start());
+    expect(result.current.results.map((item) => item.status)).toEqual(["publish-failed", "published"]);
+  });
+
+  it("rejects a signed pointer for another account", async () => {
+    const testSigner = signer(async (template) => ({ ...template, id: "a".repeat(64), pubkey: "d".repeat(64), sig: "b".repeat(128) }));
+    const { result } = renderHook(() => useDiscoveryPointers({ files, relayDestination: "wss://relay.example/", blossomDestination: "https://blossom.example", signer: testSigner }));
+    await act(async () => result.current.start());
+    expect(result.current.results.every((item) => item.status === "signing-failed")).toBe(true);
+    expect(publish).not.toHaveBeenCalled();
+  });
+});

--- a/src/hooks/useDiscoveryPointers.ts
+++ b/src/hooks/useDiscoveryPointers.ts
@@ -65,8 +65,21 @@ export function useDiscoveryPointers(input: {
       setState("complete");
       return;
     }
-    const session = openDestinationRelay({ destination: input.relayDestination, signer: input.signer, signal: controller.signal });
     const nextResults: DiscoveryPointerResult[] = [];
+    let session;
+    try {
+      session = openDestinationRelay({ destination: input.relayDestination, signer: input.signer, signal: controller.signal });
+    } catch (error) {
+      const detail = error instanceof Error && error.message ? ` ${error.message}` : "";
+      setResults(prepared.map((item) => item.blocked ?? {
+        kind: item.definition.kind,
+        label: item.definition.label,
+        status: "publish-failed",
+        reason: `The destination relay connection could not start.${detail}`,
+      }));
+      setState("complete");
+      return;
+    }
     try {
       for (const item of prepared) {
         if (item.blocked) {

--- a/src/hooks/useDiscoveryPointers.ts
+++ b/src/hooks/useDiscoveryPointers.ts
@@ -49,22 +49,34 @@ export function useDiscoveryPointers(input: {
       { kind: RELAY_LIST_KIND, label: "Relay list", build: buildRelayListTemplate, destination: input.relayDestination },
       { kind: BLOSSOM_SERVER_LIST_KIND, label: "Blossom server list", build: buildBlossomServerListTemplate, destination: input.blossomDestination },
     ];
+    const prepared = definitions.map((definition) => {
+      const timestamp = replacementCreatedAt({
+        nowSeconds,
+        newestSeconds: newestPointerCreatedAt(input.files["events.json"], definition.kind, ownerPubkey),
+        toleranceSeconds: MAX_REPLACEMENT_FUTURE_SKEW_SECONDS,
+      });
+      if (timestamp.blocked) {
+        return { definition, blocked: { kind: definition.kind, label: definition.label, status: "blocked" as const, reason: timestamp.reason } };
+      }
+      return { definition, createdAt: timestamp.createdAt };
+    });
+    if (prepared.every((item) => item.blocked)) {
+      setResults(prepared.flatMap((item) => item.blocked ? [item.blocked] : []));
+      setState("complete");
+      return;
+    }
     const session = openDestinationRelay({ destination: input.relayDestination, signer: input.signer, signal: controller.signal });
     const nextResults: DiscoveryPointerResult[] = [];
     try {
-      for (const definition of definitions) {
-        const timestamp = replacementCreatedAt({
-          nowSeconds,
-          newestSeconds: newestPointerCreatedAt(input.files["events.json"], definition.kind, ownerPubkey),
-          toleranceSeconds: MAX_REPLACEMENT_FUTURE_SKEW_SECONDS,
-        });
-        if (timestamp.blocked) {
-          nextResults.push({ kind: definition.kind, label: definition.label, status: "blocked", reason: timestamp.reason });
+      for (const item of prepared) {
+        if (item.blocked) {
+          nextResults.push(item.blocked);
           continue;
         }
+        const { definition } = item;
         let event: NostrEvent;
         try {
-          event = await input.signer.signEvent(definition.build(definition.destination, timestamp.createdAt));
+          event = await input.signer.signEvent(definition.build(definition.destination, item.createdAt));
           if (event.pubkey !== ownerPubkey) throw new Error("The signer returned an event for a different account.");
         } catch (error) {
           const detail = error instanceof Error && error.message ? ` ${error.message}` : "";
@@ -80,6 +92,8 @@ export function useDiscoveryPointers(input: {
           nextResults.push({ kind: definition.kind, label: definition.label, status: "publish-failed", reason: outcome.message });
         }
       }
+    } catch (error) {
+      if (!controller.signal.aborted) throw error;
     } finally {
       await session.close();
     }

--- a/src/hooks/useDiscoveryPointers.ts
+++ b/src/hooks/useDiscoveryPointers.ts
@@ -1,0 +1,93 @@
+// ABOUTME: Publishes relay and Blossom discovery pointers independently after an account move
+// ABOUTME: Reports timestamp, signing, ownership, and relay failures separately for each pointer
+
+import type { NostrEvent, NostrSigner } from "@nostrify/nostrify";
+import { useEffect, useRef, useState } from "react";
+
+import type { ArchiveFiles } from "@/lib/exit/archive";
+import {
+  BLOSSOM_SERVER_LIST_KIND,
+  buildBlossomServerListTemplate,
+  buildRelayListTemplate,
+  MAX_REPLACEMENT_FUTURE_SKEW_SECONDS,
+  newestPointerCreatedAt,
+  RELAY_LIST_KIND,
+  replacementCreatedAt,
+} from "@/lib/exit/discoveryPointers";
+import { openDestinationRelay } from "@/lib/exit/relayConnection";
+
+export type DiscoveryPointerStatus = "published" | "duplicate" | "blocked" | "signing-failed" | "publish-failed";
+
+export interface DiscoveryPointerResult {
+  kind: number;
+  label: string;
+  status: DiscoveryPointerStatus;
+  reason?: string;
+}
+
+export function useDiscoveryPointers(input: {
+  files: ArchiveFiles;
+  relayDestination: string;
+  blossomDestination: string;
+  signer: NostrSigner;
+}) {
+  const [state, setState] = useState<"idle" | "running" | "complete">("idle");
+  const [results, setResults] = useState<DiscoveryPointerResult[]>([]);
+  const activeController = useRef<AbortController | null>(null);
+
+  useEffect(() => () => activeController.current?.abort(), []);
+
+  async function start() {
+    const controller = new AbortController();
+    activeController.current?.abort();
+    activeController.current = controller;
+    setState("running");
+    setResults([]);
+    const ownerPubkey = input.files["manifest.json"].pubkey;
+    const nowSeconds = Math.floor(Date.now() / 1000);
+    const definitions = [
+      { kind: RELAY_LIST_KIND, label: "Relay list", build: buildRelayListTemplate, destination: input.relayDestination },
+      { kind: BLOSSOM_SERVER_LIST_KIND, label: "Blossom server list", build: buildBlossomServerListTemplate, destination: input.blossomDestination },
+    ];
+    const session = openDestinationRelay({ destination: input.relayDestination, signer: input.signer, signal: controller.signal });
+    const nextResults: DiscoveryPointerResult[] = [];
+    try {
+      for (const definition of definitions) {
+        const timestamp = replacementCreatedAt({
+          nowSeconds,
+          newestSeconds: newestPointerCreatedAt(input.files["events.json"], definition.kind, ownerPubkey),
+          toleranceSeconds: MAX_REPLACEMENT_FUTURE_SKEW_SECONDS,
+        });
+        if (timestamp.blocked) {
+          nextResults.push({ kind: definition.kind, label: definition.label, status: "blocked", reason: timestamp.reason });
+          continue;
+        }
+        let event: NostrEvent;
+        try {
+          event = await input.signer.signEvent(definition.build(definition.destination, timestamp.createdAt));
+          if (event.pubkey !== ownerPubkey) throw new Error("The signer returned an event for a different account.");
+        } catch (error) {
+          const detail = error instanceof Error && error.message ? ` ${error.message}` : "";
+          nextResults.push({ kind: definition.kind, label: definition.label, status: "signing-failed", reason: `Your signer refused this pointer.${detail}` });
+          continue;
+        }
+        const outcome = await session.publish(event);
+        if (outcome.status === "accepted") {
+          nextResults.push({ kind: definition.kind, label: definition.label, status: "published" });
+        } else if (outcome.status === "duplicate") {
+          nextResults.push({ kind: definition.kind, label: definition.label, status: "duplicate", reason: outcome.message });
+        } else {
+          nextResults.push({ kind: definition.kind, label: definition.label, status: "publish-failed", reason: outcome.message });
+        }
+      }
+    } finally {
+      await session.close();
+    }
+    if (!controller.signal.aborted) {
+      setResults(nextResults);
+      setState("complete");
+    }
+  }
+
+  return { state, results, start };
+}

--- a/src/lib/exit/discoveryPointers.test.ts
+++ b/src/lib/exit/discoveryPointers.test.ts
@@ -1,0 +1,43 @@
+import type { NostrEvent } from "@nostrify/nostrify";
+import { describe, expect, it } from "vitest";
+
+import {
+  BLOSSOM_SERVER_LIST_KIND,
+  buildBlossomServerListTemplate,
+  buildRelayListTemplate,
+  newestPointerCreatedAt,
+  RELAY_LIST_KIND,
+  replacementCreatedAt,
+} from "./discoveryPointers";
+
+const OWNER = "a".repeat(64);
+
+function event(kind: number, createdAt: number, pubkey = OWNER): NostrEvent {
+  return { id: "b".repeat(64), pubkey, sig: "c".repeat(128), kind, created_at: createdAt, content: "", tags: [] };
+}
+
+describe("discovery pointer templates", () => {
+  it("builds destination-only NIP-65 and BUD-03 lists", () => {
+    expect(buildRelayListTemplate("wss://relay.example/", 10)).toEqual({ kind: 10002, created_at: 10, content: "", tags: [["r", "wss://relay.example/"]] });
+    expect(buildBlossomServerListTemplate("https://blossom.example", 11)).toEqual({ kind: 10063, created_at: 11, content: "", tags: [["server", "https://blossom.example"]] });
+    expect([RELAY_LIST_KIND, BLOSSOM_SERVER_LIST_KIND]).not.toContain(1063);
+    expect(JSON.stringify([buildRelayListTemplate("wss://relay.example/", 10), buildBlossomServerListTemplate("https://blossom.example", 11)])).not.toMatch(/relay\.divine\.video|media\.divine\.video/);
+  });
+
+  it("finds only the owner's newest pointer", () => {
+    expect(newestPointerCreatedAt([
+      event(RELAY_LIST_KIND, 10),
+      event(RELAY_LIST_KIND, 20),
+      event(RELAY_LIST_KIND, 99, "d".repeat(64)),
+      event(BLOSSOM_SERVER_LIST_KIND, 30),
+    ], RELAY_LIST_KIND, OWNER)).toBe(20);
+  });
+
+  it("beats older and equal timestamps and blocks future-dated pointers", () => {
+    expect(replacementCreatedAt({ nowSeconds: 20, newestSeconds: null })).toEqual({ createdAt: 20 });
+    expect(replacementCreatedAt({ nowSeconds: 20, newestSeconds: 10 })).toEqual({ createdAt: 20 });
+    expect(replacementCreatedAt({ nowSeconds: 20, newestSeconds: 20, toleranceSeconds: 60 })).toEqual({ createdAt: 21 });
+    expect(replacementCreatedAt({ nowSeconds: 20, newestSeconds: 21 })).toMatchObject({ blocked: true });
+    expect(replacementCreatedAt({ nowSeconds: 20, newestSeconds: 20, toleranceSeconds: 1 })).toEqual({ createdAt: 21 });
+  });
+});

--- a/src/lib/exit/discoveryPointers.test.ts
+++ b/src/lib/exit/discoveryPointers.test.ts
@@ -5,6 +5,7 @@ import {
   BLOSSOM_SERVER_LIST_KIND,
   buildBlossomServerListTemplate,
   buildRelayListTemplate,
+  MAX_REPLACEMENT_FUTURE_SKEW_SECONDS,
   newestPointerCreatedAt,
   RELAY_LIST_KIND,
   replacementCreatedAt,
@@ -39,5 +40,10 @@ describe("discovery pointer templates", () => {
     expect(replacementCreatedAt({ nowSeconds: 20, newestSeconds: 20, toleranceSeconds: 60 })).toEqual({ createdAt: 21 });
     expect(replacementCreatedAt({ nowSeconds: 20, newestSeconds: 21 })).toMatchObject({ blocked: true });
     expect(replacementCreatedAt({ nowSeconds: 20, newestSeconds: 20, toleranceSeconds: 1 })).toEqual({ createdAt: 21 });
+    expect(replacementCreatedAt({
+      nowSeconds: 20,
+      newestSeconds: 21,
+      toleranceSeconds: MAX_REPLACEMENT_FUTURE_SKEW_SECONDS,
+    })).toMatchObject({ blocked: true });
   });
 });

--- a/src/lib/exit/discoveryPointers.ts
+++ b/src/lib/exit/discoveryPointers.ts
@@ -1,0 +1,44 @@
+// ABOUTME: Builds destination-only Nostr discovery pointer templates for account moves
+// ABOUTME: Chooses replacement timestamps without relying on replaceable-event tie breaks
+
+import type { NostrEvent } from "@nostrify/nostrify";
+
+import type { EventTemplate } from "./eventRewrite";
+
+export const RELAY_LIST_KIND = 10_002;
+export const BLOSSOM_SERVER_LIST_KIND = 10_063;
+export const MAX_REPLACEMENT_FUTURE_SKEW_SECONDS = 60;
+
+export function buildRelayListTemplate(relayUrl: string, createdAt: number): EventTemplate {
+  return { kind: RELAY_LIST_KIND, created_at: createdAt, content: "", tags: [["r", relayUrl]] };
+}
+
+export function buildBlossomServerListTemplate(serverOrigin: string, createdAt: number): EventTemplate {
+  return { kind: BLOSSOM_SERVER_LIST_KIND, created_at: createdAt, content: "", tags: [["server", serverOrigin]] };
+}
+
+export function newestPointerCreatedAt(events: NostrEvent[], kind: number, ownerPubkey: string): number | null {
+  const timestamps = events
+    .filter((event) => event.kind === kind && event.pubkey === ownerPubkey)
+    .map((event) => event.created_at);
+  return timestamps.length > 0 ? Math.max(...timestamps) : null;
+}
+
+export type ReplacementTimestamp =
+  | { createdAt: number; blocked?: never; reason?: never }
+  | { createdAt?: never; blocked: true; reason: string };
+
+export function replacementCreatedAt(input: {
+  nowSeconds: number;
+  newestSeconds: number | null;
+  toleranceSeconds?: number;
+}): ReplacementTimestamp {
+  const createdAt = Math.max(input.nowSeconds, (input.newestSeconds ?? -1) + 1);
+  if (createdAt > input.nowSeconds + (input.toleranceSeconds ?? 0)) {
+    return {
+      blocked: true,
+      reason: "The existing discovery pointer is too far in the future to replace safely. Fix its timestamp before publishing another one.",
+    };
+  }
+  return { createdAt };
+}

--- a/src/lib/exit/discoveryPointers.ts
+++ b/src/lib/exit/discoveryPointers.ts
@@ -7,7 +7,7 @@ import type { EventTemplate } from "./eventRewrite";
 
 export const RELAY_LIST_KIND = 10_002;
 export const BLOSSOM_SERVER_LIST_KIND = 10_063;
-export const MAX_REPLACEMENT_FUTURE_SKEW_SECONDS = 60;
+export const MAX_REPLACEMENT_FUTURE_SKEW_SECONDS = 1;
 
 export function buildRelayListTemplate(relayUrl: string, createdAt: number): EventTemplate {
   return { kind: RELAY_LIST_KIND, created_at: createdAt, content: "", tags: [["r", relayUrl]] };

--- a/src/lib/exit/relayConnection.test.ts
+++ b/src/lib/exit/relayConnection.test.ts
@@ -1,0 +1,60 @@
+import type { NostrEvent, NostrSigner } from "@nostrify/nostrify";
+import { describe, expect, it, vi } from "vitest";
+
+import { openDestinationRelay } from "./relayConnection";
+
+const RELAY = "wss://relay.example/nostr";
+const EVENT = { id: "a".repeat(64), pubkey: "b".repeat(64), sig: "c".repeat(128), kind: 1, created_at: 1, content: "", tags: [] };
+
+function signer(): NostrSigner {
+  return {
+    signEvent: vi.fn(async (template) => ({ ...template, id: "d".repeat(64), pubkey: "b".repeat(64), sig: "e".repeat(128) })),
+  } as unknown as NostrSigner;
+}
+
+describe("openDestinationRelay", () => {
+  it("publishes, maps duplicate refusals, and closes", async () => {
+    const close = vi.fn().mockResolvedValue(undefined);
+    const event = vi.fn()
+      .mockResolvedValueOnce(undefined)
+      .mockRejectedValueOnce(new Error("duplicate: stored"));
+    const session = openDestinationRelay({ destination: RELAY, signer: signer(), relayFactory: () => ({ event, close }) });
+    await expect(session.publish(EVENT)).resolves.toEqual({ status: "accepted" });
+    await expect(session.publish(EVENT)).resolves.toEqual({ status: "duplicate", message: "The relay already has this event." });
+    await session.close();
+    expect(close).toHaveBeenCalledOnce();
+  });
+
+  it("signs NIP-42 challenges for the full relay URL", async () => {
+    const testSigner = signer();
+    let auth: ((challenge: string) => Promise<NostrEvent>) | undefined;
+    openDestinationRelay({
+      destination: RELAY,
+      signer: testSigner,
+      relayFactory: (_url, options) => {
+        auth = options.auth;
+        return { event: vi.fn(), close: vi.fn().mockResolvedValue(undefined) };
+      },
+    });
+    await auth!("challenge value");
+    expect(testSigner.signEvent).toHaveBeenCalledWith(expect.objectContaining({
+      kind: 22242,
+      tags: [["relay", RELAY], ["challenge", "challenge value"]],
+    }));
+  });
+
+  it("bounds retries and reports the last rate limit", async () => {
+    const event = vi.fn().mockRejectedValue(new Error("rate-limited: slow"));
+    const wait = vi.fn().mockResolvedValue(undefined);
+    const session = openDestinationRelay({
+      destination: RELAY,
+      signer: signer(),
+      relayFactory: () => ({ event, close: vi.fn().mockResolvedValue(undefined) }),
+      wait,
+      maxRateLimitRetries: 1,
+    });
+    await expect(session.publish(EVENT)).resolves.toMatchObject({ status: "failed", code: "rate-limited" });
+    expect(event).toHaveBeenCalledTimes(2);
+    expect(wait).toHaveBeenCalledOnce();
+  });
+});

--- a/src/lib/exit/relayConnection.ts
+++ b/src/lib/exit/relayConnection.ts
@@ -1,0 +1,157 @@
+// ABOUTME: Publishes signed Nostr events through one authenticated destination relay session
+// ABOUTME: Centralizes relay refusal, retry, timeout, cancellation, and NIP-42 behavior
+
+import { NRelay1, type NostrEvent, type NostrSigner } from "@nostrify/nostrify";
+
+import { DestinationError } from "./destination";
+
+export type RelayPublishOutcome =
+  | { status: "accepted" }
+  | { status: "duplicate"; message: string }
+  | { status: "failed"; code: string; message: string };
+
+interface RelayConnection {
+  event(event: NostrEvent, options?: { signal?: AbortSignal }): Promise<void>;
+  close(): Promise<void>;
+}
+
+interface RelayFactoryOptions {
+  auth(challenge: string): Promise<NostrEvent>;
+}
+
+interface RelayAuthState {
+  failure: string | null;
+  currentPublish: AbortController | null;
+  handshake: Promise<void> | null;
+}
+
+export interface DestinationRelayOptions {
+  destination: string;
+  signer: NostrSigner;
+  signal?: AbortSignal;
+  relayFactory?: (url: string, options: RelayFactoryOptions) => RelayConnection;
+  wait?: (milliseconds: number, signal?: AbortSignal) => Promise<void>;
+  eventTimeoutMs?: number;
+  maxRateLimitRetries?: number;
+}
+
+export interface DestinationRelaySession {
+  publish(event: NostrEvent): Promise<RelayPublishOutcome>;
+  close(): Promise<void>;
+}
+
+const DEFAULT_EVENT_TIMEOUT_MS = 15_000;
+
+function defaultWait(milliseconds: number, signal?: AbortSignal): Promise<void> {
+  return new Promise((resolve, reject) => {
+    if (signal?.aborted) {
+      reject(new DOMException("Relay publish cancelled", "AbortError"));
+      return;
+    }
+    const timeout = window.setTimeout(resolve, milliseconds);
+    const abort = () => {
+      window.clearTimeout(timeout);
+      reject(new DOMException("Relay publish cancelled", "AbortError"));
+    };
+    signal?.addEventListener("abort", abort, { once: true });
+  });
+}
+
+type RelayRefusal = Exclude<RelayPublishOutcome, { status: "accepted" }> & { retry?: boolean };
+
+function relayRefusal(error: unknown): RelayRefusal {
+  if (error instanceof DOMException && error.name === "AbortError") {
+    return { status: "failed", code: "timeout", message: "The relay did not answer before the publish timed out." };
+  }
+  const raw = error instanceof Error ? error.message.trim() : "";
+  const separator = raw.indexOf(":");
+  const prefix = (separator === -1 ? "" : raw.slice(0, separator)).toLowerCase();
+  const detail = (separator === -1 ? raw : raw.slice(separator + 1)).replace(/\s+/g, " ").trim().slice(0, 200);
+  switch (prefix) {
+    case "duplicate": return { status: "duplicate", message: "The relay already has this event." };
+    case "rate-limited": return { status: "failed", code: prefix, message: "The relay is accepting events too slowly.", retry: true };
+    case "auth-required": return { status: "failed", code: prefix, message: "The relay wanted proof of your account before accepting this event.", retry: true };
+    case "blocked": return { status: "failed", code: prefix, message: `The relay blocked this event.${detail ? ` ${detail}` : ""}` };
+    case "restricted": return { status: "failed", code: prefix, message: `The relay restricts this event.${detail ? ` ${detail}` : ""}` };
+    case "invalid": return { status: "failed", code: prefix, message: `The relay says this event is invalid.${detail ? ` ${detail}` : ""}` };
+    case "pow": return { status: "failed", code: prefix, message: `The relay requires proof of work.${detail ? ` ${detail}` : ""}` };
+    default: return { status: "failed", code: "relay-error", message: raw || "The relay returned a response this tool could not read." };
+  }
+}
+
+function publishSignal(parent: AbortSignal | undefined, timeoutMs: number, authState: RelayAuthState) {
+  const timeout = new AbortController();
+  const currentPublish = new AbortController();
+  authState.currentPublish = currentPublish;
+  const handle = window.setTimeout(() => timeout.abort(), timeoutMs);
+  const signals = [timeout.signal, currentPublish.signal];
+  if (parent) signals.push(parent);
+  return {
+    signal: AbortSignal.any(signals),
+    dispose: () => {
+      window.clearTimeout(handle);
+      if (authState.currentPublish === currentPublish) authState.currentPublish = null;
+    },
+  };
+}
+
+export function openDestinationRelay(options: DestinationRelayOptions): DestinationRelaySession {
+  const wait = options.wait ?? defaultWait;
+  const timeoutMs = options.eventTimeoutMs ?? DEFAULT_EVENT_TIMEOUT_MS;
+  const authState: RelayAuthState = { failure: null, currentPublish: null, handshake: null };
+  const relayFactory = options.relayFactory ?? ((url, relayOptions) => new NRelay1(url, {
+    auth: relayOptions.auth,
+    backoff: false,
+    idleTimeout: false,
+  }));
+  const relay = relayFactory(options.destination, {
+    auth: async (challenge) => {
+      const handshake = options.signer.signEvent({
+        kind: 22242,
+        created_at: Math.floor(Date.now() / 1000),
+        content: "",
+        tags: [["relay", options.destination], ["challenge", challenge]],
+      });
+      authState.handshake = handshake.then(() => undefined, () => undefined);
+      try {
+        return await handshake;
+      } catch {
+        authState.failure = "Your signer refused the relay's access request.";
+        authState.currentPublish?.abort();
+        throw new DestinationError("auth-required", authState.failure);
+      }
+    },
+  });
+
+  return {
+    async publish(event) {
+      for (let attempt = 0; ; attempt += 1) {
+        if (options.signal?.aborted) throw new DOMException("Relay publish cancelled", "AbortError");
+        if (authState.failure) return { status: "failed", code: "auth-required", message: authState.failure };
+        const timed = publishSignal(options.signal, timeoutMs, authState);
+        try {
+          await relay.event(event, { signal: timed.signal });
+          return { status: "accepted" };
+        } catch (error) {
+          if (options.signal?.aborted) throw new DOMException("Relay publish cancelled", "AbortError");
+          if (authState.failure) return { status: "failed", code: "auth-required", message: authState.failure };
+          const refusal = relayRefusal(error);
+          if (refusal.status === "duplicate") return refusal;
+          if (refusal.retry && attempt < (options.maxRateLimitRetries ?? 2)) {
+            // Nostrify answers a connect-time NIP-42 challenge but does not
+            // resend events that were already refused while auth was pending.
+            if (refusal.code === "auth-required" && authState.handshake) {
+              await Promise.race([authState.handshake, wait(timeoutMs, options.signal)]);
+            }
+            await wait(1000 * 2 ** attempt, options.signal);
+            continue;
+          }
+          return refusal;
+        } finally {
+          timed.dispose();
+        }
+      }
+    },
+    close: () => relay.close(),
+  };
+}

--- a/src/lib/exit/relayPublisher.ts
+++ b/src/lib/exit/relayPublisher.ts
@@ -1,7 +1,7 @@
 // ABOUTME: Re-signs changed archive events and publishes them to one destination relay
 // ABOUTME: Orders referenced events first while isolating signer and relay failures per event
 
-import { NRelay1, type NostrEvent, type NostrSigner } from "@nostrify/nostrify";
+import type { NostrEvent, NostrSigner } from "@nostrify/nostrify";
 
 import {
   buildDestinationUrlMap,
@@ -10,9 +10,9 @@ import {
   rewriteEventMedia,
   rewriteEventReferences,
 } from "./eventRewrite";
-import { DestinationError } from "./destination";
 import type { MirrorResult } from "./mirrorClient";
 import { normalizeRelayDestinationUrl } from "./relayDestination";
+import { openDestinationRelay, type DestinationRelayOptions } from "./relayConnection";
 
 export type PublishStatus = "published" | "unchanged" | "skipped" | "failed";
 
@@ -39,22 +39,13 @@ export interface PublishSummary {
   remainingMediaUrls: number;
 }
 
-interface RelayConnection {
-  event(event: NostrEvent, options?: { signal?: AbortSignal }): Promise<void>;
-  close(): Promise<void>;
-}
-
-interface RelayFactoryOptions {
-  auth(challenge: string): Promise<NostrEvent>;
-}
-
 export interface PublishArchiveOptions {
   destination: string;
   events: NostrEvent[];
   mirrorResults: MirrorResult[];
   signer: NostrSigner;
   signal?: AbortSignal;
-  relayFactory?: (url: string, options: RelayFactoryOptions) => RelayConnection;
+  relayFactory?: DestinationRelayOptions["relayFactory"];
   wait?: (milliseconds: number, signal?: AbortSignal) => Promise<void>;
   eventTimeoutMs?: number;
   maxRateLimitRetries?: number;
@@ -68,74 +59,7 @@ interface PreparedEvent {
   remainingMediaUrls: number;
 }
 
-interface RelayAuthState {
-  failure: string | null;
-  currentPublish: AbortController | null;
-  handshake: Promise<void> | null;
-}
-
 const HEX_64 = /^[0-9a-f]{64}$/i;
-const DEFAULT_EVENT_TIMEOUT_MS = 15_000;
-
-function defaultWait(milliseconds: number, signal?: AbortSignal): Promise<void> {
-  return new Promise((resolve, reject) => {
-    if (signal?.aborted) {
-      reject(new DOMException("Republish cancelled", "AbortError"));
-      return;
-    }
-    const timeout = window.setTimeout(resolve, milliseconds);
-    const abort = () => {
-      window.clearTimeout(timeout);
-      reject(new DOMException("Republish cancelled", "AbortError"));
-    };
-    signal?.addEventListener("abort", abort, { once: true });
-  });
-}
-
-function relayRefusal(error: unknown): { code: string; message: string; retry: boolean; duplicate: boolean } {
-  if (error instanceof DOMException && error.name === "AbortError") {
-    return { code: "timeout", message: "The relay did not answer before the publish timed out.", retry: false, duplicate: false };
-  }
-  const raw = error instanceof Error ? error.message.trim() : "";
-  const separator = raw.indexOf(":");
-  const prefix = (separator === -1 ? "" : raw.slice(0, separator)).toLowerCase();
-  const detail = (separator === -1 ? raw : raw.slice(separator + 1)).replace(/\s+/g, " ").trim().slice(0, 200);
-  switch (prefix) {
-    case "duplicate": return { code: prefix, message: "The relay already has this event.", retry: false, duplicate: true };
-    case "rate-limited": return { code: prefix, message: "The relay is accepting events too slowly.", retry: true, duplicate: false };
-    case "auth-required": return { code: prefix, message: "The relay wanted proof of your account before accepting this event.", retry: true, duplicate: false };
-    case "blocked": return { code: prefix, message: `The relay blocked this event.${detail ? ` ${detail}` : ""}`, retry: false, duplicate: false };
-    case "restricted": return { code: prefix, message: `The relay restricts this event.${detail ? ` ${detail}` : ""}`, retry: false, duplicate: false };
-    case "invalid": return { code: prefix, message: `The relay says this event is invalid.${detail ? ` ${detail}` : ""}`, retry: false, duplicate: false };
-    case "pow": return { code: prefix, message: `The relay requires proof of work.${detail ? ` ${detail}` : ""}`, retry: false, duplicate: false };
-    default: return { code: "relay-error", message: raw || "The relay returned a response this tool could not read.", retry: false, duplicate: false };
-  }
-}
-
-function publishSignal(parent: AbortSignal | undefined, timeoutMs: number, authState: RelayAuthState): { signal: AbortSignal; dispose(): void } {
-  const timeout = new AbortController();
-  const currentPublish = new AbortController();
-  authState.currentPublish = currentPublish;
-  const handle = window.setTimeout(() => timeout.abort(), timeoutMs);
-  const signals = [timeout.signal, currentPublish.signal];
-  if (parent) signals.push(parent);
-  return {
-    signal: AbortSignal.any(signals),
-    dispose: () => {
-      window.clearTimeout(handle);
-      if (authState.currentPublish === currentPublish) authState.currentPublish = null;
-    },
-  };
-}
-
-async function createRelayAuth(signer: NostrSigner, relay: string, challenge: string): Promise<NostrEvent> {
-  return signer.signEvent({
-    kind: 22242,
-    created_at: Math.floor(Date.now() / 1000),
-    content: "",
-    tags: [["relay", relay], ["challenge", challenge]],
-  });
-}
 
 async function prepareEvents(options: PublishArchiveOptions): Promise<{
   events: PreparedEvent[];
@@ -222,101 +146,31 @@ async function prepareEvents(options: PublishArchiveOptions): Promise<{
   return { events, results };
 }
 
-async function publishOne(
-  relay: RelayConnection,
-  prepared: PreparedEvent,
-  options: PublishArchiveOptions,
-  authState: RelayAuthState,
-): Promise<PublishResult> {
-  const wait = options.wait ?? defaultWait;
-  const authenticationFailure = (): PublishResult => ({
-    event_id: prepared.original.id,
-    published_event_id: null,
-    kind: prepared.original.kind,
-    status: "failed",
-    remaining_media_urls: prepared.remainingMediaUrls,
-    reason: authState.failure ?? "The relay's access request could not be signed.",
-  });
-  for (let attempt = 0; ; attempt += 1) {
-    if (options.signal?.aborted) throw new DOMException("Republish cancelled", "AbortError");
-    if (authState.failure) return authenticationFailure();
-    const timed = publishSignal(options.signal, options.eventTimeoutMs ?? DEFAULT_EVENT_TIMEOUT_MS, authState);
-    try {
-      await relay.event(prepared.event, { signal: timed.signal });
-      return {
-        event_id: prepared.original.id,
-        published_event_id: prepared.event.id,
-        kind: prepared.original.kind,
-        status: prepared.changed ? "published" : "unchanged",
-        remaining_media_urls: prepared.remainingMediaUrls,
-      };
-    } catch (error) {
-      if (options.signal?.aborted) throw new DOMException("Republish cancelled", "AbortError");
-      if (authState.failure) return authenticationFailure();
-      const refusal = relayRefusal(error);
-      if (refusal.duplicate) {
-        return {
-          event_id: prepared.original.id,
-          published_event_id: prepared.event.id,
-          kind: prepared.original.kind,
-          status: prepared.changed ? "published" : "unchanged",
-          remaining_media_urls: prepared.remainingMediaUrls,
-          reason: refusal.message,
-        };
-      }
-      if (refusal.retry && attempt < (options.maxRateLimitRetries ?? 2)) {
-        // A NIP-42 relay challenges on connect and refuses whatever is already
-        // on the wire. Nostrify answers the challenge but never resends those
-        // events, so wait for the signature to settle and send them again.
-        // Bounded by the per-event timeout so a signer that never answers
-        // cannot stall the run.
-        if (refusal.code === "auth-required" && authState.handshake) {
-          await Promise.race([authState.handshake, wait(options.eventTimeoutMs ?? DEFAULT_EVENT_TIMEOUT_MS, options.signal)]);
-        }
-        await wait(1000 * 2 ** attempt, options.signal);
-        continue;
-      }
-      return {
-        event_id: prepared.original.id,
-        published_event_id: null,
-        kind: prepared.original.kind,
-        status: "failed",
-        remaining_media_urls: prepared.remainingMediaUrls,
-        reason: refusal.message,
-      };
-    } finally {
-      timed.dispose();
-    }
-  }
-}
-
 export async function publishArchiveEvents(options: PublishArchiveOptions): Promise<PublishResult[]> {
   const destination = normalizeRelayDestinationUrl(options.destination);
   const preparation = await prepareEvents(options);
   const results = [...preparation.results];
   if (preparation.events.length === 0) return results;
-  const relayFactory = options.relayFactory ?? ((url, relayOptions) => new NRelay1(url, {
-    auth: relayOptions.auth,
-    backoff: false,
-    idleTimeout: false,
-  }));
-  const authState: RelayAuthState = { failure: null, currentPublish: null, handshake: null };
-  const relay = relayFactory(destination, {
-    auth: async (challenge) => {
-      const handshake = createRelayAuth(options.signer, destination, challenge);
-      authState.handshake = handshake.then(() => undefined, () => undefined);
-      try {
-        return await handshake;
-      } catch {
-        authState.failure = "Your signer refused the relay's access request.";
-        authState.currentPublish?.abort();
-        throw new DestinationError("auth-required", authState.failure);
-      }
-    },
+  const relay = openDestinationRelay({
+    destination,
+    signer: options.signer,
+    signal: options.signal,
+    relayFactory: options.relayFactory,
+    wait: options.wait,
+    eventTimeoutMs: options.eventTimeoutMs,
+    maxRateLimitRetries: options.maxRateLimitRetries,
   });
   try {
     for (const event of preparation.events) {
-      const result = await publishOne(relay, event, options, authState);
+      const outcome = await relay.publish(event.event);
+      const result: PublishResult = {
+        event_id: event.original.id,
+        published_event_id: outcome.status === "failed" ? null : event.event.id,
+        kind: event.original.kind,
+        status: outcome.status === "failed" ? "failed" : event.changed ? "published" : "unchanged",
+        remaining_media_urls: event.remainingMediaUrls,
+        ...(outcome.status !== "accepted" ? { reason: outcome.message } : {}),
+      };
       results.push(result);
       options.onProgress?.({ completed: results.length, total: options.events.length, result });
     }

--- a/src/pages/ExitStartPage.discovery.test.tsx
+++ b/src/pages/ExitStartPage.discovery.test.tsx
@@ -1,0 +1,57 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { createFixtureFetch } from "@/lib/exit/__fixtures__/fixtureFetch";
+import { FixtureSigner } from "@/lib/exit/__fixtures__/fixtureSigner";
+import { fixturePubkey } from "@/lib/exit/__fixtures__/exportFixtures";
+import { TestApp } from "@/test/TestApp";
+
+import { ExitStartPage } from "./ExitStartPage";
+
+vi.mock("@/components/MarketingLayout", () => ({ MarketingLayout: ({ children }: { children: React.ReactNode }) => <div>{children}</div> }));
+vi.mock("@/components/auth/LocalNsecBanner", () => ({ LocalNsecBanner: () => null }));
+vi.mock("@/lib/localNsecAccount", () => ({ getLocalNsecLogin: () => null }));
+vi.mock("@/components/exit/DiscoveryPointerForm", () => ({ DiscoveryPointerForm: () => <div>Discovery pointer form</div> }));
+
+const signer = new FixtureSigner();
+vi.mock("@/hooks/useCurrentUser", () => ({
+  useCurrentUser: () => ({ user: { pubkey: fixturePubkey, signer }, signer, isResolvingJwt: false }),
+}));
+
+const mockMirror = vi.fn();
+const mockRepublish = vi.fn();
+vi.mock("@/hooks/useDestinationMirror", () => ({ useDestinationMirror: () => mockMirror() }));
+vi.mock("@/hooks/useDestinationRepublish", () => ({ useDestinationRepublish: () => mockRepublish() }));
+
+describe("ExitStartPage discovery pointer gate", () => {
+  beforeEach(() => {
+    mockMirror.mockReturnValue({ state: "complete", progress: null, results: [], summary: {}, failure: null, destination: "https://blossom.example", start: vi.fn() });
+    mockRepublish.mockReturnValue({ state: "complete", progress: null, results: [], summary: { published: 0, unchanged: 1, failed: 0, skipped: 0, remainingMediaUrls: 0 }, failure: null, destination: "wss://relay.example/", start: vi.fn() });
+    vi.stubGlobal("fetch", createFixtureFetch("one-page"));
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  async function createArchive() {
+    render(<TestApp><ExitStartPage /></TestApp>);
+    await userEvent.click(screen.getByRole("button", { name: /Create my archive/ }));
+    await waitFor(() => expect(screen.getByText("Discovery pointer form")).toBeInTheDocument());
+  }
+
+  it("offers pointers after at least one destination event succeeds", async () => {
+    await createArchive();
+    expect(screen.getByRole("heading", { name: "Publish your new home" })).toBeInTheDocument();
+  });
+
+  it("does not offer pointers after an all-failed republish", async () => {
+    mockRepublish.mockReturnValue({ state: "complete", progress: null, results: [], summary: { published: 0, unchanged: 0, failed: 2, skipped: 0, remainingMediaUrls: 0 }, failure: null, destination: "wss://relay.example/", start: vi.fn() });
+    render(<TestApp><ExitStartPage /></TestApp>);
+    await userEvent.click(screen.getByRole("button", { name: /Create my archive/ }));
+    await waitFor(() => expect(screen.getByText(/Your archive is ready/)).toBeInTheDocument());
+    expect(screen.queryByText("Discovery pointer form")).not.toBeInTheDocument();
+  });
+});

--- a/src/pages/ExitStartPage.tsx
+++ b/src/pages/ExitStartPage.tsx
@@ -9,6 +9,7 @@ import {
   Copy,
   DownloadSimple,
   Key,
+  MapPin,
   WarningCircle,
 } from "@phosphor-icons/react";
 import { useNostrLogin } from "@nostrify/react/login";
@@ -17,6 +18,7 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import { Link } from "react-router-dom";
 
 import { DestinationForm } from "@/components/exit/DestinationForm";
+import { DiscoveryPointerForm } from "@/components/exit/DiscoveryPointerForm";
 import { KeySafetyNotice } from "@/components/exit/KeySafetyNotice";
 import { MediaProgressList } from "@/components/exit/MediaProgressList";
 import { RelayDestinationForm } from "@/components/exit/RelayDestinationForm";
@@ -450,6 +452,29 @@ export function ExitStartPage() {
               summary={destinationRepublish.summary}
               failure={destinationRepublish.failure}
               onStart={destinationRepublish.start}
+            />
+          </section>
+        )}
+
+        {archiveFiles
+          && signer
+          && destinationMirror.destination
+          && destinationRepublish.destination
+          && destinationRepublish.state === "complete"
+          && destinationRepublish.summary
+          && destinationRepublish.summary.published + destinationRepublish.summary.unchanged > 0 && (
+          <section>
+            <SectionHero
+              eyebrow="Make the move discoverable"
+              icon={<MapPin weight="fill" className="h-7 w-7" />}
+              title="Publish your new home"
+              lead="Share destination-only discovery pointers so compatible apps can find your relay and Blossom server without Divine in the path."
+            />
+            <DiscoveryPointerForm
+              files={archiveFiles}
+              relayDestination={destinationRepublish.destination}
+              blossomDestination={destinationMirror.destination}
+              signer={signer}
             />
           </section>
         )}


### PR DESCRIPTION
## Summary

- Adds the final account-move step that publishes destination-only relay and Blossom discovery pointers.
- Reports each pointer independently and preserves the existing authenticated relay retry, timeout, and NIP-42 behavior through a shared session primitive.
- Retains normalized destinations from the earlier copy and republication steps, and offers discovery publication only after at least one event reaches the destination relay.

## Motivation

- Moving posts and media is not enough for compatible clients to discover their new locations. Publishing NIP-65 kind 10002 and BUD-03 kind 10063 lists lets those clients find the user's chosen infrastructure without Divine remaining in the advertised path.
- Existing replaceable pointers may have equal or future timestamps, so replacements explicitly advance the archived timestamp and stop when doing so would require unsafe clock skew.
- This deliberately does not change archive republication filtering: existing pointer events may still be copied during the preceding step and are superseded when this final step succeeds.

## Related Issue

- Closes #596

## Testing

- [x] `npm run test`
- [x] Focused Vitest coverage for pointer construction, timestamp ordering, relay sessions, independent failures, destination retention, and page gating

## Visuals

- [ ] UI change with screenshots/video attached
- [ ] No visual change
- [x] Visuals and text avoid sensitive external brand or partner names unless explicitly approved

The new UI is behind a signed-in export, completed media copy, and successful destination republication. Its gated states are covered by component/page tests; no screenshot fixture currently reaches that completed workflow.
