### PR TITLE
fix(video-player): keep paused videos from restarting

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -58,6 +58,11 @@ as a handle. Display surfaces resolve `display_name`, then `name`, then a
 deterministic fallback through [`resolveDisplayName`](./src/lib/resolveDisplayName.ts);
 handle surfaces deliberately keep their separate `name`-only fallback.
 
+`VideoPlaybackContext` keeps viewport activation separate from an explicit user
+pause. A paused active video stays paused through overlays, rerenders, and mute
+changes; moving another video into the active position clears the pause so feed
+autoplay resumes when the user scrolls back.
+
 ### Notification Read Marker
 
 Web and mobile both write the same Funnelcake per-pubkey notification read

--- a/src/components/FullscreenVideoItem.test.tsx
+++ b/src/components/FullscreenVideoItem.test.tsx
@@ -1,0 +1,188 @@
+import { fireEvent, render } from '@testing-library/react';
+import { forwardRef, type HTMLAttributes, type ReactNode } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ParsedVideoData } from '@/types/video';
+import { FullscreenVideoItem } from './FullscreenVideoItem';
+
+const playbackMocks = vi.hoisted(() => ({
+  setActiveVideo: vi.fn(),
+  setUserPaused: vi.fn(),
+  setGlobalMuted: vi.fn(),
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock('@/hooks/useVideoPlayback', () => ({
+  useVideoPlayback: () => ({
+    activeVideoId: 'fs:video-1',
+    userPausedVideoId: null,
+    setActiveVideo: playbackMocks.setActiveVideo,
+    setUserPaused: playbackMocks.setUserPaused,
+    globalMuted: true,
+    setGlobalMuted: playbackMocks.setGlobalMuted,
+  }),
+}));
+
+vi.mock('@/hooks/useAuthor', () => ({ useAuthor: () => ({ data: undefined }) }));
+vi.mock('@/lib/generateProfile', () => ({
+  enhanceAuthorData: () => ({ metadata: {} }),
+}));
+vi.mock('@/hooks/useVideoReactions', () => ({ useVideoReactions: () => ({ data: undefined }) }));
+vi.mock('@/hooks/useVideoLists', () => ({ useVideosInLists: () => ({ data: undefined }) }));
+vi.mock('@/hooks/useModeration', () => ({ useMuteItem: () => ({ mutateAsync: vi.fn() }) }));
+vi.mock('@/hooks/useDeleteVideo', () => ({
+  useDeleteVideo: () => ({ mutate: vi.fn(), isPending: false }),
+  useCanDeleteVideo: () => false,
+}));
+vi.mock('@/hooks/useToast', () => ({ useToast: () => ({ toast: vi.fn() }) }));
+vi.mock('@/hooks/useBadges', () => ({ useBadges: () => ({ data: undefined }) }));
+vi.mock('@/hooks/useBandwidthTier', () => ({ useBandwidthTier: () => 'high' }));
+vi.mock('@/lib/bandwidthTracker', () => ({ getOptimalVideoUrl: (url: string) => url }));
+vi.mock('@/hooks/useSubtitles', () => ({ useSubtitles: () => ({ cues: [], hasSubtitles: false }) }));
+vi.mock('@/hooks/useValidatedProfileLinkPath', () => ({
+  useValidatedProfileLinkPath: () => '/profile/test',
+}));
+
+// Forward the ref to the <video> so the component can target its own element,
+// exactly as the real VideoPlayer does via setRefs.
+vi.mock('@/components/VideoPlayer', () => ({
+  VideoPlayer: forwardRef<HTMLVideoElement, { videoId: string }>(({ videoId }, ref) => (
+    <video ref={ref} data-testid={`vp-${videoId}`} />
+  )),
+}));
+
+vi.mock('@/components/VideoCommentsModal', () => ({ VideoCommentsModal: () => null }));
+vi.mock('@/components/VideoReactionsModal', () => ({ VideoReactionsModal: () => null }));
+vi.mock('@/components/NoteContent', () => ({ NoteContent: () => null }));
+vi.mock('@/components/AddToListDialog', () => ({ AddToListDialog: () => null }));
+vi.mock('@/components/ReportContentDialog', () => ({ ReportContentDialog: () => null }));
+vi.mock('@/components/DeleteVideoDialog', () => ({ DeleteVideoDialog: () => null }));
+vi.mock('@/components/ViewSourceDialog', () => ({ ViewSourceDialog: () => null }));
+vi.mock('@/components/InlineBadges', () => ({ InlineBadges: () => null }));
+vi.mock('@/components/VideoVerificationBadgeRow', () => ({ VideoVerificationBadgeRow: () => null }));
+vi.mock('@/components/SmartLink', () => ({
+  SmartLink: ({ children }: { children: ReactNode }) => <a>{children}</a>,
+}));
+vi.mock('@/components/ui/dropdown-menu', () => ({
+  DropdownMenu: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  DropdownMenuContent: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  DropdownMenuItem: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  DropdownMenuSeparator: () => <div />,
+  DropdownMenuTrigger: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+}));
+vi.mock('@/components/ui/avatar', () => ({
+  Avatar: ({ children }: HTMLAttributes<HTMLDivElement>) => <div>{children}</div>,
+  AvatarImage: () => <img alt="" />,
+  AvatarFallback: ({ children }: HTMLAttributes<HTMLDivElement>) => <div>{children}</div>,
+}));
+vi.mock('@/components/ui/button', () => ({
+  Button: ({ children, ...props }: HTMLAttributes<HTMLButtonElement>) => (
+    <button {...props}>{children}</button>
+  ),
+}));
+
+const video = {
+  id: 'video-1',
+  pubkey: 'f'.repeat(64),
+  videoUrl: 'https://example.com/v.mp4',
+  hlsUrl: undefined,
+  fallbackVideoUrls: [],
+  thumbnailUrl: 'https://example.com/t.jpg',
+  blurhash: undefined,
+  title: 'Test',
+  content: '',
+  hashtags: [],
+  duration: 6,
+  createdAt: 1_700_000_000,
+  originalVineTimestamp: undefined,
+  isVineMigrated: false,
+  loopCount: 0,
+  vineId: undefined,
+  authorName: 'Someone',
+  authorAvatar: undefined,
+} as unknown as ParsedVideoData;
+
+function renderItem(prefix?: ReactNode) {
+  return render(
+    <>
+      {prefix}
+      <FullscreenVideoItem
+        video={video}
+        isActive
+        playbackId="fs:video-1"
+        onBack={vi.fn()}
+        onLike={vi.fn()}
+        onRepost={vi.fn()}
+        onShare={vi.fn()}
+        onDownload={vi.fn()}
+        isLiked={false}
+        isReposted={false}
+        likeCount={0}
+        repostCount={0}
+        commentCount={0}
+      />
+    </>
+  );
+}
+
+function setPaused(el: HTMLMediaElement, paused: boolean) {
+  Object.defineProperty(el, 'paused', { value: paused, configurable: true });
+}
+
+describe('FullscreenVideoItem tap-to-pause', () => {
+  beforeEach(() => {
+    HTMLMediaElement.prototype.play = vi.fn().mockResolvedValue(undefined);
+    HTMLMediaElement.prototype.pause = vi.fn();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    playbackMocks.setUserPaused.mockReset();
+  });
+
+  it('records a user pause in the playback context when a playing video is tapped', () => {
+    const { container } = renderItem();
+    const itemVideo = container.querySelector<HTMLVideoElement>('[data-testid="vp-video-1"]')!;
+    setPaused(itemVideo, false); // playing
+    const overlay = container.querySelector('.inset-0.pointer-events-auto');
+    if (!overlay) throw new Error('expected the tap overlay to render');
+
+    fireEvent.click(overlay);
+
+    expect(playbackMocks.setUserPaused).toHaveBeenCalledWith('fs:video-1', true);
+  });
+
+  it('clears the user pause in the playback context when a paused video is tapped', () => {
+    const { container } = renderItem();
+    const itemVideo = container.querySelector<HTMLVideoElement>('[data-testid="vp-video-1"]')!;
+    setPaused(itemVideo, true); // already paused
+    const overlay = container.querySelector('.inset-0.pointer-events-auto');
+    if (!overlay) throw new Error('expected the tap overlay to render');
+
+    fireEvent.click(overlay);
+
+    expect(playbackMocks.setUserPaused).toHaveBeenCalledWith('fs:video-1', false);
+  });
+
+  it('pauses its own video element, not the first video in the document', () => {
+    // The fullscreen feed mounts every item, so multiple <video> elements coexist.
+    // A decoy rendered first would win document.querySelector('video').
+    const decoy = <video data-testid="decoy" />;
+    const { container } = renderItem(decoy);
+    const decoyVideo = container.querySelector<HTMLVideoElement>('[data-testid="decoy"]')!;
+    const itemVideo = container.querySelector<HTMLVideoElement>('[data-testid="vp-video-1"]')!;
+    setPaused(decoyVideo, false);
+    setPaused(itemVideo, false);
+    const decoyPause = vi.spyOn(decoyVideo, 'pause');
+    const itemPause = vi.spyOn(itemVideo, 'pause');
+
+    const overlay = container.querySelector('.inset-0.pointer-events-auto');
+    if (!overlay) throw new Error('expected the tap overlay to render');
+    fireEvent.click(overlay);
+
+    expect(itemPause).toHaveBeenCalled();
+    expect(decoyPause).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/FullscreenVideoItem.tsx
+++ b/src/components/FullscreenVideoItem.tsx
@@ -106,7 +106,8 @@ export function FullscreenVideoItem({
   const [showDeleteDialog, setShowDeleteDialog] = useState(false);
   const [showViewSourceDialog, setShowViewSourceDialog] = useState(false);
   const videoContainerRef = useRef<HTMLDivElement>(null);
-  const { globalMuted, setGlobalMuted, setActiveVideo } = useVideoPlayback();
+  const videoElementRef = useRef<HTMLVideoElement>(null);
+  const { globalMuted, setGlobalMuted, setActiveVideo, setUserPaused } = useVideoPlayback();
   const { cues: subtitleCues, hasSubtitles } = useSubtitles(video);
   // Subtitles default to ON when available, independent of mute state
   const [subtitlesVisible, setSubtitlesVisible] = useState(true);
@@ -173,16 +174,26 @@ export function FullscreenVideoItem({
 
   // Handle tap on video area to toggle play/pause
   const handleOverlayClick = useCallback(() => {
-    // Find the video element and toggle play
-    const videoEl = document.querySelector(`video`) as HTMLVideoElement;
+    // Toggle this item's own video element. The fullscreen feed mounts every
+    // item, so multiple <video> elements are in the document at once;
+    // document.querySelector('video') would grab the first one, not the one the
+    // user tapped. Use the ref VideoPlayer forwards to its <video>.
+    const videoEl = videoElementRef.current;
     if (videoEl) {
+      // Record the pause in the shared playback model so the active-status and
+      // mute-sync effects honor it. Without this, a mute toggle (or any effect
+      // re-run) resumes a video the user paused, since this overlay bypasses
+      // VideoPlayer.togglePlay. See divinevideo/divine-web#680.
+      const pausedVideoId = playbackId ?? video.id;
       if (videoEl.paused) {
+        setUserPaused(pausedVideoId, false);
         videoEl.play().catch(() => { /* handled by VideoPlayer */ });
       } else {
+        setUserPaused(pausedVideoId, true);
         videoEl.pause();
       }
     }
-  }, []);
+  }, [playbackId, video.id, setUserPaused]);
 
   // Handle double-tap to like
   const handleDoubleTap = useCallback(() => {
@@ -241,6 +252,7 @@ export function FullscreenVideoItem({
       <div className="absolute inset-0 z-0 flex items-center justify-center">
         {!videoError ? (
           <VideoPlayer
+            ref={videoElementRef}
             videoId={video.id}
             playbackId={playbackId}
             src={video.videoUrl}

--- a/src/components/VideoPlayer.test.tsx
+++ b/src/components/VideoPlayer.test.tsx
@@ -8,6 +8,7 @@ import { VideoPlayer } from './VideoPlayer';
 const mockRegisterVideo = vi.fn();
 const mockUnregisterVideo = vi.fn();
 const mockUpdateVideoVisibility = vi.fn();
+const mockSetUserPaused = vi.fn();
 const hlsTestState = vi.hoisted(() => ({
   instances: [] as Array<{
     attachMedia: ReturnType<typeof vi.fn>;
@@ -24,6 +25,8 @@ const hlsTestState = vi.hoisted(() => ({
 vi.mock('@/hooks/useVideoPlayback', () => ({
   useVideoPlayback: vi.fn(() => ({
     activeVideoId: null,
+    userPausedVideoId: null,
+    setUserPaused: mockSetUserPaused,
     registerVideo: mockRegisterVideo,
     unregisterVideo: mockUnregisterVideo,
     updateVideoVisibility: mockUpdateVideoVisibility,
@@ -249,6 +252,29 @@ describe('VideoPlayer', () => {
   });
 
   describe('ref stability - prevents infinite loop', () => {
+    it('does not run unmount cleanup when context actions change identity', async () => {
+      const { useVideoPlayback } = await import('@/hooks/useVideoPlayback');
+      (useVideoPlayback as ReturnType<typeof vi.fn>).mockImplementation(() => ({
+        activeVideoId: null,
+        userPausedVideoId: null,
+        setUserPaused: mockSetUserPaused,
+        registerVideo: mockRegisterVideo,
+        unregisterVideo: vi.fn(),
+        updateVideoVisibility: vi.fn(),
+        globalMuted: true,
+      }));
+      const pauseSpy = vi.spyOn(HTMLMediaElement.prototype, 'pause');
+
+      const { rerender } = render(
+        <VideoPlayer videoId="cleanup-stability" src="https://example.com/stable.mp4" />
+      );
+      pauseSpy.mockClear();
+
+      rerender(<VideoPlayer videoId="cleanup-stability" src="https://example.com/stable.mp4" />);
+
+      expect(pauseSpy).not.toHaveBeenCalled();
+    });
+
     it('should not trigger infinite loop when context values change', async () => {
       // This test verifies the bug: setRefs callback must be stable
       //
@@ -764,6 +790,56 @@ describe('VideoPlayer', () => {
   });
 
   describe('active playback startup', () => {
+    it('keeps a user-paused active video paused across rerenders and mute changes', async () => {
+      let globalMuted = true;
+      let userPausedVideoId: string | null = null;
+      let isPaused = false;
+      const playSpy = vi.fn().mockImplementation(() => {
+        isPaused = false;
+        return Promise.resolve();
+      });
+      const pauseSpy = vi.fn().mockImplementation(() => {
+        isPaused = true;
+      });
+      vi.spyOn(HTMLMediaElement.prototype, 'paused', 'get').mockImplementation(() => isPaused);
+      HTMLMediaElement.prototype.play = playSpy;
+      HTMLMediaElement.prototype.pause = pauseSpy;
+      mockSetUserPaused.mockImplementation((videoId: string, paused: boolean) => {
+        userPausedVideoId = paused ? videoId : null;
+      });
+
+      const { useVideoPlayback } = await import('@/hooks/useVideoPlayback');
+      (useVideoPlayback as ReturnType<typeof vi.fn>).mockImplementation(() => ({
+        activeVideoId: 'user-paused',
+        userPausedVideoId,
+        setUserPaused: mockSetUserPaused,
+        registerVideo: mockRegisterVideo,
+        unregisterVideo: mockUnregisterVideo,
+        updateVideoVisibility: mockUpdateVideoVisibility,
+        globalMuted,
+      }));
+
+      const { container, rerender } = render(
+        <VideoPlayer videoId="user-paused" src="https://example.com/user-paused.mp4" />
+      );
+      const video = container.querySelector('video');
+      if (!video) throw new Error('expected rendered video element');
+
+      fireEvent.click(video);
+      expect(mockSetUserPaused).toHaveBeenCalledWith('user-paused', true);
+      expect(pauseSpy).toHaveBeenCalled();
+
+      playSpy.mockClear();
+      rerender(<VideoPlayer videoId="user-paused" src="https://example.com/user-paused.mp4" />);
+      globalMuted = false;
+      rerender(<VideoPlayer videoId="user-paused" src="https://example.com/user-paused.mp4" />);
+      await act(async () => {
+        await Promise.resolve();
+      });
+
+      expect(playSpy).not.toHaveBeenCalled();
+    });
+
     it('starts an active video before loadeddata fires', async () => {
       const playSpy = vi.fn().mockResolvedValue(undefined);
       HTMLMediaElement.prototype.play = playSpy;

--- a/src/components/VideoPlayer.test.tsx
+++ b/src/components/VideoPlayer.test.tsx
@@ -790,6 +790,85 @@ describe('VideoPlayer', () => {
   });
 
   describe('active playback startup', () => {
+    it('does not resume a user-paused video when loading completes', async () => {
+      const playSpy = vi.fn().mockResolvedValue(undefined);
+      HTMLMediaElement.prototype.play = playSpy;
+
+      const { useVideoPlayback } = await import('@/hooks/useVideoPlayback');
+      (useVideoPlayback as ReturnType<typeof vi.fn>).mockImplementation(() => ({
+        activeVideoId: 'loading-paused',
+        userPausedVideoId: 'loading-paused',
+        setUserPaused: mockSetUserPaused,
+        registerVideo: mockRegisterVideo,
+        unregisterVideo: mockUnregisterVideo,
+        updateVideoVisibility: mockUpdateVideoVisibility,
+        globalMuted: true,
+      }));
+
+      const { container } = render(
+        <VideoPlayer videoId="loading-paused" src="https://example.com/loading-paused.mp4" />
+      );
+      const video = container.querySelector('video');
+      if (!video) throw new Error('expected rendered video element');
+      playSpy.mockClear();
+
+      fireEvent.loadedData(video);
+
+      expect(playSpy).not.toHaveBeenCalled();
+    });
+
+    it('does not run a queued mute resume after the user pauses', async () => {
+      let userPausedVideoId: string | null = null;
+      let isPaused = false;
+      const playSpy = vi.fn().mockImplementation(() => {
+        isPaused = false;
+        return Promise.resolve();
+      });
+      HTMLMediaElement.prototype.play = playSpy;
+      HTMLMediaElement.prototype.pause = vi.fn().mockImplementation(() => {
+        isPaused = true;
+      });
+      vi.spyOn(HTMLMediaElement.prototype, 'paused', 'get').mockImplementation(() => isPaused);
+      const rafQueue: FrameRequestCallback[] = [];
+      vi.spyOn(globalThis, 'requestAnimationFrame').mockImplementation((cb) => {
+        rafQueue.push(cb);
+        return rafQueue.length;
+      });
+      mockSetUserPaused.mockImplementation((videoId: string, paused: boolean) => {
+        userPausedVideoId = paused ? videoId : null;
+      });
+
+      const { useVideoPlayback } = await import('@/hooks/useVideoPlayback');
+      (useVideoPlayback as ReturnType<typeof vi.fn>).mockImplementation(() => ({
+        activeVideoId: 'queued-resume',
+        userPausedVideoId,
+        setUserPaused: mockSetUserPaused,
+        registerVideo: mockRegisterVideo,
+        unregisterVideo: mockUnregisterVideo,
+        updateVideoVisibility: mockUpdateVideoVisibility,
+        globalMuted: true,
+      }));
+
+      const { container, rerender } = render(
+        <VideoPlayer videoId="queued-resume" src="https://example.com/queued-resume.mp4" />
+      );
+      const video = container.querySelector('video');
+      if (!video) throw new Error('expected rendered video element');
+      playSpy.mockClear();
+
+      fireEvent.click(video);
+      rerender(<VideoPlayer videoId="queued-resume" src="https://example.com/queued-resume.mp4" />);
+      act(() => {
+        for (let i = 0; i < 10 && rafQueue.length > 0; i++) {
+          const pending = rafQueue.splice(0);
+          pending.forEach((cb) => cb(0));
+        }
+      });
+
+      expect(playSpy).not.toHaveBeenCalled();
+      expect(isPaused).toBe(true);
+    });
+
     it('keeps a user-paused active video paused across rerenders and mute changes', async () => {
       let globalMuted = true;
       let userPausedVideoId: string | null = null;

--- a/src/components/VideoPlayer.test.tsx
+++ b/src/components/VideoPlayer.test.tsx
@@ -804,6 +804,13 @@ describe('VideoPlayer', () => {
       vi.spyOn(HTMLMediaElement.prototype, 'paused', 'get').mockImplementation(() => isPaused);
       HTMLMediaElement.prototype.play = playSpy;
       HTMLMediaElement.prototype.pause = pauseSpy;
+      // The mute-sync effect resumes inside a double requestAnimationFrame; run
+      // rAF synchronously so a regressed effect's play() actually fires and can
+      // be caught, instead of being scheduled into a frame the test never flushes.
+      vi.spyOn(globalThis, 'requestAnimationFrame').mockImplementation((cb) => {
+        cb(0);
+        return 0;
+      });
       mockSetUserPaused.mockImplementation((videoId: string, paused: boolean) => {
         userPausedVideoId = paused ? videoId : null;
       });
@@ -825,12 +832,18 @@ describe('VideoPlayer', () => {
       const video = container.querySelector('video');
       if (!video) throw new Error('expected rendered video element');
 
+      // Ignore any startup play() from mounting an active video; from here on
+      // the user has paused, so no effect may resume it.
+      playSpy.mockClear();
+
       fireEvent.click(video);
       expect(mockSetUserPaused).toHaveBeenCalledWith('user-paused', true);
       expect(pauseSpy).toHaveBeenCalled();
 
-      playSpy.mockClear();
+      // A plain rerender (isUserPaused now true) must not let the active-status
+      // effect resume the paused video.
       rerender(<VideoPlayer videoId="user-paused" src="https://example.com/user-paused.mp4" />);
+      // A mute toggle must not resume it either (the mute-sync effect path).
       globalMuted = false;
       rerender(<VideoPlayer videoId="user-paused" src="https://example.com/user-paused.mp4" />);
       await act(async () => {
@@ -838,6 +851,7 @@ describe('VideoPlayer', () => {
       });
 
       expect(playSpy).not.toHaveBeenCalled();
+      expect(isPaused).toBe(true);
     });
 
     it('starts an active video before loadeddata fires', async () => {

--- a/src/components/VideoPlayer.test.tsx
+++ b/src/components/VideoPlayer.test.tsx
@@ -10,6 +10,7 @@ const mockUnregisterVideo = vi.fn();
 const mockUpdateVideoVisibility = vi.fn();
 const mockSetUserPaused = vi.fn();
 const hlsTestState = vi.hoisted(() => ({
+  inViewRef: vi.fn(),
   instances: [] as Array<{
     attachMedia: ReturnType<typeof vi.fn>;
     destroy: ReturnType<typeof vi.fn>;
@@ -127,7 +128,7 @@ vi.mock('hls.js', () => {
 // Mock react-intersection-observer to avoid observer.observe issues
 vi.mock('react-intersection-observer', () => ({
   useInView: vi.fn(() => ({
-    ref: vi.fn(),
+    ref: hlsTestState.inViewRef,
     inView: true,
     entry: null,
   })),
@@ -170,6 +171,8 @@ describe('VideoPlayer', () => {
     const { useVideoPlayback } = await import('@/hooks/useVideoPlayback');
     (useVideoPlayback as ReturnType<typeof vi.fn>).mockImplementation(() => ({
       activeVideoId: null,
+      userPausedVideoId: null,
+      setUserPaused: mockSetUserPaused,
       registerVideo: mockRegisterVideo,
       unregisterVideo: mockUnregisterVideo,
       updateVideoVisibility: mockUpdateVideoVisibility,
@@ -273,6 +276,18 @@ describe('VideoPlayer', () => {
       rerender(<VideoPlayer videoId="cleanup-stability" src="https://example.com/stable.mp4" />);
 
       expect(pauseSpy).not.toHaveBeenCalled();
+    });
+
+    it('does not run unmount cleanup when the video identity changes', () => {
+      const { rerender } = render(
+        <VideoPlayer videoId="video-a" src="https://example.com/a.mp4" />
+      );
+      mockUnregisterVideo.mockClear();
+
+      rerender(<VideoPlayer videoId="video-b" src="https://example.com/b.mp4" />);
+
+      expect(mockUnregisterVideo).toHaveBeenCalledWith('video-a');
+      expect(mockUnregisterVideo).not.toHaveBeenCalledWith('video-b');
     });
 
     it('should not trigger infinite loop when context values change', async () => {

--- a/src/components/VideoPlayer.test.tsx
+++ b/src/components/VideoPlayer.test.tsx
@@ -804,13 +804,22 @@ describe('VideoPlayer', () => {
       vi.spyOn(HTMLMediaElement.prototype, 'paused', 'get').mockImplementation(() => isPaused);
       HTMLMediaElement.prototype.play = playSpy;
       HTMLMediaElement.prototype.pause = pauseSpy;
-      // The mute-sync effect resumes inside a double requestAnimationFrame; run
-      // rAF synchronously so a regressed effect's play() actually fires and can
-      // be caught, instead of being scheduled into a frame the test never flushes.
+      // The mute-sync effect resumes inside a double requestAnimationFrame.
+      // Queue the callbacks and flush them at controlled points instead of
+      // relying on the environment's frame timing, so the test is deterministic:
+      // we drain the mount frame while the video is still playing, then flush
+      // again after the pause to catch any effect that tries to resume it.
+      const rafQueue: FrameRequestCallback[] = [];
       vi.spyOn(globalThis, 'requestAnimationFrame').mockImplementation((cb) => {
-        cb(0);
-        return 0;
+        rafQueue.push(cb);
+        return rafQueue.length;
       });
+      const flushFrames = () => {
+        for (let i = 0; i < 10 && rafQueue.length > 0; i++) {
+          const pending = rafQueue.splice(0);
+          pending.forEach((cb) => cb(0));
+        }
+      };
       mockSetUserPaused.mockImplementation((videoId: string, paused: boolean) => {
         userPausedVideoId = paused ? videoId : null;
       });
@@ -832,8 +841,10 @@ describe('VideoPlayer', () => {
       const video = container.querySelector('video');
       if (!video) throw new Error('expected rendered video element');
 
-      // Ignore any startup play() from mounting an active video; from here on
-      // the user has paused, so no effect may resume it.
+      // Drain the mount frame while the video is still playing, so a leftover
+      // frame can't fire after the pause and resume it. Then ignore any startup
+      // play(): from here on the user has paused, so no effect may resume it.
+      act(() => flushFrames());
       playSpy.mockClear();
 
       fireEvent.click(video);
@@ -846,9 +857,8 @@ describe('VideoPlayer', () => {
       // A mute toggle must not resume it either (the mute-sync effect path).
       globalMuted = false;
       rerender(<VideoPlayer videoId="user-paused" src="https://example.com/user-paused.mp4" />);
-      await act(async () => {
-        await Promise.resolve();
-      });
+      // Fire any frame a regressed effect scheduled to resume the paused video.
+      act(() => flushFrames());
 
       expect(playSpy).not.toHaveBeenCalled();
       expect(isPaused).toBe(true);

--- a/src/components/VideoPlayer.tsx
+++ b/src/components/VideoPlayer.tsx
@@ -152,21 +152,34 @@ export const VideoPlayer = forwardRef<HTMLVideoElement, VideoPlayerProps>(
     // Mobile-specific state
     const [touchState, setTouchState] = useState<TouchState | null>(null);
     const [lastTapTime, setLastTapTime] = useState(0);
-    const [longPressTimer, setLongPressTimer] = useState<NodeJS.Timeout | null>(null);
+    const longPressTimerRef = useRef<NodeJS.Timeout | null>(null);
 
     const resolvedPlaybackId = playbackId ?? videoId;
-    const { activeVideoId, registerVideo, unregisterVideo, updateVideoVisibility, globalMuted } = useVideoPlayback();
+    const {
+      activeVideoId,
+      globalMuted,
+      registerVideo,
+      setUserPaused,
+      unregisterVideo,
+      updateVideoVisibility,
+      userPausedVideoId,
+    } = useVideoPlayback();
     const isActive = activeVideoId === resolvedPlaybackId;
+    const isUserPaused = userPausedVideoId === resolvedPlaybackId;
 
     // Store context functions in refs to avoid unstable dependencies in setRefs callback
     // This prevents infinite loops when context functions change reference
     const registerVideoRef = useRef(registerVideo);
     const unregisterVideoRef = useRef(unregisterVideo);
+    const updateVideoVisibilityRef = useRef(updateVideoVisibility);
+    const resolvedPlaybackIdRef = useRef(resolvedPlaybackId);
     const globalMutedRef = useRef(globalMuted);
 
     // Keep refs updated with latest values
     registerVideoRef.current = registerVideo;
     unregisterVideoRef.current = unregisterVideo;
+    updateVideoVisibilityRef.current = updateVideoVisibility;
+    resolvedPlaybackIdRef.current = resolvedPlaybackId;
     globalMutedRef.current = globalMuted;
 
     // Get responsive layout class
@@ -270,11 +283,11 @@ export const VideoPlayer = forwardRef<HTMLVideoElement, VideoPlayerProps>(
     // Update playing state based on active status and control video playback
     useEffect(() => {
       verboseLog(`[VideoPlayer ${videoId}] Active status changed: ${isActive}`);
-      setIsPlaying(isActive);
+      setIsPlaying(isActive && !isUserPaused);
 
       // Actually control the video element
       if (videoRef.current) {
-        if (isActive && !hasError) {
+        if (isActive && !isUserPaused && !hasError) {
           verboseLog(`[VideoPlayer ${videoId}] Starting playback`);
           // Ensure video is not already playing before calling play()
           if (videoRef.current.paused) {
@@ -293,13 +306,13 @@ export const VideoPlayer = forwardRef<HTMLVideoElement, VideoPlayerProps>(
           videoRef.current.currentTime = 0;
         }
       }
-    }, [isActive, videoId, hasError]);
+    }, [isActive, isUserPaused, videoId, hasError]);
 
     // Sync video muted state with global muted state
     useEffect(() => {
       if (videoRef.current) {
         const video = videoRef.current;
-        const shouldBePlayingCheck = isActive && !hasError;
+        const shouldBePlayingCheck = isActive && !isUserPaused && !hasError;
 
         verboseLog(`[VideoPlayer ${videoId}] Syncing muted state to: ${globalMuted}, isActive: ${isActive}, shouldBePlaying: ${shouldBePlayingCheck}`);
 
@@ -335,7 +348,7 @@ export const VideoPlayer = forwardRef<HTMLVideoElement, VideoPlayerProps>(
           }, 100);
         }
       }
-    }, [globalMuted, videoId, isActive, hasError]);
+    }, [globalMuted, videoId, isActive, isUserPaused, hasError]);
 
     // Handle play/pause
     const togglePlay = useCallback(() => {
@@ -347,9 +360,11 @@ export const VideoPlayer = forwardRef<HTMLVideoElement, VideoPlayerProps>(
 
       if (isPlaying) {
         verboseLog(`[VideoPlayer ${videoId}] Pausing video`);
+        setUserPaused(resolvedPlaybackId, true);
         videoRef.current.pause();
       } else {
         verboseLog(`[VideoPlayer ${videoId}] Attempting to play video`);
+        setUserPaused(resolvedPlaybackId, false);
         videoRef.current.play().catch((error) => {
           debugError(`[VideoPlayer ${videoId}] Play failed:`, error);
           if (error.name === 'NotSupportedError') {
@@ -359,7 +374,7 @@ export const VideoPlayer = forwardRef<HTMLVideoElement, VideoPlayerProps>(
         });
       }
       setIsPlaying(!isPlaying);
-    }, [videoId, isPlaying]);
+    }, [videoId, isPlaying, resolvedPlaybackId, setUserPaused]);
 
 
 
@@ -382,8 +397,8 @@ export const VideoPlayer = forwardRef<HTMLVideoElement, VideoPlayerProps>(
       const currentTime = Date.now();
 
       // Clear any existing long press timer
-      if (longPressTimer) {
-        clearTimeout(longPressTimer);
+      if (longPressTimerRef.current) {
+        clearTimeout(longPressTimerRef.current);
       }
 
       // Set up touch state
@@ -399,9 +414,9 @@ export const VideoPlayer = forwardRef<HTMLVideoElement, VideoPlayerProps>(
       const timer = setTimeout(() => {
         onLongPress?.();
       }, 500);
-      setLongPressTimer(timer);
+      longPressTimerRef.current = timer;
 
-    }, [isMobile, longPressTimer, onLongPress]);
+    }, [isMobile, onLongPress]);
 
     const handleTouchMove = useCallback((e: React.TouchEvent) => {
       if (!isMobile || !touchState) return;
@@ -418,9 +433,9 @@ export const VideoPlayer = forwardRef<HTMLVideoElement, VideoPlayerProps>(
       const deltaY = touch.clientY - touchState.startY;
 
       // Clear long press timer on movement
-      if (longPressTimer) {
-        clearTimeout(longPressTimer);
-        setLongPressTimer(null);
+      if (longPressTimerRef.current) {
+        clearTimeout(longPressTimerRef.current);
+        longPressTimerRef.current = null;
       }
 
       // Handle pinch gesture
@@ -449,7 +464,7 @@ export const VideoPlayer = forwardRef<HTMLVideoElement, VideoPlayerProps>(
           onBrightnessGesture?.({ direction, delta: Math.abs(deltaY) });
         }
       }
-    }, [isMobile, touchState, longPressTimer, onPinch, onVolumeGesture, onBrightnessGesture]);
+    }, [isMobile, touchState, onPinch, onVolumeGesture, onBrightnessGesture]);
 
     const handleTouchEnd = useCallback((e: React.TouchEvent) => {
       if (!isMobile || !touchState) return;
@@ -459,18 +474,18 @@ export const VideoPlayer = forwardRef<HTMLVideoElement, VideoPlayerProps>(
       const isButton = target.closest('button');
       if (isButton) {
         // Clear any state and timers, but don't process any gestures
-        if (longPressTimer) {
-          clearTimeout(longPressTimer);
-          setLongPressTimer(null);
+        if (longPressTimerRef.current) {
+          clearTimeout(longPressTimerRef.current);
+          longPressTimerRef.current = null;
         }
         setTouchState(null);
         return; // Don't handle tap/swipe gestures if touching a button
       }
 
       // Clear long press timer
-      if (longPressTimer) {
-        clearTimeout(longPressTimer);
-        setLongPressTimer(null);
+      if (longPressTimerRef.current) {
+        clearTimeout(longPressTimerRef.current);
+        longPressTimerRef.current = null;
       }
 
       const currentTime = Date.now();
@@ -502,7 +517,7 @@ export const VideoPlayer = forwardRef<HTMLVideoElement, VideoPlayerProps>(
       }
 
       setTouchState(null);
-    }, [isMobile, touchState, longPressTimer, lastTapTime, togglePlay, onDoubleTap, onSwipeLeft, onSwipeRight]);
+    }, [isMobile, touchState, lastTapTime, togglePlay, onDoubleTap, onSwipeLeft, onSwipeRight]);
 
     // Track load timing
     const loadStartTime = useRef<number | null>(null);
@@ -999,11 +1014,11 @@ export const VideoPlayer = forwardRef<HTMLVideoElement, VideoPlayerProps>(
         }
 
         // Clear visibility and unregister
-        updateVideoVisibility(resolvedPlaybackId, 0);
-        unregisterVideo(resolvedPlaybackId);
+        updateVideoVisibilityRef.current(resolvedPlaybackIdRef.current, 0);
+        unregisterVideoRef.current(resolvedPlaybackIdRef.current);
 
         // Clean up timers
-        if (longPressTimer) clearTimeout(longPressTimer);
+        if (longPressTimerRef.current) clearTimeout(longPressTimerRef.current);
 
         // Revoke blob URL to prevent memory leaks
         if (blobUrlRef.current) {
@@ -1012,7 +1027,7 @@ export const VideoPlayer = forwardRef<HTMLVideoElement, VideoPlayerProps>(
           blobUrlRef.current = null;
         }
       };
-    }, [resolvedPlaybackId, videoId, unregisterVideo, updateVideoVisibility, longPressTimer]);
+    }, [videoId]);
 
     // Handle GIF format (use img tag)
     const currentUrl = allUrls[currentUrlIndex] || src;

--- a/src/components/VideoPlayer.tsx
+++ b/src/components/VideoPlayer.tsx
@@ -1024,7 +1024,7 @@ export const VideoPlayer = forwardRef<HTMLVideoElement, VideoPlayerProps>(
 
         // Revoke blob URL to prevent memory leaks
         if (blobUrlRef.current) {
-          verboseLog(`[VideoPlayer ${videoId}] Revoking blob URL on unmount`);
+          verboseLog(`[VideoPlayer ${resolvedPlaybackIdRef.current}] Revoking blob URL on unmount`);
           URL.revokeObjectURL(blobUrlRef.current);
           blobUrlRef.current = null;
         }

--- a/src/components/VideoPlayer.tsx
+++ b/src/components/VideoPlayer.tsx
@@ -1029,7 +1029,7 @@ export const VideoPlayer = forwardRef<HTMLVideoElement, VideoPlayerProps>(
           blobUrlRef.current = null;
         }
       };
-    }, [videoId]);
+    }, []);
 
     // Handle GIF format (use img tag)
     const currentUrl = allUrls[currentUrlIndex] || src;

--- a/src/components/VideoPlayer.tsx
+++ b/src/components/VideoPlayer.tsx
@@ -166,6 +166,8 @@ export const VideoPlayer = forwardRef<HTMLVideoElement, VideoPlayerProps>(
     } = useVideoPlayback();
     const isActive = activeVideoId === resolvedPlaybackId;
     const isUserPaused = userPausedVideoId === resolvedPlaybackId;
+    const shouldBePlayingRef = useRef(isActive && !isUserPaused && !hasError);
+    shouldBePlayingRef.current = isActive && !isUserPaused && !hasError;
 
     // Store context functions in refs to avoid unstable dependencies in setRefs callback
     // This prevents infinite loops when context functions change reference
@@ -328,7 +330,7 @@ export const VideoPlayer = forwardRef<HTMLVideoElement, VideoPlayerProps>(
           requestAnimationFrame(() => {
             // Then use another one to ensure we're after any browser-triggered events
             requestAnimationFrame(() => {
-              if (video.paused) {
+              if (video.paused && shouldBePlayingRef.current) {
                 verboseLog(`[VideoPlayer ${videoId}] Video paused after mute change, resuming...`);
                 video.play().catch(error => {
                   verboseLog(`[VideoPlayer ${videoId}] Failed to resume after mute change:`, error);
@@ -581,7 +583,7 @@ export const VideoPlayer = forwardRef<HTMLVideoElement, VideoPlayerProps>(
       setHasLoadedOnce(true);
       setAuthDeniedAfterVerification(false);
 
-      if (isActive && !hasError && videoRef.current?.paused) {
+      if (isActive && !isUserPaused && !hasError && videoRef.current?.paused) {
         videoRef.current.play().catch((error) => {
           debugError(`[VideoPlayer ${videoId}] Failed to resume after load:`, error);
           if (error.name === 'NotSupportedError') {

--- a/src/components/VideoPlayer.tsx
+++ b/src/components/VideoPlayer.tsx
@@ -1005,9 +1005,9 @@ export const VideoPlayer = forwardRef<HTMLVideoElement, VideoPlayerProps>(
 
     // Cleanup on unmount
     useEffect(() => {
-      verboseLog(`[VideoPlayer ${videoId}] Component mounting`);
+      verboseLog(`[VideoPlayer ${resolvedPlaybackIdRef.current}] Component mounting`);
       return () => {
-        verboseLog(`[VideoPlayer ${videoId}] Component unmounting`);
+        verboseLog(`[VideoPlayer ${resolvedPlaybackIdRef.current}] Component unmounting`);
 
         // Ensure video is paused before unmounting
         if (videoRef.current) {

--- a/src/contexts/VideoPlaybackContext.test.tsx
+++ b/src/contexts/VideoPlaybackContext.test.tsx
@@ -1,14 +1,22 @@
 import { act, fireEvent, render, screen } from '@testing-library/react';
+import { useRef } from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { useVideoPlayback } from '@/hooks/useVideoPlayback';
 import { VideoPlaybackProvider } from './VideoPlaybackContext';
 
 function Harness() {
-  const { activeVideoId, setActiveVideo, updateVideoVisibility } = useVideoPlayback();
+  const { activeVideoId, setActiveVideo, setUserPaused, updateVideoVisibility, userPausedVideoId } = useVideoPlayback();
 
   return (
     <div>
       <div data-testid="active-video-id">{activeVideoId ?? ''}</div>
+      <div data-testid="user-paused-video-id">{userPausedVideoId ?? ''}</div>
+      <button
+        type="button"
+        onClick={() => setUserPaused('fullscreen:video-1', true)}
+      >
+        pause-fullscreen
+      </button>
       <button
         type="button"
         onClick={() => setActiveVideo('fullscreen:video-1')}
@@ -27,6 +35,26 @@ function Harness() {
       >
         fullscreen-visible
       </button>
+    </div>
+  );
+}
+
+function IdentityHarness() {
+  const playback = useVideoPlayback();
+  const initialFunctions = useRef({
+    registerVideo: playback.registerVideo,
+    setActiveVideo: playback.setActiveVideo,
+    setUserPaused: playback.setUserPaused,
+    unregisterVideo: playback.unregisterVideo,
+    updateVideoVisibility: playback.updateVideoVisibility,
+  });
+  const functionsAreStable = Object.entries(initialFunctions.current).every(
+    ([name, fn]) => playback[name as keyof typeof initialFunctions.current] === fn
+  );
+
+  return (
+    <div>
+      <div data-testid="functions-stable">{String(functionsAreStable)}</div>
     </div>
   );
 }
@@ -56,5 +84,39 @@ describe('VideoPlaybackContext', () => {
     });
 
     expect(screen.getByTestId('active-video-id')).toHaveTextContent('fullscreen:video-1');
+  });
+
+  it('keeps context actions stable across provider rerenders', () => {
+    const { rerender } = render(
+      <VideoPlaybackProvider>
+        <IdentityHarness />
+      </VideoPlaybackProvider>
+    );
+
+    rerender(
+      <VideoPlaybackProvider>
+        <IdentityHarness />
+      </VideoPlaybackProvider>
+    );
+
+    expect(screen.getByTestId('functions-stable')).toHaveTextContent('true');
+  });
+
+  it('clears a user pause when another video becomes active', () => {
+    render(
+      <VideoPlaybackProvider>
+        <Harness />
+      </VideoPlaybackProvider>
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'activate-fullscreen' }));
+    fireEvent.click(screen.getByRole('button', { name: 'pause-fullscreen' }));
+    expect(screen.getByTestId('user-paused-video-id')).toHaveTextContent('fullscreen:video-1');
+
+    fireEvent.click(screen.getByRole('button', { name: 'inline-visible' }));
+    act(() => vi.advanceTimersByTime(150));
+
+    expect(screen.getByTestId('active-video-id')).toHaveTextContent('video-1');
+    expect(screen.getByTestId('user-paused-video-id')).toBeEmptyDOMElement();
   });
 });

--- a/src/contexts/VideoPlaybackContext.test.tsx
+++ b/src/contexts/VideoPlaybackContext.test.tsx
@@ -5,7 +5,7 @@ import { useVideoPlayback } from '@/hooks/useVideoPlayback';
 import { VideoPlaybackProvider } from './VideoPlaybackContext';
 
 function Harness() {
-  const { activeVideoId, setActiveVideo, setUserPaused, updateVideoVisibility, userPausedVideoId } = useVideoPlayback();
+  const { activeVideoId, setActiveVideo, setUserPaused, unregisterVideo, updateVideoVisibility, userPausedVideoId } = useVideoPlayback();
 
   return (
     <div>
@@ -16,6 +16,15 @@ function Harness() {
         onClick={() => setUserPaused('fullscreen:video-1', true)}
       >
         pause-fullscreen
+      </button>
+      <button
+        type="button"
+        onClick={() => setActiveVideo('fullscreen:video-1')}
+      >
+        reactivate-fullscreen
+      </button>
+      <button type="button" onClick={() => unregisterVideo('fullscreen:video-1')}>
+        unregister-fullscreen
       </button>
       <button
         type="button"
@@ -41,6 +50,7 @@ function Harness() {
 
 function IdentityHarness() {
   const playback = useVideoPlayback();
+  const initialValue = useRef(playback);
   const initialFunctions = useRef({
     registerVideo: playback.registerVideo,
     setActiveVideo: playback.setActiveVideo,
@@ -55,6 +65,7 @@ function IdentityHarness() {
   return (
     <div>
       <div data-testid="functions-stable">{String(functionsAreStable)}</div>
+      <div data-testid="value-stable">{String(initialValue.current === playback)}</div>
     </div>
   );
 }
@@ -100,6 +111,34 @@ describe('VideoPlaybackContext', () => {
     );
 
     expect(screen.getByTestId('functions-stable')).toHaveTextContent('true');
+    expect(screen.getByTestId('value-stable')).toHaveTextContent('true');
+  });
+
+  it('keeps a user pause when the same video is activated again', () => {
+    render(
+      <VideoPlaybackProvider>
+        <Harness />
+      </VideoPlaybackProvider>
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'activate-fullscreen' }));
+    fireEvent.click(screen.getByRole('button', { name: 'pause-fullscreen' }));
+    fireEvent.click(screen.getByRole('button', { name: 'reactivate-fullscreen' }));
+
+    expect(screen.getByTestId('user-paused-video-id')).toHaveTextContent('fullscreen:video-1');
+  });
+
+  it('clears a user pause when its player unregisters', () => {
+    render(
+      <VideoPlaybackProvider>
+        <Harness />
+      </VideoPlaybackProvider>
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'pause-fullscreen' }));
+    fireEvent.click(screen.getByRole('button', { name: 'unregister-fullscreen' }));
+
+    expect(screen.getByTestId('user-paused-video-id')).toBeEmptyDOMElement();
   });
 
   it('clears a user pause when another video becomes active', () => {

--- a/src/contexts/VideoPlaybackContext.tsx
+++ b/src/contexts/VideoPlaybackContext.tsx
@@ -80,6 +80,7 @@ export function VideoPlaybackProvider({ children }: { children: ReactNode }) {
     verboseLog(`Unregistering video: ${videoId}`);
     videoRefs.current.delete(videoId);
     videoVisibility.current.delete(videoId);
+    setUserPausedVideoId((pausedVideoId) => pausedVideoId === videoId ? null : pausedVideoId);
 
     // Remove from registration order
     const orderIndex = registrationOrder.current.indexOf(videoId);

--- a/src/contexts/VideoPlaybackContext.tsx
+++ b/src/contexts/VideoPlaybackContext.tsx
@@ -1,7 +1,7 @@
 // ABOUTME: Context for managing video playback state across the feed
 // ABOUTME: Ensures only one video plays at a time based on viewport visibility
 
-import { createContext, useState, useRef, ReactNode } from 'react';
+import { createContext, useCallback, useEffect, useMemo, useState, useRef, ReactNode } from 'react';
 import { verboseLog } from '@/lib/debug';
 
 // Maximum number of video references to keep in memory
@@ -10,7 +10,9 @@ const MAX_VIDEO_REFS = 30;
 
 export interface VideoPlaybackContextType {
   activeVideoId: string | null;
+  userPausedVideoId: string | null;
   setActiveVideo: (videoId: string | null) => void;
+  setUserPaused: (videoId: string, paused: boolean) => void;
   registerVideo: (videoId: string, element: HTMLVideoElement) => void;
   unregisterVideo: (videoId: string) => void;
   updateVideoVisibility: (videoId: string, visibilityRatio: number) => void;
@@ -22,6 +24,7 @@ export const VideoPlaybackContext = createContext<VideoPlaybackContextType | und
 
 export function VideoPlaybackProvider({ children }: { children: ReactNode }) {
   const [activeVideoId, setActiveVideoId] = useState<string | null>(null);
+  const [userPausedVideoId, setUserPausedVideoId] = useState<string | null>(null);
   const [globalMuted, setGlobalMuted] = useState(true); // Start muted by default
   const videoRefs = useRef<Map<string, HTMLVideoElement>>(new Map());
   const videoVisibility = useRef<Map<string, number>>(new Map());
@@ -32,16 +35,25 @@ export function VideoPlaybackProvider({ children }: { children: ReactNode }) {
   const activeVideoIdRef = useRef<string | null>(null);
   activeVideoIdRef.current = activeVideoId;
 
-  const setActiveVideo = (videoId: string | null) => {
-    verboseLog(`setActiveVideo called with: ${videoId}, current: ${activeVideoId}`);
-    verboseLog(`Registered videos: ${Array.from(videoRefs.current.keys()).join(', ')}`);
-
-    // Just update the active video ID
-    // The VideoPlayer components will handle play/pause based on this change
+  const activateVideo = useCallback((videoId: string | null) => {
+    setUserPausedVideoId((pausedVideoId) => pausedVideoId === videoId ? pausedVideoId : null);
     setActiveVideoId(videoId);
-  };
+  }, []);
 
-  const registerVideo = (videoId: string, element: HTMLVideoElement) => {
+  const setActiveVideo = useCallback((videoId: string | null) => {
+    verboseLog(`setActiveVideo called with: ${videoId}, current: ${activeVideoIdRef.current}`);
+    verboseLog(`Registered videos: ${Array.from(videoRefs.current.keys()).join(', ')}`);
+    activateVideo(videoId);
+  }, [activateVideo]);
+
+  const setUserPaused = useCallback((videoId: string, paused: boolean) => {
+    setUserPausedVideoId((pausedVideoId) => {
+      if (paused) return videoId;
+      return pausedVideoId === videoId ? null : pausedVideoId;
+    });
+  }, []);
+
+  const registerVideo = useCallback((videoId: string, element: HTMLVideoElement) => {
     verboseLog(`Registering video: ${videoId}`);
 
     // Add to registration order (move to end if already exists)
@@ -62,9 +74,9 @@ export function VideoPlaybackProvider({ children }: { children: ReactNode }) {
         videoVisibility.current.delete(oldestId);
       }
     }
-  };
+  }, []);
 
-  const unregisterVideo = (videoId: string) => {
+  const unregisterVideo = useCallback((videoId: string) => {
     verboseLog(`Unregistering video: ${videoId}`);
     videoRefs.current.delete(videoId);
     videoVisibility.current.delete(videoId);
@@ -74,9 +86,9 @@ export function VideoPlaybackProvider({ children }: { children: ReactNode }) {
     if (orderIndex !== -1) {
       registrationOrder.current.splice(orderIndex, 1);
     }
-  };
+  }, []);
 
-  const updateVideoVisibility = (videoId: string, visibilityRatio: number) => {
+  const updateVideoVisibility = useCallback((videoId: string, visibilityRatio: number) => {
     // Update visibility for this video
     if (visibilityRatio > 0) {
       videoVisibility.current.set(videoId, visibilityRatio);
@@ -88,7 +100,7 @@ export function VideoPlaybackProvider({ children }: { children: ReactNode }) {
     // This skips the debounce for the first video on page load (priority video)
     if (activeVideoIdRef.current === null && visibilityRatio >= 0.5) {
       verboseLog(`Immediately activating first visible video: ${videoId} (${(visibilityRatio * 100).toFixed(1)}% visible)`);
-      setActiveVideoId(videoId);
+      activateVideo(videoId);
       return;
     }
 
@@ -116,22 +128,39 @@ export function VideoPlaybackProvider({ children }: { children: ReactNode }) {
       // Use ref to get current value and avoid stale closure
       if (mostVisibleId !== activeVideoIdRef.current) {
         verboseLog(`Switching to most visible video: ${mostVisibleId} (${(maxVisibility * 100).toFixed(1)}% visible)`);
-        setActiveVideoId(mostVisibleId);
+        activateVideo(mostVisibleId);
       }
     }, 100); // Small debounce to avoid rapid switching
-  };
+  }, [activateVideo]);
+
+  useEffect(() => () => {
+    if (visibilityUpdateTimer.current) clearTimeout(visibilityUpdateTimer.current);
+  }, []);
+
+  const value = useMemo(() => ({
+    activeVideoId,
+    userPausedVideoId,
+    setActiveVideo,
+    setUserPaused,
+    registerVideo,
+    unregisterVideo,
+    updateVideoVisibility,
+    globalMuted,
+    setGlobalMuted,
+  }), [
+    activeVideoId,
+    globalMuted,
+    registerVideo,
+    setActiveVideo,
+    setUserPaused,
+    unregisterVideo,
+    updateVideoVisibility,
+    userPausedVideoId,
+  ]);
 
   return (
     <VideoPlaybackContext.Provider
-      value={{
-        activeVideoId,
-        setActiveVideo,
-        registerVideo,
-        unregisterVideo,
-        updateVideoVisibility,
-        globalMuted,
-        setGlobalMuted,
-      }}
+      value={value}
     >
       {children}
     </VideoPlaybackContext.Provider>


### PR DESCRIPTION
## Summary

- Keeps a video paused when the user opens comments, triggers a rerender, or changes mute state.
- Clears that pause after the video scrolls out of the active position so feed autoplay resumes normally when it returns.
- Stops ordinary playback-context updates and long presses from running destructive unmount cleanup across mounted players.

## Motivation

A user pause was only stored inside the player while the shared playback model continued to treat the most visible video as playable. At the same time, unstable context callbacks repeatedly ran cleanup intended for unmount, pausing and rewinding every mounted player, unregistering them, and revoking protected-media blob URLs.

This change gives user pause an explicit single-active-video state, stabilizes playback context actions and its provider value, and confines cleanup to actual player lifecycle changes. It deliberately does not persist a pause after the user scrolls to another video.

## Related Issue

- Closes #680

## Testing

- [x] `npm run test`
- [ ] Manual verification completed

## Visuals

- [x] No visual change
- [x] Visuals and text avoid sensitive external brand or partner names unless explicitly approved