### PR TITLE
fix(exit): explain that copied posts may still load from Divine

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -212,6 +212,10 @@ Encrypted messages, ephemeral or authentication events, deletion requests,
 and vanish requests are skipped. Relay refusals remain per-event results and
 do not stop unrelated publishes.
 
+The moving flow also states the boundary of that rewrite: copies already held
+by independent relays are not updated or removed, and their original media
+links may continue loading files from Divine.
+
 Once at least one event is present at the destination relay, the page can publish
 destination-only discovery metadata: a NIP-65 kind-10002 relay list and a BUD-03
 kind-10063 Blossom server list. Each pointer is signed once, then published to

--- a/src/pages/ExitStartPage.discovery.test.tsx
+++ b/src/pages/ExitStartPage.discovery.test.tsx
@@ -47,6 +47,10 @@ describe("ExitStartPage discovery pointer gate", () => {
     expect(screen.getByRole("heading", { name: "Publish your new home" })).toBeInTheDocument();
     expect(screen.getByText(/name only your destination to Divine and public metadata relays/)).toBeInTheDocument();
     expect(screen.queryByText(/without Divine in the path/)).not.toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Old copies stay where they are" })).toBeInTheDocument();
+    expect(
+      screen.getByText(/Those copies can still point at Divine-hosted media/)
+    ).toBeInTheDocument();
   });
 
   it("does not offer pointers after an all-failed republish", async () => {

--- a/src/pages/ExitStartPage.discovery.test.tsx
+++ b/src/pages/ExitStartPage.discovery.test.tsx
@@ -59,5 +59,8 @@ describe("ExitStartPage discovery pointer gate", () => {
     await userEvent.click(screen.getByRole("button", { name: /Create my archive/ }));
     await waitFor(() => expect(screen.getByText(/Your archive is ready/)).toBeInTheDocument());
     expect(screen.queryByText("Discovery pointer form")).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("heading", { name: "Old copies stay where they are" })
+    ).not.toBeInTheDocument();
   });
 });

--- a/src/pages/ExitStartPage.tsx
+++ b/src/pages/ExitStartPage.tsx
@@ -476,6 +476,17 @@ export function ExitStartPage() {
               blossomDestination={destinationMirror.destination}
               signer={signer}
             />
+            <Card variant="brand" accent="violet" className="mt-5">
+              <CardHeader>
+                <CardTitle>Old copies stay where they are</CardTitle>
+              </CardHeader>
+              <CardContent className="text-base leading-relaxed text-muted-foreground">
+                Other relays may already hold copies of your posts. Those copies can
+                still point at Divine-hosted media, so apps that use them may keep
+                loading your videos from Divine. Moving cannot update or remove those
+                copies.
+              </CardContent>
+            </Card>
           </section>
         )}
 

--- a/src/pages/PortabilityPage.test.tsx
+++ b/src/pages/PortabilityPage.test.tsx
@@ -24,11 +24,17 @@ describe("PortabilityPage", () => {
     expect(
       screen.getByText(/It does not delete anything from Divine./)
     ).toBeInTheDocument();
+    expect(
+      screen.getByText(/Compatible apps can use those copies when they find them./)
+    ).toBeInTheDocument();
     expect(container.querySelector('a[href="/delete-account"]')).toBeTruthy();
     expect(
       screen.getByText(/If you're looking for information about deleting your Divine account/)
     ).toBeInTheDocument();
     expect(screen.getByText(/Moving is not all-or-nothing./)).toBeInTheDocument();
+    expect(
+      screen.getByText(/Those copies can still point at Divine-hosted media/)
+    ).toBeInTheDocument();
     expect(
       screen.getByText(/You do not have to choose between Divine and the rest of the network./)
     ).toBeInTheDocument();

--- a/src/pages/PortabilityPage.tsx
+++ b/src/pages/PortabilityPage.tsx
@@ -87,9 +87,9 @@ export function PortabilityPage() {
           </h1>
           <p className="text-lg md:text-xl text-brand-light-green max-w-3xl leading-relaxed">
             Divine accounts are built so you can take your identity and content
-            to infrastructure you choose. Moving changes where other apps can
-            find your account and videos. It does not delete anything from
-            Divine.
+            to infrastructure you choose. Moving creates copies of your account
+            and videos in the places you choose. Compatible apps can use those
+            copies when they find them. It does not delete anything from Divine.
           </p>
           <p className="text-base md:text-lg text-brand-off-white/80 max-w-3xl leading-relaxed mt-4">
             This guide explains the moving flow without assuming you know how
@@ -206,7 +206,8 @@ export function PortabilityPage() {
               <p>
                 Content that has already been copied by independent services may
                 remain available outside Divine. Divine does not control those
-                services.
+                services. Those copies can still point at Divine-hosted media, so
+                apps that use them may keep loading your videos from Divine.
               </p>
             </CardContent>
           </Card>


### PR DESCRIPTION
## Summary

- Correct the portability flow's claim that publishing destination pointers removes Divine from the playback path.
- Tell people that independent relays may retain older post copies whose media links still load from Divine.
- Qualify the portability guide without changing migration, discovery, deletion, or relay behavior.

## Motivation

A completed move rewrites the copies published by the portability flow, but it cannot update or remove copies already held by independent relays. Apps that render those older copies can therefore keep loading media from Divine. The previous wording promised more than the protocol and product can guarantee.

This deliberately leaves pointer distribution (#670), stale guide copy and navigation (#671), and moved-post timestamp selection (#672) unchanged.

## Related Issue

- Closes #673

## Testing

- [x] `npm run test`
- [x] Manual verification completed

Focused regression coverage verifies the warning appears when the discovery step is reachable and that the portability guide explains the media-path consequence. The full suite passed with 315 test files and 2,593 tests, followed by a successful production build.

## Visuals

- [ ] UI change with screenshots/video attached
- [ ] No visual change
- [x] Visuals and text avoid sensitive external brand or partner names unless explicitly approved

Visible copy-only update using existing brand card primitives; no screenshot is attached because the new notice appears only after completing the signed-in migration stages.
