### PR TITLE
fix(exit): let other apps find moved accounts

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -210,12 +210,14 @@ and vanish requests are skipped. Relay refusals remain per-event results and
 do not stop unrelated publishes.
 
 Once at least one event is present at the destination relay, the page can publish
-destination-only discovery metadata there: a NIP-65 kind-10002 relay list and a
-BUD-03 kind-10063 Blossom server list. Each pointer is signed and reported
-independently. Replacement timestamps explicitly exceed the owner's archived
-pointer, and a pointer that would require more than one second of future clock
-skew blocks that publication rather than relying on relay tie-breaking or
-guessing the destination's clock policy.
+destination-only discovery metadata: a NIP-65 kind-10002 relay list and a BUD-03
+kind-10063 Blossom server list. Each pointer is signed once, then published to
+the destination and the public metadata relays that other clients query. The UI
+reports success only when a public metadata relay accepts the pointer. Replacement
+timestamps explicitly exceed the owner's archived pointer, and a pointer that
+would require more than one second of future clock skew blocks that publication
+rather than relying on relay tie-breaking or guessing the destination's clock
+policy.
 
 ## Linting
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -212,8 +212,10 @@ do not stop unrelated publishes.
 Once at least one event is present at the destination relay, the page can publish
 destination-only discovery metadata: a NIP-65 kind-10002 relay list and a BUD-03
 kind-10063 Blossom server list. Each pointer is signed once, then published to
-the destination and the public metadata relays that other clients query. The UI
-reports success only when a public metadata relay accepts the pointer. Replacement
+the destination and the public metadata relays that other clients query. Divine's
+own relay is one of those publication targets so an app that knows the old home
+can follow the move, but it never counts toward discovery: the UI reports success
+only when a metadata relay outside Divine accepts the pointer. Replacement
 timestamps explicitly exceed the owner's archived pointer, and a pointer that
 would require more than one second of future clock skew blocks that publication
 rather than relying on relay tie-breaking or guessing the destination's clock

--- a/src/components/exit/DiscoveryPointerForm.test.tsx
+++ b/src/components/exit/DiscoveryPointerForm.test.tsx
@@ -29,11 +29,11 @@ const signer = {
 } as unknown as NostrSigner;
 
 describe("DiscoveryPointerForm", () => {
-  const publish = vi.fn();
-
   beforeEach(() => {
-    publish.mockReset().mockResolvedValue({ status: "accepted" });
-    vi.mocked(openDestinationRelay).mockReturnValue({ publish, close: vi.fn().mockResolvedValue(undefined) });
+    vi.mocked(openDestinationRelay).mockReset().mockImplementation(() => ({
+      publish: vi.fn().mockResolvedValue({ status: "accepted" }),
+      close: vi.fn().mockResolvedValue(undefined),
+    }));
   });
 
   function renderForm() {
@@ -51,20 +51,38 @@ describe("DiscoveryPointerForm", () => {
     renderForm();
     await userEvent.click(screen.getByRole("button", { name: "Publish destination pointers" }));
 
-    expect(await screen.findByText("Relay list: published")).toBeInTheDocument();
-    expect(screen.getByText("Blossom server list: published")).toBeInTheDocument();
-    expect(screen.getByText("Compatible third-party clients that check your destination relay should now find your new home automatically.")).toBeInTheDocument();
+    expect(await screen.findByText("Relay list — published to 4 of 4 places apps look.")).toBeInTheDocument();
+    expect(screen.getByText("Blossom server list — published to 4 of 4 places apps look.")).toBeInTheDocument();
+    expect(screen.getByText("Other apps can now find your new home through public discovery relays.")).toBeInTheDocument();
   });
 
-  it("keeps a failed pointer separate from a successful one", async () => {
-    publish
-      .mockResolvedValueOnce({ status: "failed", code: "blocked", message: "The relay blocked this event." })
-      .mockResolvedValueOnce({ status: "accepted" });
+  it("names a failed relay while accepting partial discovery", async () => {
+    vi.mocked(openDestinationRelay).mockImplementation(({ destination }) => ({
+      publish: vi.fn().mockResolvedValue(destination === "wss://relay.damus.io/"
+        ? { status: "failed", code: "blocked", message: "The relay blocked this event." }
+        : { status: "accepted" }),
+      close: vi.fn().mockResolvedValue(undefined),
+    }));
     renderForm();
     await userEvent.click(screen.getByRole("button", { name: "Publish destination pointers" }));
 
-    expect(await screen.findByText("Relay list: not published")).toBeInTheDocument();
-    expect(screen.getByText("Blossom server list: published")).toBeInTheDocument();
-    expect(screen.getByText(/Fix the failed pointer before relying on automatic discovery/)).toBeInTheDocument();
+    expect(await screen.findByText("Relay list — published to 3 of 4 places apps look.")).toBeInTheDocument();
+    expect(screen.getAllByText(/wss:\/\/relay\.damus\.io\/: The relay blocked this event\./)).toHaveLength(2);
+    expect(screen.getByText("Other apps can now find your new home through public discovery relays.")).toBeInTheDocument();
+  });
+
+  it("does not claim discovery when only the destination accepts pointers", async () => {
+    vi.mocked(openDestinationRelay).mockImplementation(({ destination }) => ({
+      publish: vi.fn().mockResolvedValue(destination === "wss://relay.example/"
+        ? { status: "accepted" }
+        : { status: "failed", code: "blocked", message: "The relay blocked this event." }),
+      close: vi.fn().mockResolvedValue(undefined),
+    }));
+    renderForm();
+    await userEvent.click(screen.getByRole("button", { name: "Publish destination pointers" }));
+
+    expect(await screen.findByText("Relay list — only published to your destination.")).toBeInTheDocument();
+    expect(screen.getByText("Blossom server list — only published to your destination.")).toBeInTheDocument();
+    expect(screen.getByText(/At least one pointer is not discoverable yet/)).toBeInTheDocument();
   });
 });

--- a/src/components/exit/DiscoveryPointerForm.test.tsx
+++ b/src/components/exit/DiscoveryPointerForm.test.tsx
@@ -49,6 +49,7 @@ describe("DiscoveryPointerForm", () => {
 
   it("reports each pointer and confirms automatic discovery after both succeed", async () => {
     renderForm();
+    expect(screen.getByText(/same signed pointers to Divine and public metadata relays/)).toBeInTheDocument();
     await userEvent.click(screen.getByRole("button", { name: "Publish destination pointers" }));
 
     expect(await screen.findByText("Relay list — published to 3 of 3 places apps look.")).toBeInTheDocument();

--- a/src/components/exit/DiscoveryPointerForm.test.tsx
+++ b/src/components/exit/DiscoveryPointerForm.test.tsx
@@ -51,8 +51,8 @@ describe("DiscoveryPointerForm", () => {
     renderForm();
     await userEvent.click(screen.getByRole("button", { name: "Publish destination pointers" }));
 
-    expect(await screen.findByText("Relay list — published to 4 of 4 places apps look.")).toBeInTheDocument();
-    expect(screen.getByText("Blossom server list — published to 4 of 4 places apps look.")).toBeInTheDocument();
+    expect(await screen.findByText("Relay list — published to 3 of 3 places apps look.")).toBeInTheDocument();
+    expect(screen.getByText("Blossom server list — published to 3 of 3 places apps look.")).toBeInTheDocument();
     expect(screen.getByText("Other apps can now find your new home through public discovery relays.")).toBeInTheDocument();
   });
 
@@ -66,7 +66,7 @@ describe("DiscoveryPointerForm", () => {
     renderForm();
     await userEvent.click(screen.getByRole("button", { name: "Publish destination pointers" }));
 
-    expect(await screen.findByText("Relay list — published to 3 of 4 places apps look.")).toBeInTheDocument();
+    expect(await screen.findByText("Relay list — published to 2 of 3 places apps look.")).toBeInTheDocument();
     expect(screen.getAllByText(/wss:\/\/relay\.damus\.io\/: The relay blocked this event\./)).toHaveLength(2);
     expect(screen.getByText("Other apps can now find your new home through public discovery relays.")).toBeInTheDocument();
   });
@@ -84,5 +84,22 @@ describe("DiscoveryPointerForm", () => {
     expect(await screen.findByText("Relay list — only published to your destination.")).toBeInTheDocument();
     expect(screen.getByText("Blossom server list — only published to your destination.")).toBeInTheDocument();
     expect(screen.getByText(/At least one pointer is not discoverable yet/)).toBeInTheDocument();
+  });
+
+  it("does not call a pointer discoverable when only Divine's own relay accepts it", async () => {
+    vi.mocked(openDestinationRelay).mockImplementation(({ destination }) => ({
+      publish: vi.fn().mockResolvedValue(
+        destination === "wss://relay.example/" || destination === "wss://relay.divine.video/"
+          ? { status: "accepted" }
+          : { status: "failed", code: "blocked", message: "The relay blocked this event." },
+      ),
+      close: vi.fn().mockResolvedValue(undefined),
+    }));
+    renderForm();
+    await userEvent.click(screen.getByRole("button", { name: "Publish destination pointers" }));
+
+    expect(await screen.findByText("Relay list — only published to your destination.")).toBeInTheDocument();
+    expect(screen.getByText(/At least one pointer is not discoverable yet/)).toBeInTheDocument();
+    expect(screen.queryByText("Other apps can now find your new home through public discovery relays.")).toBeNull();
   });
 });

--- a/src/components/exit/DiscoveryPointerForm.tsx
+++ b/src/components/exit/DiscoveryPointerForm.tsx
@@ -18,7 +18,7 @@ interface DiscoveryPointerFormProps {
 
 export function DiscoveryPointerForm(props: DiscoveryPointerFormProps) {
   const pointers = useDiscoveryPointers(props);
-  const successful = pointers.results.filter((result) => result.status === "published" || result.status === "duplicate").length;
+  const discoverable = pointers.summaries.filter((summary) => summary.status === "published").length;
 
   return (
     <Card variant="brand" accent="violet">
@@ -38,20 +38,32 @@ export function DiscoveryPointerForm(props: DiscoveryPointerFormProps) {
         {pointers.state === "complete" && (
           <div className="space-y-4">
             <ul className="space-y-3">
-              {pointers.results.map((result) => {
-                const ok = result.status === "published" || result.status === "duplicate";
+              {pointers.summaries.map((summary) => {
+                const ok = summary.status === "published";
+                const outcome = ok
+                  ? `published to ${summary.acceptedDiscoveryRelays.length} of ${summary.totalDiscoveryRelays} places apps look`
+                  : summary.status === "destination-only"
+                    ? "only published to your destination"
+                    : "not published";
                 return (
-                  <li key={result.kind} className="flex items-start gap-3">
+                  <li key={summary.kind} className="flex items-start gap-3">
                     {ok ? <CheckCircle weight="fill" className="mt-1 h-5 w-5 flex-shrink-0 text-brand-dark-green dark:text-brand-green" /> : <WarningCircle weight="fill" className="mt-1 h-5 w-5 flex-shrink-0 text-destructive" />}
-                    <div><p className="font-semibold text-foreground">{result.label}: {ok ? "published" : "not published"}</p>{result.reason && <p className="text-sm text-muted-foreground">{result.reason}</p>}</div>
+                    <div>
+                      <p className="font-semibold text-foreground">{summary.label} — {outcome}.</p>
+                      {summary.failures.map((failure) => (
+                        <p key={`${summary.kind}:${failure.relay ?? summary.status}`} className="break-all text-sm text-muted-foreground">
+                          {failure.relay ? `${failure.relay}: ` : ""}{failure.reason}
+                        </p>
+                      ))}
+                    </div>
                   </li>
                 );
               })}
             </ul>
             <p className="text-base leading-relaxed text-muted-foreground" role="status">
-              {successful === 2
-                ? "Compatible third-party clients that check your destination relay should now find your new home automatically."
-                : "Some old discovery pointers may still advertise Divine. Fix the failed pointer before relying on automatic discovery."}
+              {discoverable === 2
+                ? "Other apps can now find your new home through public discovery relays."
+                : "At least one pointer is not discoverable yet. Try publishing again before relying on automatic discovery."}
             </p>
           </div>
         )}

--- a/src/components/exit/DiscoveryPointerForm.tsx
+++ b/src/components/exit/DiscoveryPointerForm.tsx
@@ -61,7 +61,7 @@ export function DiscoveryPointerForm(props: DiscoveryPointerFormProps) {
               })}
             </ul>
             <p className="text-base leading-relaxed text-muted-foreground" role="status">
-              {discoverable === 2
+              {discoverable === pointers.summaries.length
                 ? "Other apps can now find your new home through public discovery relays."
                 : "At least one pointer is not discoverable yet. Try publishing again before relying on automatic discovery."}
             </p>

--- a/src/components/exit/DiscoveryPointerForm.tsx
+++ b/src/components/exit/DiscoveryPointerForm.tsx
@@ -25,7 +25,7 @@ export function DiscoveryPointerForm(props: DiscoveryPointerFormProps) {
       <CardHeader><CardTitle>Point apps at your new home</CardTitle></CardHeader>
       <CardContent className="space-y-5">
         <p className="text-base leading-relaxed text-muted-foreground">
-          Check the media and post results above first. Publishing these pointers tells compatible apps where to find your posts and files.
+          Check the media and post results above first. This sends the same signed pointers to Divine and public metadata relays that compatible apps check. Each pointer names only your new relay or Blossom server.
         </p>
         <dl className="space-y-3 rounded-lg border border-brand-dark-green/15 p-4 dark:border-brand-green/25">
           <div><dt className="text-sm font-semibold text-foreground">Relay</dt><dd className="break-all text-sm text-muted-foreground">{props.relayDestination}</dd></div>

--- a/src/config/relays.ts
+++ b/src/config/relays.ts
@@ -103,7 +103,9 @@ export const PROFILE_RELAYS: RelayConfig[] = [
 
 /**
  * Public metadata relays where other clients can discover account-move pointers.
- * Divine remains included so clients that know the old home can find the new one.
+ * Divine remains included so clients that know the old home can find the new one,
+ * but a pointer that reaches only Divine has not been discovered by anyone else,
+ * so `pointerPublishTargets` does not count it toward automatic discovery.
  */
 export const DISCOVERY_POINTER_RELAYS: readonly RelayConfig[] = PROFILE_RELAYS;
 

--- a/src/config/relays.ts
+++ b/src/config/relays.ts
@@ -102,6 +102,12 @@ export const PROFILE_RELAYS: RelayConfig[] = [
 ];
 
 /**
+ * Public metadata relays where other clients can discover account-move pointers.
+ * Divine remains included so clients that know the old home can find the new one.
+ */
+export const DISCOVERY_POINTER_RELAYS: readonly RelayConfig[] = PROFILE_RELAYS;
+
+/**
  * Relays available in the UI relay picker
  * Users can switch between these relays for their main content feed
  */

--- a/src/hooks/useDiscoveryPointers.test.ts
+++ b/src/hooks/useDiscoveryPointers.test.ts
@@ -12,22 +12,40 @@ vi.mock("@/lib/exit/relayConnection", () => ({ openDestinationRelay: vi.fn() }))
 
 const files = buildArchiveFiles({ events: [makeFixtureEvent()], pubkey: fixturePubkey, sourceEndpoint: "https://api.divine.video", pageCount: 1, failures: [] });
 
-function signer(sign: (template: Omit<NostrEvent, "id" | "pubkey" | "sig">) => Promise<NostrEvent>): NostrSigner {
-  return { signEvent: vi.fn(sign) } as unknown as NostrSigner;
+function signer(sign?: (template: Omit<NostrEvent, "id" | "pubkey" | "sig">) => Promise<NostrEvent>): NostrSigner {
+  return {
+    signEvent: vi.fn(sign ?? (async (template) => ({ ...template, id: "a".repeat(64), pubkey: fixturePubkey, sig: "b".repeat(128) }))),
+  } as unknown as NostrSigner;
 }
 
 describe("useDiscoveryPointers", () => {
-  const publish = vi.fn();
-  const close = vi.fn();
+  const publishes = new Map<string, ReturnType<typeof vi.fn>>();
+  const closes = new Map<string, ReturnType<typeof vi.fn>>();
 
   beforeEach(() => {
-    publish.mockReset().mockResolvedValue({ status: "accepted" });
-    close.mockReset().mockResolvedValue(undefined);
-    vi.mocked(openDestinationRelay).mockReset().mockReturnValue({ publish, close });
+    publishes.clear();
+    closes.clear();
+    vi.mocked(openDestinationRelay).mockReset().mockImplementation(({ destination }) => {
+      const publish = vi.fn().mockResolvedValue({ status: "accepted" });
+      const close = vi.fn().mockResolvedValue(undefined);
+      publishes.set(destination, publish);
+      closes.set(destination, close);
+      return { publish, close };
+    });
   });
 
-  afterEach(() => {
-    vi.restoreAllMocks();
+  afterEach(() => vi.restoreAllMocks());
+
+  it("publishes both pointers to every deduplicated target and signs only twice", async () => {
+    const testSigner = signer();
+    const { result } = renderHook(() => useDiscoveryPointers({ files, relayDestination: "wss://relay.divine.video/", blossomDestination: "https://blossom.example", signer: testSigner }));
+
+    await act(async () => result.current.start());
+
+    expect(openDestinationRelay).toHaveBeenCalledTimes(4);
+    expect([...publishes.values()].every((publish) => publish.mock.calls.length === 2)).toBe(true);
+    expect(testSigner.signEvent).toHaveBeenCalledTimes(2);
+    expect(result.current.summaries.every((summary) => summary.status === "published")).toBe(true);
   });
 
   it("keeps a signer refusal local to one pointer", async () => {
@@ -38,85 +56,69 @@ describe("useDiscoveryPointers", () => {
       return { ...template, id: "a".repeat(64), pubkey: fixturePubkey, sig: "b".repeat(128) };
     });
     const { result } = renderHook(() => useDiscoveryPointers({ files, relayDestination: "wss://relay.example/", blossomDestination: "https://blossom.example", signer: testSigner }));
+
     await act(async () => result.current.start());
-    expect(result.current.results.map((item) => item.status)).toEqual(["signing-failed", "published"]);
-    expect(publish).toHaveBeenCalledOnce();
-    expect(close).toHaveBeenCalledOnce();
+
+    expect(result.current.summaries.map((summary) => summary.status)).toEqual(["signing-failed", "published"]);
+    expect([...publishes.values()].every((publish) => publish.mock.calls.length === 1)).toBe(true);
   });
 
-  it("reports relay failures independently", async () => {
-    const testSigner = signer(async (template) => ({ ...template, id: "a".repeat(64), pubkey: fixturePubkey, sig: "b".repeat(128) }));
-    publish.mockResolvedValueOnce({ status: "failed", code: "blocked", message: "blocked" }).mockResolvedValueOnce({ status: "accepted" });
+  it("keeps one relay connection failure local to that relay", async () => {
+    const testSigner = signer();
+    vi.mocked(openDestinationRelay).mockImplementation(({ destination }) => {
+      if (destination === "wss://relay.damus.io/") throw new DOMException("The port is blocked", "SecurityError");
+      const publish = vi.fn().mockResolvedValue({ status: "accepted" });
+      const close = vi.fn().mockResolvedValue(undefined);
+      publishes.set(destination, publish);
+      closes.set(destination, close);
+      return { publish, close };
+    });
     const { result } = renderHook(() => useDiscoveryPointers({ files, relayDestination: "wss://relay.example/", blossomDestination: "https://blossom.example", signer: testSigner }));
+
     await act(async () => result.current.start());
-    expect(result.current.results.map((item) => item.status)).toEqual(["publish-failed", "published"]);
+
+    expect(result.current.summaries.every((summary) => summary.status === "published")).toBe(true);
+    expect(result.current.results.filter((item) => item.status === "publish-failed")).toHaveLength(2);
+    expect(closes.size).toBe(4);
   });
 
-  it("rejects a signed pointer for another account", async () => {
-    const testSigner = signer(async (template) => ({ ...template, id: "a".repeat(64), pubkey: "d".repeat(64), sig: "b".repeat(128) }));
-    const { result } = renderHook(() => useDiscoveryPointers({ files, relayDestination: "wss://relay.example/", blossomDestination: "https://blossom.example", signer: testSigner }));
-    await act(async () => result.current.start());
-    expect(result.current.results.every((item) => item.status === "signing-failed")).toBe(true);
-    expect(publish).not.toHaveBeenCalled();
-  });
-
-  it("reports future-dated pointers without opening a relay connection", async () => {
+  it("reports future-dated pointers without signing or opening relays", async () => {
     vi.spyOn(Date, "now").mockReturnValue(20_000);
     const futureFiles = buildArchiveFiles({
-      events: [
-        makeFixtureEvent({ kind: 10_002, created_at: 21 }),
-        makeFixtureEvent({ id: "2".repeat(64), kind: 10_063, created_at: 21 }),
-      ],
+      events: [makeFixtureEvent({ kind: 10_002, created_at: 21 }), makeFixtureEvent({ id: "2".repeat(64), kind: 10_063, created_at: 21 })],
       pubkey: fixturePubkey,
       sourceEndpoint: "https://api.divine.video",
       pageCount: 1,
       failures: [],
     });
-    const testSigner = signer(async (template) => ({ ...template, id: "a".repeat(64), pubkey: fixturePubkey, sig: "b".repeat(128) }));
+    const testSigner = signer();
     const { result } = renderHook(() => useDiscoveryPointers({ files: futureFiles, relayDestination: "wss://relay.example/", blossomDestination: "https://blossom.example", signer: testSigner }));
 
     await act(async () => result.current.start());
 
-    expect(result.current.results.map((item) => item.status)).toEqual(["blocked", "blocked"]);
+    expect(result.current.summaries.map((summary) => summary.status)).toEqual(["blocked", "blocked"]);
     expect(testSigner.signEvent).not.toHaveBeenCalled();
     expect(openDestinationRelay).not.toHaveBeenCalled();
   });
 
-  it("resolves cleanly when an active publication is cancelled", async () => {
-    const testSigner = signer(async (template) => ({ ...template, id: "a".repeat(64), pubkey: fixturePubkey, sig: "b".repeat(128) }));
-    vi.mocked(openDestinationRelay).mockImplementation((options) => ({
-      publish: () => new Promise((_resolve, reject) => {
-        if (options.signal?.aborted) {
-          reject(new DOMException("Relay publish cancelled", "AbortError"));
-          return;
-        }
-        options.signal?.addEventListener("abort", () => reject(new DOMException("Relay publish cancelled", "AbortError")), { once: true });
-      }),
-      close,
-    }));
+  it("closes every active relay session when publication is cancelled", async () => {
+    const testSigner = signer();
+    vi.mocked(openDestinationRelay).mockImplementation(({ destination, signal }) => {
+      const close = vi.fn().mockResolvedValue(undefined);
+      closes.set(destination, close);
+      return {
+        publish: () => new Promise((_resolve, reject) => signal?.addEventListener("abort", () => reject(new DOMException("cancelled", "AbortError")), { once: true })),
+        close,
+      };
+    });
     const { result, unmount } = renderHook(() => useDiscoveryPointers({ files, relayDestination: "wss://relay.example/", blossomDestination: "https://blossom.example", signer: testSigner }));
     let startPromise: Promise<void> | undefined;
     act(() => { startPromise = result.current.start(); });
+    await vi.waitFor(() => expect(openDestinationRelay).toHaveBeenCalledTimes(5));
 
     unmount();
 
     await expect(startPromise).resolves.toBeUndefined();
-    expect(close).toHaveBeenCalledOnce();
-  });
-
-  it("reports a relay connection that cannot start", async () => {
-    const testSigner = signer(async (template) => ({ ...template, id: "a".repeat(64), pubkey: fixturePubkey, sig: "b".repeat(128) }));
-    vi.mocked(openDestinationRelay).mockImplementation(() => {
-      throw new DOMException("The port is blocked", "SecurityError");
-    });
-    const { result } = renderHook(() => useDiscoveryPointers({ files, relayDestination: "wss://relay.example/", blossomDestination: "https://blossom.example", signer: testSigner }));
-
-    await act(async () => result.current.start());
-
-    expect(result.current.state).toBe("complete");
-    expect(result.current.results).toEqual(expect.arrayContaining([
-      expect.objectContaining({ status: "publish-failed", reason: expect.stringContaining("could not start") }),
-    ]));
-    expect(testSigner.signEvent).not.toHaveBeenCalled();
+    expect([...closes.values()].every((close) => close.mock.calls.length === 1)).toBe(true);
   });
 });

--- a/src/hooks/useDiscoveryPointers.test.ts
+++ b/src/hooks/useDiscoveryPointers.test.ts
@@ -82,6 +82,26 @@ describe("useDiscoveryPointers", () => {
     expect(closes.size).toBe(4);
   });
 
+  it("keeps a late relay failure from discarding the other relays' results", async () => {
+    const testSigner = signer();
+    vi.mocked(openDestinationRelay).mockImplementation(({ destination }) => {
+      const publish = vi.fn().mockResolvedValue({ status: "accepted" });
+      const close = destination === "wss://relay.damus.io/"
+        ? vi.fn().mockRejectedValue(new Error("The socket closed unexpectedly"))
+        : vi.fn().mockResolvedValue(undefined);
+      publishes.set(destination, publish);
+      closes.set(destination, close);
+      return { publish, close };
+    });
+    const { result } = renderHook(() => useDiscoveryPointers({ files, relayDestination: "wss://relay.example/", blossomDestination: "https://blossom.example", signer: testSigner }));
+
+    await act(async () => result.current.start());
+
+    expect(result.current.state).toBe("complete");
+    expect(result.current.summaries.every((summary) => summary.status === "published")).toBe(true);
+    expect(result.current.results.filter((item) => item.status === "publish-failed")).toHaveLength(0);
+  });
+
   it("reports future-dated pointers without signing or opening relays", async () => {
     vi.spyOn(Date, "now").mockReturnValue(20_000);
     const futureFiles = buildArchiveFiles({

--- a/src/hooks/useDiscoveryPointers.test.ts
+++ b/src/hooks/useDiscoveryPointers.test.ts
@@ -100,6 +100,7 @@ describe("useDiscoveryPointers", () => {
     expect(result.current.state).toBe("complete");
     expect(result.current.summaries.every((summary) => summary.status === "published")).toBe(true);
     expect(result.current.results.filter((item) => item.status === "publish-failed")).toHaveLength(0);
+    expect(result.current.results.filter((item) => "relay" in item && item.relay === "wss://relay.damus.io/")).toHaveLength(2);
   });
 
   it("reports future-dated pointers without signing or opening relays", async () => {

--- a/src/hooks/useDiscoveryPointers.ts
+++ b/src/hooks/useDiscoveryPointers.ts
@@ -1,28 +1,56 @@
-// ABOUTME: Publishes relay and Blossom discovery pointers independently after an account move
-// ABOUTME: Reports timestamp, signing, ownership, and relay failures separately for each pointer
+// ABOUTME: Publishes account-move pointers to relays where other apps discover them
+// ABOUTME: Reports pointer preparation and per-relay publication outcomes independently
 
-import type { NostrEvent, NostrSigner } from "@nostrify/nostrify";
+import type { NostrSigner } from "@nostrify/nostrify";
 import { useEffect, useRef, useState } from "react";
 
 import type { ArchiveFiles } from "@/lib/exit/archive";
+import {
+  type DiscoveryPointerResult,
+  type DiscoveryPointerSummary,
+  type PointerToSign,
+  prepareSignedPointers,
+  publishPointersToRelay,
+  summarizePointerResults,
+} from "@/lib/exit/discoveryPointerPublisher";
 import {
   BLOSSOM_SERVER_LIST_KIND,
   buildBlossomServerListTemplate,
   buildRelayListTemplate,
   MAX_REPLACEMENT_FUTURE_SKEW_SECONDS,
   newestPointerCreatedAt,
+  pointerPublishTargets,
   RELAY_LIST_KIND,
   replacementCreatedAt,
 } from "@/lib/exit/discoveryPointers";
-import { openDestinationRelay } from "@/lib/exit/relayConnection";
 
-export type DiscoveryPointerStatus = "published" | "duplicate" | "blocked" | "signing-failed" | "publish-failed";
-
-export interface DiscoveryPointerResult {
+interface PointerDefinition {
   kind: number;
   label: string;
-  status: DiscoveryPointerStatus;
-  reason?: string;
+  build(destination: string, createdAt: number): ReturnType<typeof buildRelayListTemplate>;
+  destination: string;
+}
+
+function pointerDefinitions(input: { relayDestination: string; blossomDestination: string }): PointerDefinition[] {
+  return [
+    { kind: RELAY_LIST_KIND, label: "Relay list", build: buildRelayListTemplate, destination: input.relayDestination },
+    { kind: BLOSSOM_SERVER_LIST_KIND, label: "Blossom server list", build: buildBlossomServerListTemplate, destination: input.blossomDestination },
+  ];
+}
+
+function prepareTemplates(input: { files: ArchiveFiles; definitions: PointerDefinition[]; ownerPubkey: string; nowSeconds: number }) {
+  const pointers: PointerToSign[] = [];
+  const failures: DiscoveryPointerResult[] = [];
+  for (const definition of input.definitions) {
+    const timestamp = replacementCreatedAt({
+      nowSeconds: input.nowSeconds,
+      newestSeconds: newestPointerCreatedAt(input.files["events.json"], definition.kind, input.ownerPubkey),
+      toleranceSeconds: MAX_REPLACEMENT_FUTURE_SKEW_SECONDS,
+    });
+    if (timestamp.blocked) failures.push({ kind: definition.kind, label: definition.label, status: "blocked", reason: timestamp.reason });
+    else pointers.push({ kind: definition.kind, label: definition.label, template: definition.build(definition.destination, timestamp.createdAt) });
+  }
+  return { pointers, failures };
 }
 
 export function useDiscoveryPointers(input: {
@@ -33,6 +61,7 @@ export function useDiscoveryPointers(input: {
 }) {
   const [state, setState] = useState<"idle" | "running" | "complete">("idle");
   const [results, setResults] = useState<DiscoveryPointerResult[]>([]);
+  const [summaries, setSummaries] = useState<DiscoveryPointerSummary[]>([]);
   const activeController = useRef<AbortController | null>(null);
 
   useEffect(() => () => activeController.current?.abort(), []);
@@ -43,78 +72,31 @@ export function useDiscoveryPointers(input: {
     activeController.current = controller;
     setState("running");
     setResults([]);
+    setSummaries([]);
+
     const ownerPubkey = input.files["manifest.json"].pubkey;
-    const nowSeconds = Math.floor(Date.now() / 1000);
-    const definitions = [
-      { kind: RELAY_LIST_KIND, label: "Relay list", build: buildRelayListTemplate, destination: input.relayDestination },
-      { kind: BLOSSOM_SERVER_LIST_KIND, label: "Blossom server list", build: buildBlossomServerListTemplate, destination: input.blossomDestination },
-    ];
-    const prepared = definitions.map((definition) => {
-      const timestamp = replacementCreatedAt({
-        nowSeconds,
-        newestSeconds: newestPointerCreatedAt(input.files["events.json"], definition.kind, ownerPubkey),
-        toleranceSeconds: MAX_REPLACEMENT_FUTURE_SKEW_SECONDS,
-      });
-      if (timestamp.blocked) {
-        return { definition, blocked: { kind: definition.kind, label: definition.label, status: "blocked" as const, reason: timestamp.reason } };
-      }
-      return { definition, createdAt: timestamp.createdAt };
-    });
-    if (prepared.every((item) => item.blocked)) {
-      setResults(prepared.flatMap((item) => item.blocked ? [item.blocked] : []));
-      setState("complete");
-      return;
-    }
-    const nextResults: DiscoveryPointerResult[] = [];
-    let session;
-    try {
-      session = openDestinationRelay({ destination: input.relayDestination, signer: input.signer, signal: controller.signal });
-    } catch (error) {
-      const detail = error instanceof Error && error.message ? ` ${error.message}` : "";
-      setResults(prepared.map((item) => item.blocked ?? {
-        kind: item.definition.kind,
-        label: item.definition.label,
-        status: "publish-failed",
-        reason: `The destination relay connection could not start.${detail}`,
-      }));
-      setState("complete");
-      return;
-    }
-    try {
-      for (const item of prepared) {
-        if (item.blocked) {
-          nextResults.push(item.blocked);
-          continue;
-        }
-        const { definition } = item;
-        let event: NostrEvent;
-        try {
-          event = await input.signer.signEvent(definition.build(definition.destination, item.createdAt));
-          if (event.pubkey !== ownerPubkey) throw new Error("The signer returned an event for a different account.");
-        } catch (error) {
-          const detail = error instanceof Error && error.message ? ` ${error.message}` : "";
-          nextResults.push({ kind: definition.kind, label: definition.label, status: "signing-failed", reason: `Your signer refused this pointer.${detail}` });
-          continue;
-        }
-        const outcome = await session.publish(event);
-        if (outcome.status === "accepted") {
-          nextResults.push({ kind: definition.kind, label: definition.label, status: "published" });
-        } else if (outcome.status === "duplicate") {
-          nextResults.push({ kind: definition.kind, label: definition.label, status: "duplicate", reason: outcome.message });
-        } else {
-          nextResults.push({ kind: definition.kind, label: definition.label, status: "publish-failed", reason: outcome.message });
-        }
-      }
-    } catch (error) {
-      if (!controller.signal.aborted) throw error;
-    } finally {
-      await session.close();
-    }
-    if (!controller.signal.aborted) {
+    const definitions = pointerDefinitions(input);
+    const targets = pointerPublishTargets({ relayDestination: input.relayDestination });
+    const prepared = prepareTemplates({ files: input.files, definitions, ownerPubkey, nowSeconds: Math.floor(Date.now() / 1000) });
+    const signed = await prepareSignedPointers({ pointers: prepared.pointers, signer: input.signer, ownerPubkey });
+    if (signed.signed.length === 0) {
+      const nextResults = [...prepared.failures, ...signed.failures];
       setResults(nextResults);
+      setSummaries(summarizePointerResults({ pointers: definitions, targets, results: nextResults }));
       setState("complete");
+      return;
     }
+    const settled = await Promise.allSettled(targets.map((target) => publishPointersToRelay({ target, pointers: signed.signed, signer: input.signer, signal: controller.signal })));
+    if (controller.signal.aborted) return;
+    const rejected = settled.find((outcome) => outcome.status === "rejected");
+    if (rejected?.status === "rejected") throw rejected.reason;
+    const relayResults = settled.flatMap((outcome) => outcome.status === "fulfilled" ? outcome.value : []);
+    const nextResults = [...prepared.failures, ...signed.failures, ...relayResults]
+      .sort((left, right) => left.kind - right.kind || (("relay" in left ? left.relay : "").localeCompare("relay" in right ? right.relay : "")));
+    setResults(nextResults);
+    setSummaries(summarizePointerResults({ pointers: definitions, targets, results: nextResults }));
+    setState("complete");
   }
 
-  return { state, results, start };
+  return { state, results, summaries, start };
 }

--- a/src/hooks/useDiscoveryPointers.ts
+++ b/src/hooks/useDiscoveryPointers.ts
@@ -88,8 +88,8 @@ export function useDiscoveryPointers(input: {
     }
     const settled = await Promise.allSettled(targets.map((target) => publishPointersToRelay({ target, pointers: signed.signed, signer: input.signer, signal: controller.signal })));
     if (controller.signal.aborted) return;
-    const rejected = settled.find((outcome) => outcome.status === "rejected");
-    if (rejected?.status === "rejected") throw rejected.reason;
+    // publishPointersToRelay reports its own failures and only rejects when the
+    // run was cancelled, which the check above already handled.
     const relayResults = settled.flatMap((outcome) => outcome.status === "fulfilled" ? outcome.value : []);
     const nextResults = [...prepared.failures, ...signed.failures, ...relayResults]
       .sort((left, right) => left.kind - right.kind || (("relay" in left ? left.relay : "").localeCompare("relay" in right ? right.relay : "")));

--- a/src/lib/exit/discoveryPointerPublisher.test.ts
+++ b/src/lib/exit/discoveryPointerPublisher.test.ts
@@ -11,6 +11,10 @@ import {
 vi.mock("./relayConnection", () => ({ openDestinationRelay: vi.fn() }));
 
 const ownerPubkey = "a".repeat(64);
+const signedPointers = [
+  { kind: 10002, label: "Relay list", event: { kind: 10002 } as NostrEvent },
+  { kind: 10063, label: "Blossom server list", event: { kind: 10063 } as NostrEvent },
+];
 
 function signer(): NostrSigner {
   return {
@@ -72,6 +76,38 @@ describe("discovery pointer publication", () => {
 
     expect(prepared.signed).toEqual([]);
     expect(prepared.failures[0]).toMatchObject({ status: "signing-failed", reason: expect.stringContaining("different account") });
+  });
+
+  it("keeps accepted results when the relay stops answering mid-publication", async () => {
+    publish
+      .mockResolvedValueOnce({ status: "accepted" })
+      .mockRejectedValueOnce(new Error("socket closed"));
+
+    await expect(publishPointersToRelay({
+      target: { relay: "wss://indexer.example/", isDiscoveryRelay: true },
+      pointers: signedPointers,
+      signer: signer(),
+      signal: new AbortController().signal,
+    })).resolves.toEqual([
+      expect.objectContaining({ kind: 10002, status: "published" }),
+      expect.objectContaining({ kind: 10063, status: "publish-failed", reason: expect.stringContaining("stopped answering") }),
+    ]);
+  });
+
+  it("rethrows relay failures when publication was cancelled", async () => {
+    const controller = new AbortController();
+    publish.mockImplementationOnce(async () => {
+      controller.abort();
+      throw new DOMException("cancelled", "AbortError");
+    });
+
+    await expect(publishPointersToRelay({
+      target: { relay: "wss://indexer.example/", isDiscoveryRelay: true },
+      pointers: signedPointers,
+      signer: signer(),
+      signal: controller.signal,
+    })).rejects.toThrow("cancelled");
+    expect(close).toHaveBeenCalledOnce();
   });
 
   it("marks duplicate relay responses as accepted discovery", () => {

--- a/src/lib/exit/discoveryPointerPublisher.test.ts
+++ b/src/lib/exit/discoveryPointerPublisher.test.ts
@@ -1,0 +1,108 @@
+import type { NostrEvent, NostrSigner } from "@nostrify/nostrify";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { openDestinationRelay } from "./relayConnection";
+import {
+  prepareSignedPointers,
+  publishPointersToRelay,
+  summarizePointerResults,
+} from "./discoveryPointerPublisher";
+
+vi.mock("./relayConnection", () => ({ openDestinationRelay: vi.fn() }));
+
+const ownerPubkey = "a".repeat(64);
+
+function signer(): NostrSigner {
+  return {
+    signEvent: vi.fn(async (template) => ({
+      ...template,
+      id: "b".repeat(64),
+      pubkey: ownerPubkey,
+      sig: "c".repeat(128),
+    } as NostrEvent)),
+  } as unknown as NostrSigner;
+}
+
+describe("discovery pointer publication", () => {
+  const publish = vi.fn();
+  const close = vi.fn();
+
+  beforeEach(() => {
+    publish.mockReset().mockResolvedValue({ status: "accepted" });
+    close.mockReset().mockResolvedValue(undefined);
+    vi.mocked(openDestinationRelay).mockReset().mockReturnValue({ publish, close });
+  });
+
+  it("signs each pointer once before relay fan-out", async () => {
+    const testSigner = signer();
+    const prepared = await prepareSignedPointers({
+      ownerPubkey,
+      signer: testSigner,
+      pointers: [
+        { kind: 10002, label: "Relay list", template: { kind: 10002, created_at: 1, content: "", tags: [] } },
+        { kind: 10063, label: "Blossom server list", template: { kind: 10063, created_at: 1, content: "", tags: [] } },
+      ],
+    });
+
+    await Promise.all([
+      publishPointersToRelay({ target: { relay: "wss://one.example/", isDiscoveryRelay: true }, pointers: prepared.signed, signer: testSigner, signal: new AbortController().signal }),
+      publishPointersToRelay({ target: { relay: "wss://two.example/", isDiscoveryRelay: true }, pointers: prepared.signed, signer: testSigner, signal: new AbortController().signal }),
+    ]);
+
+    expect(testSigner.signEvent).toHaveBeenCalledTimes(2);
+    expect(publish).toHaveBeenCalledTimes(4);
+    expect(close).toHaveBeenCalledTimes(2);
+  });
+
+  it("rejects a signed pointer for another account", async () => {
+    const wrongSigner = {
+      signEvent: vi.fn(async (template) => ({
+        ...template,
+        id: "b".repeat(64),
+        pubkey: "d".repeat(64),
+        sig: "c".repeat(128),
+      } as NostrEvent)),
+    } as unknown as NostrSigner;
+
+    const prepared = await prepareSignedPointers({
+      ownerPubkey,
+      signer: wrongSigner,
+      pointers: [{ kind: 10002, label: "Relay list", template: { kind: 10002, created_at: 1, content: "", tags: [] } }],
+    });
+
+    expect(prepared.signed).toEqual([]);
+    expect(prepared.failures[0]).toMatchObject({ status: "signing-failed", reason: expect.stringContaining("different account") });
+  });
+
+  it("marks duplicate relay responses as accepted discovery", () => {
+    const summaries = summarizePointerResults({
+      pointers: [{ kind: 10002, label: "Relay list" }],
+      targets: [
+        { relay: "wss://destination.example/", isDiscoveryRelay: false },
+        { relay: "wss://indexer.example/", isDiscoveryRelay: true },
+      ],
+      results: [
+        { kind: 10002, label: "Relay list", relay: "wss://destination.example/", isDiscoveryRelay: false, status: "published" },
+        { kind: 10002, label: "Relay list", relay: "wss://indexer.example/", isDiscoveryRelay: true, status: "duplicate", reason: "already stored" },
+      ],
+    });
+
+    expect(summaries[0]).toMatchObject({ status: "published", acceptedDiscoveryRelays: ["wss://indexer.example/"] });
+  });
+
+  it("does not call destination-only acceptance discoverable", () => {
+    const summaries = summarizePointerResults({
+      pointers: [{ kind: 10002, label: "Relay list" }],
+      targets: [
+        { relay: "wss://destination.example/", isDiscoveryRelay: false },
+        { relay: "wss://indexer.example/", isDiscoveryRelay: true },
+      ],
+      results: [
+        { kind: 10002, label: "Relay list", relay: "wss://destination.example/", isDiscoveryRelay: false, status: "published" },
+        { kind: 10002, label: "Relay list", relay: "wss://indexer.example/", isDiscoveryRelay: true, status: "publish-failed", reason: "blocked" },
+      ],
+    });
+
+    expect(summaries[0]).toMatchObject({ status: "destination-only", acceptedDiscoveryRelays: [] });
+  });
+});

--- a/src/lib/exit/discoveryPointerPublisher.ts
+++ b/src/lib/exit/discoveryPointerPublisher.ts
@@ -48,6 +48,25 @@ export interface DiscoveryPointerSummary {
   failures: Array<{ relay?: string; reason: string }>;
 }
 
+function errorDetail(error: unknown): string {
+  return error instanceof Error && error.message ? ` ${error.message}` : "";
+}
+
+function relayFailure(
+  target: PointerPublishTarget,
+  pointer: { kind: number; label: string },
+  reason: string,
+): PointerRelayResult {
+  return {
+    kind: pointer.kind,
+    label: pointer.label,
+    relay: target.relay,
+    isDiscoveryRelay: target.isDiscoveryRelay,
+    status: "publish-failed",
+    reason,
+  };
+}
+
 export async function prepareSignedPointers(input: {
   pointers: PointerToSign[];
   signer: NostrSigner;
@@ -64,12 +83,11 @@ export async function prepareSignedPointers(input: {
       }
       signed.push({ kind: pointer.kind, label: pointer.label, event });
     } catch (error) {
-      const detail = error instanceof Error && error.message ? ` ${error.message}` : "";
       failures.push({
         kind: pointer.kind,
         label: pointer.label,
         status: "signing-failed",
-        reason: `Your signer refused this pointer.${detail}`,
+        reason: `Your signer refused this pointer.${errorDetail(error)}`,
       });
     }
   }
@@ -91,19 +109,15 @@ export async function publishPointersToRelay(input: {
       signal: input.signal,
     });
   } catch (error) {
-    const detail = error instanceof Error && error.message ? ` ${error.message}` : "";
-    return input.pointers.map((pointer) => ({
-      kind: pointer.kind,
-      label: pointer.label,
-      relay: input.target.relay,
-      isDiscoveryRelay: input.target.isDiscoveryRelay,
-      status: "publish-failed",
-      reason: `The relay connection could not start.${detail}`,
-    }));
+    return input.pointers.map((pointer) => relayFailure(
+      input.target,
+      pointer,
+      `The relay connection could not start.${errorDetail(error)}`,
+    ));
   }
 
+  const results: PointerRelayResult[] = [];
   try {
-    const results: PointerRelayResult[] = [];
     for (const pointer of input.pointers) {
       const outcome = await session.publish(pointer.event);
       if (outcome.status === "accepted") {
@@ -111,13 +125,22 @@ export async function publishPointersToRelay(input: {
       } else if (outcome.status === "duplicate") {
         results.push({ kind: pointer.kind, label: pointer.label, relay: input.target.relay, isDiscoveryRelay: input.target.isDiscoveryRelay, status: "duplicate", reason: outcome.message });
       } else {
-        results.push({ kind: pointer.kind, label: pointer.label, relay: input.target.relay, isDiscoveryRelay: input.target.isDiscoveryRelay, status: "publish-failed", reason: outcome.message });
+        results.push(relayFailure(input.target, pointer, outcome.message));
       }
     }
-    return results;
+  } catch (error) {
+    // Cancellation belongs to the caller. Every other failure has to stay a
+    // reported outcome for this relay, or one late throw would discard what
+    // the other relays in the fan-out already reported.
+    if (input.signal.aborted) throw error;
+    for (const pointer of input.pointers.slice(results.length)) {
+      results.push(relayFailure(input.target, pointer, `The relay stopped answering.${errorDetail(error)}`));
+    }
   } finally {
-    await session.close();
+    // Failing to close the socket must not throw away results already collected.
+    await session.close().catch(() => {});
   }
+  return results;
 }
 
 function isAccepted(result: DiscoveryPointerResult): result is PointerRelayResult {

--- a/src/lib/exit/discoveryPointerPublisher.ts
+++ b/src/lib/exit/discoveryPointerPublisher.ts
@@ -1,0 +1,158 @@
+// ABOUTME: Signs account-move pointers once and publishes them across discovery relays
+// ABOUTME: Keeps pre-publication failures separate from per-relay outcomes
+
+import type { NostrEvent, NostrSigner } from "@nostrify/nostrify";
+
+import { openDestinationRelay } from "./relayConnection";
+import type { PointerPublishTarget } from "./discoveryPointers";
+import type { EventTemplate } from "./eventRewrite";
+
+export interface PointerToSign {
+  kind: number;
+  label: string;
+  template: EventTemplate;
+}
+
+export interface SignedPointer {
+  kind: number;
+  label: string;
+  event: NostrEvent;
+}
+
+export interface PointerPreparationFailure {
+  kind: number;
+  label: string;
+  status: "blocked" | "signing-failed";
+  reason: string;
+}
+
+export interface PointerRelayResult {
+  kind: number;
+  label: string;
+  relay: string;
+  isDiscoveryRelay: boolean;
+  status: "published" | "duplicate" | "publish-failed";
+  reason?: string;
+}
+
+export type DiscoveryPointerResult = PointerPreparationFailure | PointerRelayResult;
+
+export interface DiscoveryPointerSummary {
+  kind: number;
+  label: string;
+  status: "published" | "destination-only" | "failed" | "blocked" | "signing-failed";
+  acceptedRelays: string[];
+  acceptedDiscoveryRelays: string[];
+  totalRelays: number;
+  totalDiscoveryRelays: number;
+  failures: Array<{ relay?: string; reason: string }>;
+}
+
+export async function prepareSignedPointers(input: {
+  pointers: PointerToSign[];
+  signer: NostrSigner;
+  ownerPubkey: string;
+}): Promise<{ signed: SignedPointer[]; failures: PointerPreparationFailure[] }> {
+  const signed: SignedPointer[] = [];
+  const failures: PointerPreparationFailure[] = [];
+
+  for (const pointer of input.pointers) {
+    try {
+      const event = await input.signer.signEvent(pointer.template);
+      if (event.pubkey !== input.ownerPubkey) {
+        throw new Error("The signer returned an event for a different account.");
+      }
+      signed.push({ kind: pointer.kind, label: pointer.label, event });
+    } catch (error) {
+      const detail = error instanceof Error && error.message ? ` ${error.message}` : "";
+      failures.push({
+        kind: pointer.kind,
+        label: pointer.label,
+        status: "signing-failed",
+        reason: `Your signer refused this pointer.${detail}`,
+      });
+    }
+  }
+
+  return { signed, failures };
+}
+
+export async function publishPointersToRelay(input: {
+  target: PointerPublishTarget;
+  pointers: SignedPointer[];
+  signer: NostrSigner;
+  signal: AbortSignal;
+}): Promise<PointerRelayResult[]> {
+  let session;
+  try {
+    session = openDestinationRelay({
+      destination: input.target.relay,
+      signer: input.signer,
+      signal: input.signal,
+    });
+  } catch (error) {
+    const detail = error instanceof Error && error.message ? ` ${error.message}` : "";
+    return input.pointers.map((pointer) => ({
+      kind: pointer.kind,
+      label: pointer.label,
+      relay: input.target.relay,
+      isDiscoveryRelay: input.target.isDiscoveryRelay,
+      status: "publish-failed",
+      reason: `The relay connection could not start.${detail}`,
+    }));
+  }
+
+  try {
+    const results: PointerRelayResult[] = [];
+    for (const pointer of input.pointers) {
+      const outcome = await session.publish(pointer.event);
+      if (outcome.status === "accepted") {
+        results.push({ kind: pointer.kind, label: pointer.label, relay: input.target.relay, isDiscoveryRelay: input.target.isDiscoveryRelay, status: "published" });
+      } else if (outcome.status === "duplicate") {
+        results.push({ kind: pointer.kind, label: pointer.label, relay: input.target.relay, isDiscoveryRelay: input.target.isDiscoveryRelay, status: "duplicate", reason: outcome.message });
+      } else {
+        results.push({ kind: pointer.kind, label: pointer.label, relay: input.target.relay, isDiscoveryRelay: input.target.isDiscoveryRelay, status: "publish-failed", reason: outcome.message });
+      }
+    }
+    return results;
+  } finally {
+    await session.close();
+  }
+}
+
+function isAccepted(result: DiscoveryPointerResult): result is PointerRelayResult {
+  return "relay" in result && (result.status === "published" || result.status === "duplicate");
+}
+
+export function summarizePointerResults(input: {
+  pointers: Array<{ kind: number; label: string }>;
+  targets: PointerPublishTarget[];
+  results: DiscoveryPointerResult[];
+}): DiscoveryPointerSummary[] {
+  return input.pointers.map((pointer) => {
+    const results = input.results.filter((result) => result.kind === pointer.kind);
+    const preparationFailure = results.find((result): result is PointerPreparationFailure => !("relay" in result));
+    const accepted = results.filter(isAccepted);
+    const acceptedDiscoveryRelays = accepted.filter((result) => result.isDiscoveryRelay).map((result) => result.relay);
+    const failures = results
+      .filter((result) => result.status === "publish-failed" || result.status === "blocked" || result.status === "signing-failed")
+      .map((result) => ({ relay: "relay" in result ? result.relay : undefined, reason: result.reason ?? "The pointer was not published." }));
+
+    let status: DiscoveryPointerSummary["status"];
+    if (preparationFailure) status = preparationFailure.status;
+    else if (acceptedDiscoveryRelays.length > 0) status = "published";
+    else if (accepted.length > 0) status = "destination-only";
+    else status = "failed";
+
+    return {
+      kind: pointer.kind,
+      label: pointer.label,
+      status,
+      acceptedRelays: accepted.map((result) => result.relay),
+      acceptedDiscoveryRelays,
+      totalRelays: input.targets.length,
+      totalDiscoveryRelays: input.targets.filter((target) => target.isDiscoveryRelay).length,
+      failures,
+    };
+  });
+}

--- a/src/lib/exit/discoveryPointers.test.ts
+++ b/src/lib/exit/discoveryPointers.test.ts
@@ -45,6 +45,17 @@ describe("discovery pointer templates", () => {
     ]);
   });
 
+  it("publishes to Divine's own relay without counting it as somewhere apps look", () => {
+    expect(pointerPublishTargets({
+      relayDestination: "wss://destination.example",
+      discoveryRelays: ["wss://relay.divine.video", "wss://indexer.example"],
+    })).toEqual([
+      { relay: "wss://destination.example/", isDiscoveryRelay: false },
+      { relay: "wss://relay.divine.video/", isDiscoveryRelay: false },
+      { relay: "wss://indexer.example/", isDiscoveryRelay: true },
+    ]);
+  });
+
   it("distinguishes a custom destination from discovery relays", () => {
     expect(pointerPublishTargets({
       relayDestination: "wss://destination.example",

--- a/src/lib/exit/discoveryPointers.test.ts
+++ b/src/lib/exit/discoveryPointers.test.ts
@@ -7,6 +7,7 @@ import {
   buildRelayListTemplate,
   MAX_REPLACEMENT_FUTURE_SKEW_SECONDS,
   newestPointerCreatedAt,
+  pointerPublishTargets,
   RELAY_LIST_KIND,
   replacementCreatedAt,
 } from "./discoveryPointers";
@@ -32,6 +33,26 @@ describe("discovery pointer templates", () => {
       event(RELAY_LIST_KIND, 99, "d".repeat(64)),
       event(BLOSSOM_SERVER_LIST_KIND, 30),
     ], RELAY_LIST_KIND, OWNER)).toBe(20);
+  });
+
+  it("publishes destination first and deduplicates normalized discovery relays", () => {
+    expect(pointerPublishTargets({
+      relayDestination: "wss://relay.example",
+      discoveryRelays: ["WSS://RELAY.EXAMPLE/", "wss://indexer.example"],
+    })).toEqual([
+      { relay: "wss://relay.example/", isDiscoveryRelay: true },
+      { relay: "wss://indexer.example/", isDiscoveryRelay: true },
+    ]);
+  });
+
+  it("distinguishes a custom destination from discovery relays", () => {
+    expect(pointerPublishTargets({
+      relayDestination: "wss://destination.example",
+      discoveryRelays: ["wss://indexer.example"],
+    })).toEqual([
+      { relay: "wss://destination.example/", isDiscoveryRelay: false },
+      { relay: "wss://indexer.example/", isDiscoveryRelay: true },
+    ]);
   });
 
   it("beats older and equal timestamps and blocks future-dated pointers", () => {

--- a/src/lib/exit/discoveryPointers.ts
+++ b/src/lib/exit/discoveryPointers.ts
@@ -3,7 +3,7 @@
 
 import type { NostrEvent } from "@nostrify/nostrify";
 
-import { DISCOVERY_POINTER_RELAYS } from "@/config/relays";
+import { DISCOVERY_POINTER_RELAYS, PRIMARY_RELAY } from "@/config/relays";
 
 import type { EventTemplate } from "./eventRewrite";
 import { normalizeRelayDestinationUrl } from "./relayDestination";
@@ -22,6 +22,7 @@ export function pointerPublishTargets(input: {
   discoveryRelays?: readonly string[];
 }): PointerPublishTarget[] {
   const destination = normalizeRelayDestinationUrl(input.relayDestination);
+  const divineRelay = normalizeRelayDestinationUrl(PRIMARY_RELAY.url);
   const discoveryRelays = input.discoveryRelays
     ?? DISCOVERY_POINTER_RELAYS.map((relay) => relay.url);
   const targets = new Map<string, PointerPublishTarget>([
@@ -32,7 +33,10 @@ export function pointerPublishTargets(input: {
     const normalized = normalizeRelayDestinationUrl(relay);
     targets.set(normalized, {
       relay: normalized,
-      isDiscoveryRelay: true,
+      // Divine's own relay is still published to, so an app that knows the old
+      // home can follow the move. It is not somewhere another app looks for
+      // one, so it must never be what makes a pointer count as discoverable.
+      isDiscoveryRelay: normalized !== divineRelay,
     });
   }
 

--- a/src/lib/exit/discoveryPointers.ts
+++ b/src/lib/exit/discoveryPointers.ts
@@ -3,11 +3,41 @@
 
 import type { NostrEvent } from "@nostrify/nostrify";
 
+import { DISCOVERY_POINTER_RELAYS } from "@/config/relays";
+
 import type { EventTemplate } from "./eventRewrite";
+import { normalizeRelayDestinationUrl } from "./relayDestination";
 
 export const RELAY_LIST_KIND = 10_002;
 export const BLOSSOM_SERVER_LIST_KIND = 10_063;
 export const MAX_REPLACEMENT_FUTURE_SKEW_SECONDS = 1;
+
+export interface PointerPublishTarget {
+  relay: string;
+  isDiscoveryRelay: boolean;
+}
+
+export function pointerPublishTargets(input: {
+  relayDestination: string;
+  discoveryRelays?: readonly string[];
+}): PointerPublishTarget[] {
+  const destination = normalizeRelayDestinationUrl(input.relayDestination);
+  const discoveryRelays = input.discoveryRelays
+    ?? DISCOVERY_POINTER_RELAYS.map((relay) => relay.url);
+  const targets = new Map<string, PointerPublishTarget>([
+    [destination, { relay: destination, isDiscoveryRelay: false }],
+  ]);
+
+  for (const relay of discoveryRelays) {
+    const normalized = normalizeRelayDestinationUrl(relay);
+    targets.set(normalized, {
+      relay: normalized,
+      isDiscoveryRelay: true,
+    });
+  }
+
+  return [...targets.values()];
+}
 
 export function buildRelayListTemplate(relayUrl: string, createdAt: number): EventTemplate {
   return { kind: RELAY_LIST_KIND, created_at: createdAt, content: "", tags: [["r", relayUrl]] };

--- a/src/lib/exit/relayConnection.ts
+++ b/src/lib/exit/relayConnection.ts
@@ -1,4 +1,4 @@
-// ABOUTME: Publishes signed Nostr events through one authenticated destination relay session
+// ABOUTME: Publishes signed Nostr events through one authenticated relay session
 // ABOUTME: Centralizes relay refusal, retry, timeout, cancellation, and NIP-42 behavior
 
 import { NRelay1, type NostrEvent, type NostrSigner } from "@nostrify/nostrify";

--- a/src/pages/ExitStartPage.discovery.test.tsx
+++ b/src/pages/ExitStartPage.discovery.test.tsx
@@ -45,6 +45,8 @@ describe("ExitStartPage discovery pointer gate", () => {
   it("offers pointers after at least one destination event succeeds", async () => {
     await createArchive();
     expect(screen.getByRole("heading", { name: "Publish your new home" })).toBeInTheDocument();
+    expect(screen.getByText(/name only your destination to Divine and public metadata relays/)).toBeInTheDocument();
+    expect(screen.queryByText(/without Divine in the path/)).not.toBeInTheDocument();
   });
 
   it("does not offer pointers after an all-failed republish", async () => {

--- a/src/pages/ExitStartPage.tsx
+++ b/src/pages/ExitStartPage.tsx
@@ -468,7 +468,7 @@ export function ExitStartPage() {
               eyebrow="Make the move discoverable"
               icon={<MapPin weight="fill" className="h-7 w-7" />}
               title="Publish your new home"
-              lead="Share destination-only discovery pointers so compatible apps can find your relay and Blossom server without Divine in the path."
+              lead="Publish pointers that name only your destination to Divine and public metadata relays, so compatible apps can find your relay and Blossom server."
             />
             <DiscoveryPointerForm
               files={archiveFiles}


### PR DESCRIPTION
## Summary

- Makes moved accounts discoverable by publishing their relay and Blossom pointers to the public metadata relays other Nostr clients already query.
- Signs each pointer once, reports acceptance per relay, and only calls a pointer discoverable when a configured discovery relay accepts it.

## Motivation

- The move flow previously stored its forwarding information only at the new destination. A client that did not already know that destination could not learn where the account moved.
- Fan-out follows NIP-65 discovery guidance while preserving the destination-only contents of both pointer events.
- This deliberately does not add public indexers to the relay list itself or change where migrated posts and media are stored.

## Related Issue

- Closes #670

## Testing

- [x] `npm run test`
- [x] Targeted pointer publisher, hook, form, and exit-page tests
- [ ] Manual verification completed

## Visuals

- [ ] UI change with screenshots/video attached
- [ ] No visual change
- [x] Visuals and text avoid sensitive external brand or partner names unless explicitly approved

The result summary copy changes, but a representative screenshot requires completing the authenticated export, mirror, and relay migration flow. Automated component coverage verifies full, partial, and destination-only outcomes.
