### PR TITLE
fix(exit): make moved posts replace old media links

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -202,8 +202,10 @@ custom `wss://` relay. Migration writes use a standalone authenticated relay
 session instead of the app's `NPool`; the same session primitive also publishes
 the discovery pointers described below. Only media with
 descriptor-and-readback verification is rewritten.
-Changed events are re-signed with their original timestamp, referenced owner
-events are prepared first so `e`, `E`, and `q` tags keep pointing at valid
+Changed replaceable and addressable events are re-signed one second after their
+original timestamp so the migrated copy deterministically supersedes the old
+media references. Other changed events keep their original timestamp, referenced
+owner events are prepared first so `e`, `E`, and `q` tags keep pointing at valid
 event IDs, and unchanged events retain their original ID and signature.
 Encrypted messages, ephemeral or authentication events, deletion requests,
 and vanish requests are skipped. Relay refusals remain per-event results and

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -204,9 +204,10 @@ the discovery pointers described below. Only media with
 descriptor-and-readback verification is rewritten.
 Changed replaceable and addressable events are re-signed one second after their
 original timestamp so the migrated copy deterministically supersedes the old
-media references. Other changed events keep their original timestamp, referenced
-owner events are prepared first so `e`, `E`, and `q` tags keep pointing at valid
-event IDs, and unchanged events retain their original ID and signature.
+media references. Other changed events keep their original timestamp.
+Referenced owner events are prepared first so `e`, `E`, and `q` tags keep
+pointing at valid event IDs, and unchanged events retain their original ID and
+signature.
 Encrypted messages, ephemeral or authentication events, deletion requests,
 and vanish requests are skipped. Relay refusals remain per-event results and
 do not stop unrelated publishes.

--- a/src/lib/exit/eventRewrite.test.ts
+++ b/src/lib/exit/eventRewrite.test.ts
@@ -134,7 +134,7 @@ describe("republishCreatedAt", () => {
   );
 
   it.each([1, 16, 1111, 9999, 20_000, 29_999, 40_000])(
-    "preserves the timestamp for regular kind %s",
+    "preserves the timestamp for kind %s, which is neither replaceable nor addressable",
     (kind) => {
       const original = event({ kind });
       expect(republishCreatedAt(original)).toBe(original.created_at);

--- a/src/lib/exit/eventRewrite.test.ts
+++ b/src/lib/exit/eventRewrite.test.ts
@@ -5,6 +5,7 @@ import type { MirrorResult } from "./mirrorClient";
 import {
   buildDestinationUrlMap,
   referencedEventIds,
+  republishCreatedAt,
   republishSkipReason,
   rewriteEventMedia,
   rewriteEventReferences,
@@ -121,4 +122,22 @@ describe("republishSkipReason", () => {
   it.each([0, 1, 3, 7, 16, 1111, 10002, 30005, 34236])("allows durable public kind %s", (kind) => {
     expect(republishSkipReason(kind)).toBeNull();
   });
+});
+
+describe("republishCreatedAt", () => {
+  it.each([0, 3, 10_000, 19_999, 30_000, 34_236, 39_999])(
+    "advances replaceable or addressable kind %s by one second",
+    (kind) => {
+      const original = event({ kind });
+      expect(republishCreatedAt(original)).toBe(original.created_at + 1);
+    },
+  );
+
+  it.each([1, 16, 1111, 9999, 20_000, 29_999, 40_000])(
+    "preserves the timestamp for regular kind %s",
+    (kind) => {
+      const original = event({ kind });
+      expect(republishCreatedAt(original)).toBe(original.created_at);
+    },
+  );
 });

--- a/src/lib/exit/eventRewrite.ts
+++ b/src/lib/exit/eventRewrite.ts
@@ -1,7 +1,7 @@
 // ABOUTME: Rewrites exported event media and references for a destination relay
 // ABOUTME: Keeps unchanged signed events intact and identifies events unsafe to republish
 
-import type { NostrEvent } from "@nostrify/nostrify";
+import { NKinds, type NostrEvent } from "@nostrify/nostrify";
 
 import type { MirrorResult } from "./mirrorClient";
 
@@ -37,6 +37,12 @@ export function republishSkipReason(kind: number): string | null {
   if (kind >= 20_000 && kind < 30_000) return "Temporary authentication and ephemeral events are not portable posts.";
   if (DESTRUCTIVE_KINDS.has(kind)) return "Deletion and vanish requests are not replayed during a move.";
   return null;
+}
+
+export function republishCreatedAt(event: NostrEvent): number {
+  return NKinds.replaceable(event.kind) || NKinds.addressable(event.kind)
+    ? event.created_at + 1
+    : event.created_at;
 }
 
 function replaceExact(value: string, urls: ReadonlyMap<string, string>): string {

--- a/src/lib/exit/relayPublisher.test.ts
+++ b/src/lib/exit/relayPublisher.test.ts
@@ -118,6 +118,20 @@ describe("publishArchiveEvents", () => {
     });
   });
 
+  it("advances an addressable event changed only by reference rewriting", async () => {
+    const signer = makeSigner();
+    const relay = fakeRelay();
+    const video = makeEvent("1", { kind: 34236, content: SOURCE, tags: [["d", "vid"], ["url", SOURCE]] });
+    // A curation set carries no media of its own, so only the rewritten `e` tag
+    // changes it — and it still has to beat the copy that points at Divine.
+    const playlist = makeEvent("3", { kind: 30_005, created_at: 1_700_000_900, content: "", tags: [["d", "list"], ["e", video.id]] });
+
+    await publishArchiveEvents({ destination: RELAY, events: [video, playlist], mirrorResults: [mirrorResult()], signer, relayFactory: () => relay });
+
+    expect(relay.published[1].created_at).toBe(playlist.created_at + 1);
+    expect(relay.published[1].tags).toContainEqual(["e", relay.published[0].id]);
+  });
+
   it("replaces serialized repost content with the newly signed referenced event", async () => {
     const signer = makeSigner();
     const relay = fakeRelay();

--- a/src/lib/exit/relayPublisher.test.ts
+++ b/src/lib/exit/relayPublisher.test.ts
@@ -93,9 +93,29 @@ describe("publishArchiveEvents", () => {
       relayFactory: () => relay,
     });
     expect(relay.published.map((event) => event.kind)).toEqual([34236, 1111, 1111]);
+    expect(relay.published[0].created_at).toBe(video.created_at + 1);
+    expect(relay.published[1].created_at).toBe(comment.created_at);
+    expect(relay.published[2].created_at).toBe(reply.created_at);
     expect(relay.published[1].tags).toEqual([["E", relay.published[0].id], ["e", relay.published[0].id]]);
     expect(relay.published[2].tags).toEqual([["E", relay.published[0].id], ["e", relay.published[1].id]]);
     expect(results.every((result) => result.status === "published")).toBe(true);
+  });
+
+  it("produces the same replacement templates on repeated runs", async () => {
+    const signer = makeSigner();
+    const video = makeEvent("1", { kind: 34236, content: SOURCE, tags: [["url", SOURCE]] });
+    const firstRelay = fakeRelay();
+    const secondRelay = fakeRelay();
+    await publishArchiveEvents({ destination: RELAY, events: [video], mirrorResults: [mirrorResult()], signer, relayFactory: () => firstRelay });
+    await publishArchiveEvents({ destination: RELAY, events: [video], mirrorResults: [mirrorResult()], signer, relayFactory: () => secondRelay });
+
+    expect(signer.signEvent).toHaveBeenNthCalledWith(2, signer.signEvent.mock.calls[0][0]);
+    expect(secondRelay.published[0]).toMatchObject({
+      kind: firstRelay.published[0].kind,
+      created_at: firstRelay.published[0].created_at,
+      content: firstRelay.published[0].content,
+      tags: firstRelay.published[0].tags,
+    });
   });
 
   it("replaces serialized repost content with the newly signed referenced event", async () => {

--- a/src/lib/exit/relayPublisher.test.ts
+++ b/src/lib/exit/relayPublisher.test.ts
@@ -295,6 +295,33 @@ describe("publishArchiveEvents", () => {
     expect(results.find((result) => result.event_id === changed.id)).toMatchObject({ status: "failed", reason: expect.stringContaining("signer refused") });
     expect(relay.published).toEqual([unchanged]);
   });
+
+  it("rejects a replacement when the signer changes its timestamp", async () => {
+    const signer = makeSigner();
+    signer.signEvent.mockImplementationOnce(async (template) => ({
+      ...template,
+      created_at: template.created_at - 1,
+      id: "f".repeat(64),
+      pubkey: PUBKEY,
+      sig: "f".repeat(128),
+    }));
+    const relay = fakeRelay();
+    const changed = makeEvent("1", { kind: 34236, content: SOURCE, tags: [["url", SOURCE]] });
+
+    const results = await publishArchiveEvents({
+      destination: RELAY,
+      events: [changed],
+      mirrorResults: [mirrorResult()],
+      signer,
+      relayFactory: () => relay,
+    });
+
+    expect(results[0]).toMatchObject({
+      status: "failed",
+      reason: expect.stringContaining("signer changed this event's timestamp"),
+    });
+    expect(relay.event).not.toHaveBeenCalled();
+  });
 });
 
 describe("summarizePublishResults", () => {

--- a/src/lib/exit/relayPublisher.ts
+++ b/src/lib/exit/relayPublisher.ts
@@ -6,6 +6,7 @@ import type { NostrEvent, NostrSigner } from "@nostrify/nostrify";
 import {
   buildDestinationUrlMap,
   referencedEventIds,
+  republishCreatedAt,
   republishSkipReason,
   rewriteEventMedia,
   rewriteEventReferences,
@@ -121,7 +122,12 @@ async function prepareEvents(options: PublishArchiveOptions): Promise<{
     let event = original;
     if (changed) {
       try {
-        event = await options.signer.signEvent(references.template);
+        // A deterministic one-second advance prevents replaceable copies from
+        // falling back to event-id or arrival-order tie-breaks.
+        event = await options.signer.signEvent({
+          ...references.template,
+          created_at: republishCreatedAt(original),
+        });
         if (event.pubkey !== original.pubkey || !HEX_64.test(event.id)) {
           throw new Error("The signer returned an event for a different account.");
         }

--- a/src/lib/exit/relayPublisher.ts
+++ b/src/lib/exit/relayPublisher.ts
@@ -124,12 +124,16 @@ async function prepareEvents(options: PublishArchiveOptions): Promise<{
       try {
         // A deterministic one-second advance prevents replaceable copies from
         // falling back to event-id or arrival-order tie-breaks.
-        event = await options.signer.signEvent({
+        const template = {
           ...references.template,
           created_at: republishCreatedAt(original),
-        });
+        };
+        event = await options.signer.signEvent(template);
         if (event.pubkey !== original.pubkey || !HEX_64.test(event.id)) {
           throw new Error("The signer returned an event for a different account.");
+        }
+        if (event.created_at !== template.created_at) {
+          throw new Error("The signer changed this event's timestamp.");
         }
       } catch (error) {
         settled.add(original.id);


### PR DESCRIPTION
## Summary

- Ensures a moved replaceable post reliably supersedes the copy that still points at Divine-hosted media.
- Advances only changed replaceable and addressable events by one deterministic second; ordinary changed events keep their original timestamp, and unchanged signed events retain their original ID and signature.
- Documents the timestamp rule and adds boundary, reference-chain, and repeated-run regression coverage.

## Motivation

Changed addressable posts were previously re-signed with the exact timestamp of the original. When clients encountered both copies, the equal timestamp left selection to event-ID or arrival-order tie-breaking, so a completed move could still resolve to the old media URLs.

The deterministic one-second advance makes the migrated copy strictly newer without making reruns time-dependent or visibly changing an archived post's date. This does not change whether destination relays accept the event or whether other relays expose the migrated copy.

## Related Issue

- Closes #672

## Testing

- [x] `npm run test`
- [x] Focused red-green regression run for `eventRewrite.test.ts` and `relayPublisher.test.ts`
- [ ] Manual verification completed

## Visuals

- [ ] UI change with screenshots/video attached
- [x] No visual change
- [x] Visuals and text avoid sensitive external brand or partner names unless explicitly approved
