### PR TITLE
fix(exit): stop calling account moves unfinished

### DIFF
--- a/src/pages/PortabilityPage.test.tsx
+++ b/src/pages/PortabilityPage.test.tsx
@@ -55,7 +55,7 @@ describe("PortabilityPage", () => {
     ).toBeInTheDocument();
   });
 
-  it("sends readers to the working export tool without overpromising the rest", () => {
+  it("sends readers to the working account-moving flow", () => {
     const { container } = render(
       <TestApp>
         <PortabilityPage />
@@ -63,9 +63,10 @@ describe("PortabilityPage", () => {
     );
 
     expect(container.querySelector('a[href="/exit/start"]')).toBeTruthy();
-    expect(screen.getByText("Download your archive now")).toBeInTheDocument();
-    expect(
-      screen.getByText(/Choosing a destination and copying your media there is still being built./)
-    ).toBeInTheDocument();
+    expect(screen.getByText("Start moving your account")).toBeInTheDocument();
+    expect(screen.getByText(/You choose a media server/)).toBeInTheDocument();
+    expect(screen.getByText(/published to the relay you choose/i)).toBeInTheDocument();
+    expect(container).not.toHaveTextContent(/still being built/i);
+    expect(container).not.toHaveTextContent(/when destination \w+ is ready/i);
   });
 });

--- a/src/pages/PortabilityPage.tsx
+++ b/src/pages/PortabilityPage.tsx
@@ -50,12 +50,12 @@ const MOVE_STEPS = [
   {
     title: "Copy your videos",
     body:
-      "When destination copying is ready, your media can be copied byte for byte. Divine will not resize, re-encode, or change the files.",
+      "You choose a media server—Divine's or someone else's—and Divine copies eligible files byte for byte without resizing, re-encoding, or changing them.",
   },
   {
     title: "Publish and point",
     body:
-      "When destination publishing is ready, your posts can be republished there, and your public account records can tell other apps where to look next.",
+      "Your posts can be rewritten to point at the copied media and published to the relay you choose. Divine can also publish account records naming that relay and media server.",
   },
 ];
 
@@ -217,7 +217,7 @@ export function PortabilityPage() {
             eyebrow="How it works"
             icon={<Compass weight="fill" className="h-7 w-7" />}
             title="Four plain steps"
-            lead="The moving flow keeps the protocol details in the background. Today you can download your archive; choosing a destination and copying your media there is still being built."
+            lead="The moving flow keeps the protocol details in the background. Build your archive, choose destinations, copy eligible media, republish posts, and publish account records from one place."
           />
 
           <div className="grid gap-5 md:grid-cols-2">
@@ -245,12 +245,11 @@ export function PortabilityPage() {
               <div className="flex items-start justify-between gap-3">
                 <div>
                   <h3 className="font-display font-extrabold tracking-tight text-xl text-brand-dark-green dark:text-brand-off-white">
-                    Download your archive now
+                    Start moving your account
                   </h3>
                   <p className="mt-2 text-sm leading-relaxed text-muted-foreground">
-                    Sign in and take a copy of your posts, video records, and media
-                    list today. Choosing a destination and copying your media there
-                    is still being built.
+                    Sign in to build your archive, choose a media server and relay,
+                    and move eligible media and posts.
                   </p>
                 </div>
                 <ArrowSquareOut className="h-5 w-5 flex-shrink-0 text-brand-dark-green dark:text-brand-green group-hover:translate-x-0.5 transition-transform" />


### PR DESCRIPTION
## Summary

- Describe media copying, relay republication, and discovery-pointer publishing as available parts of the account-moving flow.
- Rename the archive-only call to action so it represents the complete move.
- Add regression coverage that rejects the obsolete future-tense copy.

> Avoid naming corporate partners, customers, or other sensitive external brands in this PR title or body. Use generic descriptors unless a maintainer explicitly approves the public reference.

## Motivation

- The portability guide still said destination copying and publishing were unfinished after those capabilities shipped, which could discourage people from using the working flow.
- The signed-in account menu and app sidebar already link to `/exit`, so this deliberately does not add or rearrange navigation.
- The new wording describes available capabilities without promising that every file or publication attempt succeeds.

## Related Issue

- Closes #671

## Testing

- [x] `npm run test`
- [ ] Manual verification completed — automated browser setup was unavailable in this environment

## Visuals

- [ ] UI change with screenshots/video attached — text-only change; local browser inspection was unavailable
- [ ] No visual change
- [x] Visuals and text avoid sensitive external brand or partner names unless explicitly approved