### PR TITLE
fix(comments): show commenter names when profile handles are empty

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -53,6 +53,11 @@ contexts (`AppContext`, `VideoPlaybackContext`, `FullscreenFeedContext`,
 and subscriptions against Nostr relays. Auth uses `@divinevideo/login` with
 `NostrLoginProvider`, hydrated from cross-subdomain cookies.
 
+Profile metadata remains raw through the fetch layer because `name` is also used
+as a handle. Display surfaces resolve `display_name`, then `name`, then a
+deterministic fallback through [`resolveDisplayName`](./src/lib/resolveDisplayName.ts);
+handle surfaces deliberately keep their separate `name`-only fallback.
+
 ### Notification Read Marker
 
 Web and mobile both write the same Funnelcake per-pubkey notification read

--- a/src/components/InlineNostrText.tsx
+++ b/src/components/InlineNostrText.tsx
@@ -2,7 +2,7 @@ import { useMemo } from 'react';
 import { nip19 } from 'nostr-tools';
 import { SmartLink } from '@/components/SmartLink';
 import { useAuthor } from '@/hooks/useAuthor';
-import { genUserName } from '@/lib/genUserName';
+import { resolveDisplayName } from '@/lib/resolveDisplayName';
 
 const NIP19_CHARS = '023456789acdefghjklmnpqrstuvwxyz';
 const NOSTR_MENTION_REGEX = new RegExp(`(?:nostr:)?\\b(npub1[${NIP19_CHARS}]{58})(?=$|[^A-Za-z0-9_]|nostr:)`, 'g');
@@ -29,7 +29,7 @@ function extractPubkeys(text: string): string[] {
 function MentionName({ pubkey }: { pubkey: string }) {
   const author = useAuthor(pubkey);
   const npub = nip19.npubEncode(pubkey);
-  const displayName = author.data?.metadata?.name || author.data?.metadata?.display_name || genUserName(pubkey);
+  const displayName = resolveDisplayName(author.data?.metadata, pubkey);
 
   return (
     <SmartLink to={`/${npub}`} ownerPubkey={pubkey} className="hover:underline">

--- a/src/components/NoteContent.test.tsx
+++ b/src/components/NoteContent.test.tsx
@@ -3,6 +3,7 @@ import { render, screen } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import { nip19 } from 'nostr-tools';
 import { NoteContent } from './NoteContent';
+import { genUserName } from '@/lib/genUserName';
 import type { NostrEvent } from '@nostrify/nostrify';
 
 const noteMocks = vi.hoisted(() => ({
@@ -142,6 +143,27 @@ describe('NoteContent — prefixed nostr: form (regression)', () => {
     expect(links).toHaveLength(2);
     expect(links[0]).toHaveAttribute('href', `/${NPUB}`);
     expect(links[1]).toHaveAttribute('href', `/${NPUB}`);
+  });
+});
+
+describe('NoteContent — mention name styling', () => {
+  it('styles a whitespace-only profile name as a generated name', () => {
+    noteMocks.metadata = { name: '   ' };
+
+    renderContent(`hello ${NPUB}`);
+
+    const link = screen.getByRole('link');
+    expect(link.textContent).toBe(`@${genUserName(PUBKEY_HEX)}`);
+    expect(link.className).toContain('text-gray-500');
+    expect(link.className).not.toContain('text-blue-500');
+  });
+
+  it('styles a real profile name as a real name', () => {
+    renderContent(`hello ${NPUB}`);
+
+    const link = screen.getByRole('link');
+    expect(link.textContent).toBe('@rabble');
+    expect(link.className).toContain('text-blue-500');
   });
 });
 

--- a/src/components/NoteContent.tsx
+++ b/src/components/NoteContent.tsx
@@ -4,7 +4,7 @@ import { SmartLink } from '@/components/SmartLink';
 import { nip19 } from 'nostr-tools';
 import { useAuthor } from '@/hooks/useAuthor';
 import { useValidatedProfileLinkPath } from '@/hooks/useValidatedProfileLinkPath';
-import { genUserName } from '@/lib/genUserName';
+import { resolveDisplayName } from '@/lib/resolveDisplayName';
 import { cn } from '@/lib/utils';
 
 interface NoteContentProps {
@@ -119,7 +119,7 @@ export function NoteContent({
 function NostrMention({ pubkey }: { pubkey: string }) {
   const author = useAuthor(pubkey);
   const hasRealName = !!(author.data?.metadata?.name || author.data?.metadata?.display_name);
-  const displayName = author.data?.metadata?.name || author.data?.metadata?.display_name || genUserName(pubkey);
+  const displayName = resolveDisplayName(author.data?.metadata, pubkey);
   const nip05 = author.data?.metadata?.nip05;
   const profilePath = useValidatedProfileLinkPath({
     pubkey,

--- a/src/components/NoteContent.tsx
+++ b/src/components/NoteContent.tsx
@@ -118,7 +118,9 @@ export function NoteContent({
 // Helper component to display user mentions
 function NostrMention({ pubkey }: { pubkey: string }) {
   const author = useAuthor(pubkey);
-  const hasRealName = !!(author.data?.metadata?.name || author.data?.metadata?.display_name);
+  // Trim to match resolveDisplayName: a whitespace-only field falls through to the
+  // generated name, so it must not be styled as a real one.
+  const hasRealName = !!(author.data?.metadata?.display_name?.trim() || author.data?.metadata?.name?.trim());
   const displayName = resolveDisplayName(author.data?.metadata, pubkey);
   const nip05 = author.data?.metadata?.nip05;
   const profilePath = useValidatedProfileLinkPath({

--- a/src/components/PeopleListMember.tsx
+++ b/src/components/PeopleListMember.tsx
@@ -3,7 +3,7 @@
 import type { NostrMetadata } from '@nostrify/nostrify';
 import { Link } from 'react-router-dom';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
-import { genUserName } from '@/lib/genUserName';
+import { resolveDisplayName } from '@/lib/resolveDisplayName';
 import { getSafeProfileImage } from '@/lib/imageUtils';
 import { buildProfileLinkPath } from '@/lib/profileLinks';
 
@@ -13,7 +13,7 @@ interface PeopleListMemberProps {
 }
 
 export function PeopleListMember({ pubkey, metadata }: PeopleListMemberProps) {
-  const name = metadata?.display_name || metadata?.name || genUserName(pubkey);
+  const name = resolveDisplayName(metadata, pubkey);
 
   return (
     <Link

--- a/src/components/UserListDialog.tsx
+++ b/src/components/UserListDialog.tsx
@@ -17,7 +17,7 @@ import { useBatchedAuthors } from '@/hooks/useBatchedAuthors';
 import { useSubdomainNavigate } from '@/hooks/useSubdomainNavigate';
 import { useValidatedProfileLinkPath } from '@/hooks/useValidatedProfileLinkPath';
 import { getSafeProfileImage } from '@/lib/imageUtils';
-import { genUserName } from '@/lib/genUserName';
+import { resolveDisplayName } from '@/lib/resolveDisplayName';
 import { Sentry } from '@/lib/sentry';
 
 const ESTIMATED_ROW_HEIGHT = 56;
@@ -39,7 +39,7 @@ interface UserRowProps {
 }
 
 const UserRow = memo(function UserRow({ pubkey, metadata, onNavigate }: UserRowProps) {
-  const displayName = metadata?.display_name || metadata?.name || genUserName(pubkey);
+  const displayName = resolveDisplayName(metadata, pubkey);
   const profileImage = getSafeProfileImage(metadata?.picture) || '/user-avatar.png';
   const profilePath = useValidatedProfileLinkPath({
     pubkey,

--- a/src/components/VideoCard.test.tsx
+++ b/src/components/VideoCard.test.tsx
@@ -36,6 +36,7 @@ const authorMocks = vi.hoisted(() => ({
     name: 'Video Author',
     picture: 'https://example.com/avatar.jpg',
   } as Record<string, unknown>,
+  reposterMetadata: undefined as Record<string, unknown> | undefined,
   useNip05Validation: vi.fn(),
 }));
 
@@ -189,9 +190,11 @@ vi.mock('@/components/SmartLink', () => ({
 }));
 
 vi.mock('@/hooks/useAuthor', () => ({
-  useAuthor: () => ({
+  useAuthor: (pubkey: string) => ({
     data: {
-      metadata: authorMocks.metadata,
+      metadata: authorMocks.reposterMetadata && pubkey === 'b'.repeat(64)
+        ? authorMocks.reposterMetadata
+        : authorMocks.metadata,
     },
     isLoading: false,
   }),
@@ -422,6 +425,7 @@ describe('VideoCard', () => {
       name: 'Video Author',
       picture: 'https://example.com/avatar.jpg',
     };
+    authorMocks.reposterMetadata = undefined;
     authorMocks.useNip05Validation.mockReturnValue({
       isValid: false,
       isLoading: false,
@@ -471,6 +475,30 @@ describe('VideoCard', () => {
       'href',
       `/${nip19.npubEncode(baseVideo.pubkey)}`,
     );
+  });
+
+  it('shows the reposter display_name when their name is empty', () => {
+    authorMocks.reposterMetadata = {
+      name: '',
+      display_name: 'Visible Reposter',
+      picture: 'https://example.com/reposter.jpg',
+    };
+
+    render(
+      <VideoCard
+        video={{
+          ...baseVideo,
+          reposts: [{
+            eventId: 'repost-event-1',
+            reposterPubkey: 'b'.repeat(64),
+            repostedAt: 1_700_000_001,
+          }],
+        }}
+        mode="thumbnail"
+      />,
+    );
+
+    expect(screen.getByText(/Visible Reposter/)).toBeInTheDocument();
   });
 
   it('builds the thumbnail link from the navigation context when provided', () => {

--- a/src/components/VideoCard.tsx
+++ b/src/components/VideoCard.tsx
@@ -31,6 +31,7 @@ import { useVideoPlayback } from '@/hooks/useVideoPlayback';
 import { useVideosInLists } from '@/hooks/useVideoLists';
 import { enhanceAuthorData } from '@/lib/generateProfile';
 import { genUserName } from '@/lib/genUserName';
+import { resolveDisplayName } from '@/lib/resolveDisplayName';
 import { formatDistanceToNow } from 'date-fns';
 import type { ParsedVideoData } from '@/types/video';
 import { SHORT_VIDEO_KIND } from '@/types/video';
@@ -148,7 +149,6 @@ export function VideoCard({
   const latestRepost = hasReposts ? video.reposts[video.reposts.length - 1] : null;
   const reposterPubkey = latestRepost?.reposterPubkey;
   const reposterData = useAuthor(reposterPubkey || '');
-  const shouldShowReposter = hasReposts && reposterPubkey;
   const playbackCountLabel = video.isVineMigrated
     ? formatClassicVineViewBreakdown(viewCount, video.loopCount ?? 0)
     : formatLoopCount(viewCount);
@@ -273,12 +273,7 @@ export function VideoCard({
 
   // Enhance author data with generated profiles
   const author = enhanceAuthorData(authorData.data, video.pubkey);
-  const reposter = shouldShowReposter && reposterPubkey
-    ? enhanceAuthorData(reposterData.data, reposterPubkey)
-    : null;
-
   const metadata: NostrMetadata = author.metadata;
-  const reposterMetadata: NostrMetadata | undefined = reposter?.metadata;
 
   // Use raw author data (pre-enhancement) to detect real vs generated names
   // enhanceAuthorData fills in generated names like "ElectricVine742" — we don't want those
@@ -300,7 +295,7 @@ export function VideoCard({
 
   const reposterName = reposterData.isLoading
     ? t('videoCard.loadingProfile')
-    : (reposterMetadata?.name || (reposterPubkey ? genUserName(reposterPubkey) : ''));
+    : (reposterPubkey ? resolveDisplayName(reposterData.data?.metadata, reposterPubkey) : '');
 
   // NEW: Get all unique reposters for display
   const allReposters = video.reposts || [];

--- a/src/components/VideoListBadges.tsx
+++ b/src/components/VideoListBadges.tsx
@@ -14,7 +14,7 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from '@/components/ui/tooltip';
-import { genUserName } from '@/lib/genUserName';
+import { resolveDisplayName } from '@/lib/resolveDisplayName';
 import { buildListPath } from '@/lib/eventRouting';
 import { useState } from 'react';
 import { AddToListDialog } from './AddToListDialog';
@@ -40,7 +40,7 @@ function ListBadge({
   videoCount: number;
 }) {
   const author = useAuthor(listPubkey);
-  const authorName = author.data?.metadata?.name || genUserName(listPubkey);
+  const authorName = resolveDisplayName(author.data?.metadata, listPubkey);
 
   return (
     <TooltipProvider>

--- a/src/components/VideoReactionsModal.tsx
+++ b/src/components/VideoReactionsModal.tsx
@@ -4,7 +4,7 @@ import { Heart, Repeat as Repeat2, CircleNotch as Loader2 } from '@phosphor-icon
 import { useAuthor } from '@/hooks/useAuthor';
 import { useBatchedAuthors } from '@/hooks/useBatchedAuthors';
 import { enhanceAuthorData } from '@/lib/generateProfile';
-import { genUserName } from '@/lib/genUserName';
+import { resolveDisplayName } from '@/lib/resolveDisplayName';
 import { getSafeProfileImage } from '@/lib/imageUtils';
 import { formatDistanceToNow } from 'date-fns';
 import { SmartLink } from '@/components/SmartLink';
@@ -27,7 +27,7 @@ function ReactionUserItem({ pubkey, timestamp }: { pubkey: string; timestamp: nu
 
   const displayName = authorData.isLoading
     ? "Loading..."
-    : (metadata?.display_name || metadata?.name || genUserName(pubkey));
+    : resolveDisplayName(metadata, pubkey);
   const profileImage = getSafeProfileImage(metadata?.picture);
   const profileUrl = useValidatedProfileLinkPath({
     pubkey,

--- a/src/components/auth/AccountSwitcher.test.tsx
+++ b/src/components/auth/AccountSwitcher.test.tsx
@@ -180,6 +180,28 @@ describe('AccountSwitcher', () => {
     expect(mockNavigate).toHaveBeenCalledWith('/exit');
   });
 
+  it('shows display_name when an account name is empty', () => {
+    mockUseLoggedInAccounts.mockReturnValue({
+      currentUser: {
+        id: 'nsec-account',
+        metadata: { name: '', display_name: 'Visible Account' },
+        pubkey: 'a'.repeat(64),
+      },
+      otherUsers: [{
+        id: 'other-account',
+        metadata: { name: '', display_name: 'Other Account' },
+        pubkey: 'b'.repeat(64),
+      }],
+      removeLogin: mockRemoveLogin,
+      setLogin: mockSetLogin,
+    });
+
+    render(<AccountSwitcher onAddAccountClick={vi.fn()} />);
+
+    expect(screen.getAllByText('Visible Account')).not.toHaveLength(0);
+    expect(screen.getByText('Other Account')).toBeInTheDocument();
+  });
+
   describe('nsec backup banner mounting (#182)', () => {
     beforeEach(() => {
       mockUseNostrLogin.mockReturnValue({ logins: [LOCAL_NSEC_LOGIN] });

--- a/src/components/auth/AccountSwitcher.tsx
+++ b/src/components/auth/AccountSwitcher.tsx
@@ -19,7 +19,7 @@ import { useNostrLogin } from '@nostrify/react/login';
 import { useLoggedInAccounts, type Account } from '@/hooks/useLoggedInAccounts';
 import { useDivineSession } from '@/hooks/useDivineSession';
 import { clearLoginCookie, clearJwtCookie } from '@/lib/crossSubdomainAuth';
-import { genUserName } from '@/lib/genUserName';
+import { resolveDisplayName } from '@/lib/resolveDisplayName';
 import { getSafeProfileImage } from '@/lib/imageUtils';
 import { getLocalNsecLogin } from '@/lib/localNsecAccount';
 import { OVERLAY_LAYERS } from '@/lib/overlayLayers';
@@ -45,7 +45,7 @@ export function AccountSwitcher({ onAddAccountClick }: AccountSwitcherProps) {
   const isJwtCurrentUser = currentUser.id.startsWith('jwt:');
 
   const getDisplayName = (account: Account): string => {
-    return account.metadata.name ?? genUserName(account.pubkey);
+    return resolveDisplayName(account.metadata, account.pubkey);
   }
 
   const handleMyProfileClick = () => {

--- a/src/components/comments/Comment.test.tsx
+++ b/src/components/comments/Comment.test.tsx
@@ -1,0 +1,132 @@
+import { render, screen } from '@testing-library/react';
+import type { NostrEvent, NostrMetadata } from '@nostrify/nostrify';
+import type { ReactNode } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const COMMENTER_PUBKEY = 'a'.repeat(64);
+const PARENT_PUBKEY = 'b'.repeat(64);
+
+const authorMetadata = vi.hoisted(() => new Map<string, NostrMetadata>());
+
+vi.mock('@/hooks/useAuthor', () => ({
+  useAuthor: (pubkey: string) => ({
+    data: authorMetadata.has(pubkey) ? { metadata: authorMetadata.get(pubkey) } : undefined,
+  }),
+}));
+
+vi.mock('@/hooks/useComments', () => ({
+  getDirectReplies: () => [],
+  useComments: () => ({ data: { allComments: [] } }),
+}));
+
+vi.mock('@/hooks/useCurrentUser', () => ({
+  useCurrentUser: () => ({ user: undefined }),
+}));
+
+vi.mock('@/hooks/useModeration', () => ({
+  useMuteItem: () => ({ mutate: vi.fn() }),
+}));
+
+vi.mock('@/hooks/useDeleteComment', () => ({
+  useDeleteComment: () => ({ mutate: vi.fn(), isPending: false }),
+}));
+
+vi.mock('@/hooks/useToast', () => ({
+  useToast: () => ({ toast: vi.fn() }),
+}));
+
+vi.mock('@/components/NoteContent', () => ({
+  NoteContent: ({ event }: { event: NostrEvent }) => <span>{event.content}</span>,
+}));
+
+vi.mock('@/components/SmartLink', () => ({
+  SmartLink: ({ children }: { children: ReactNode }) => <span>{children}</span>,
+}));
+
+vi.mock('@/components/ReportContentDialog', () => ({ ReportContentDialog: () => null }));
+vi.mock('@/components/DeleteCommentDialog', () => ({ DeleteCommentDialog: () => null }));
+vi.mock('./CommentForm', () => ({ CommentForm: () => null }));
+
+vi.mock('@/components/ui/avatar', () => ({
+  Avatar: ({ children }: { children: ReactNode }) => <span>{children}</span>,
+  AvatarFallback: ({ children }: { children: ReactNode }) => <span>{children}</span>,
+  AvatarImage: () => null,
+}));
+
+vi.mock('@/components/ui/button', () => ({
+  Button: ({ children }: { children: ReactNode }) => <button>{children}</button>,
+}));
+
+vi.mock('@/components/ui/card', () => ({
+  Card: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  CardContent: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock('@/components/ui/collapsible', () => ({
+  Collapsible: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  CollapsibleContent: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  CollapsibleTrigger: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock('@/components/ui/dropdown-menu', () => ({
+  DropdownMenu: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  DropdownMenuContent: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  DropdownMenuItem: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  DropdownMenuSeparator: () => null,
+  DropdownMenuTrigger: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+import { Comment } from './Comment';
+
+function makeComment(pubkey: string, content: string): NostrEvent {
+  return {
+    id: pubkey,
+    pubkey,
+    created_at: 1_700_000_000,
+    kind: 1111,
+    tags: [],
+    content,
+    sig: 'c'.repeat(128),
+  };
+}
+
+describe('Comment', () => {
+  beforeEach(() => {
+    authorMetadata.clear();
+  });
+
+  it('renders display_name when the commenter name is empty', () => {
+    authorMetadata.set(COMMENTER_PUBKEY, {
+      name: '',
+      display_name: 'Visible Commenter',
+      picture: 'https://example.com/commenter.png',
+    });
+
+    render(<Comment root={new URL('https://example.com/video')} comment={makeComment(COMMENTER_PUBKEY, 'Hello')} />);
+
+    expect(screen.getByText('Visible Commenter')).toBeInTheDocument();
+  });
+
+  it('renders the parent display_name in a reply preview when its name is empty', () => {
+    authorMetadata.set(COMMENTER_PUBKEY, { name: 'reply-author' });
+    authorMetadata.set(PARENT_PUBKEY, {
+      name: '',
+      display_name: 'Visible Parent',
+      picture: 'https://example.com/parent.png',
+    });
+
+    render(
+      <Comment
+        root={new URL('https://example.com/video')}
+        comment={makeComment(COMMENTER_PUBKEY, 'Reply')}
+        parentComment={makeComment(PARENT_PUBKEY, 'Parent comment')}
+      />,
+    );
+
+    expect(screen.getByText('Visible Parent')).toBeInTheDocument();
+  });
+});

--- a/src/components/comments/Comment.tsx
+++ b/src/components/comments/Comment.tsx
@@ -25,7 +25,7 @@ import {
 } from '@/components/ui/dropdown-menu';
 import { Chat as MessageSquare, CaretDown as ChevronDown, CaretRight as ChevronRight, DotsThree as MoreHorizontal, Flag, SpeakerHigh as Volume2, Trash as Trash2, ArrowBendDownRight as CornerDownRight } from '@phosphor-icons/react';
 import { formatDistanceToNow } from 'date-fns';
-import { genUserName } from '@/lib/genUserName';
+import { resolveDisplayName } from '@/lib/resolveDisplayName';
 import { MuteType } from '@/types/moderation';
 import { useToast } from '@/hooks/useToast';
 
@@ -54,7 +54,7 @@ export function Comment({ root, comment, depth = 0, maxDepth = 3, limit, parentC
   const { toast } = useToast();
 
   const metadata = author.data?.metadata;
-  const displayName = metadata?.name ?? genUserName(comment.pubkey)
+  const displayName = resolveDisplayName(metadata, comment.pubkey);
   const timeAgo = formatDistanceToNow(new Date(comment.created_at * 1000), { addSuffix: true });
 
   // Get direct replies to this comment
@@ -69,7 +69,9 @@ export function Comment({ root, comment, depth = 0, maxDepth = 3, limit, parentC
   // Parent comment data (passed as prop when this is a reply)
   const parentAuthor = useAuthor(parentComment?.pubkey || '');
   const parentMetadata = parentAuthor.data?.metadata;
-  const parentDisplayName = parentComment ? (parentMetadata?.name ?? genUserName(parentComment.pubkey)) : '';
+  const parentDisplayName = parentComment
+    ? resolveDisplayName(parentMetadata, parentComment.pubkey)
+    : '';
 
   const handleReportComment = () => {
     setReportType('comment');

--- a/src/hooks/useHydratedNotifications.ts
+++ b/src/hooks/useHydratedNotifications.ts
@@ -6,7 +6,7 @@ import { keepPreviousData, useQuery, useQueryClient } from '@tanstack/react-quer
 import { API_CONFIG } from '@/config/api';
 import { fetchBulkVideos, fetchVideoById } from '@/lib/funnelcakeClient';
 import { isFunnelcakeAvailable } from '@/lib/funnelcakeHealth';
-import { genUserName } from '@/lib/genUserName';
+import { resolveDisplayName } from '@/lib/resolveDisplayName';
 import { getSafeProfileImage, getSafeThumbnailUrl } from '@/lib/imageUtils';
 import { groupRawNotifications, type NotificationVideoMeta } from '@/lib/notificationGrouping';
 import { useNotifications } from '@/hooks/useNotifications';
@@ -255,8 +255,7 @@ function buildProfilesMap(
     const author = authorsData[pubkey];
     const metadata = author?.metadata;
 
-    const displayName =
-      metadata?.display_name || metadata?.name || genUserName(pubkey);
+    const displayName = resolveDisplayName(metadata, pubkey);
 
     map.set(pubkey, {
       pubkey,

--- a/src/lib/conversationDisplay.test.ts
+++ b/src/lib/conversationDisplay.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest';
+
+import { getConversationSubtitle } from '@/lib/conversationDisplay';
+import { genUserName } from '@/lib/genUserName';
+
+const PUBKEY = 'b'.repeat(64);
+
+describe('getConversationSubtitle', () => {
+  it('keeps display_name out of a generated @handle when name and nip05 are absent', () => {
+    expect(getConversationSubtitle(PUBKEY, {
+      name: '',
+      display_name: 'Display Name With Spaces',
+    })).toBe(`@${genUserName(PUBKEY)}`);
+  });
+});

--- a/src/lib/conversationDisplay.ts
+++ b/src/lib/conversationDisplay.ts
@@ -1,9 +1,19 @@
+// ABOUTME: Subtitle for a DM conversation header - a NIP-05 address or an @handle.
+// ABOUTME: Handle surface, so it stays name-only and never falls back to display_name.
+
 import { DIVINE_SUPPORT_PUBKEY } from '@/lib/dm';
 import { genUserName } from '@/lib/genUserName';
 import { getDivineNip05Info } from '@/lib/nip05Utils';
 
 type Translate = (key: string, opts?: Record<string, unknown>) => string;
 
+/**
+ * Build the conversation subtitle shown under a peer's name.
+ *
+ * Deliberately ignores display_name: the result is rendered behind an `@`, and a
+ * handle of `@Some Display Name` is neither valid nor actionable. An absent name
+ * falls through to the generated name, which is handle-shaped.
+ */
 export function getConversationSubtitle(
   pubkey: string,
   metadata?: { display_name?: string; name?: string; nip05?: string },

--- a/src/lib/conversationDisplay.ts
+++ b/src/lib/conversationDisplay.ts
@@ -1,0 +1,29 @@
+import { DIVINE_SUPPORT_PUBKEY } from '@/lib/dm';
+import { genUserName } from '@/lib/genUserName';
+import { getDivineNip05Info } from '@/lib/nip05Utils';
+
+type Translate = (key: string, opts?: Record<string, unknown>) => string;
+
+export function getConversationSubtitle(
+  pubkey: string,
+  metadata?: { display_name?: string; name?: string; nip05?: string },
+  translate?: Translate,
+): string {
+  if (pubkey === DIVINE_SUPPORT_PUBKEY) {
+    return translate
+      ? translate('conversationPage.privateSupportChat')
+      : 'Private support chat';
+  }
+
+  const nip05 = metadata?.nip05?.trim();
+  if (nip05) {
+    const divineInfo = getDivineNip05Info(nip05);
+    if (divineInfo) {
+      return divineInfo.displayName;
+    }
+
+    return nip05.startsWith('_@') ? `@${nip05.slice(2)}` : `@${nip05}`;
+  }
+
+  return `@${metadata?.name || genUserName(pubkey)}`;
+}

--- a/src/lib/resolveDisplayName.test.ts
+++ b/src/lib/resolveDisplayName.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+
+import { genUserName } from '@/lib/genUserName';
+import { resolveDisplayName } from '@/lib/resolveDisplayName';
+
+const PUBKEY = 'a'.repeat(64);
+
+describe('resolveDisplayName', () => {
+  it('prefers display_name when both fields are set', () => {
+    expect(resolveDisplayName({ display_name: 'Display Name', name: 'handle' }, PUBKEY))
+      .toBe('Display Name');
+  });
+
+  it('uses name when display_name is absent', () => {
+    expect(resolveDisplayName({ name: 'handle' }, PUBKEY)).toBe('handle');
+  });
+
+  it('generates a name when name is empty and display_name is absent', () => {
+    expect(resolveDisplayName({ name: '' }, PUBKEY)).toBe(genUserName(PUBKEY));
+  });
+
+  it('generates a name when name contains only whitespace', () => {
+    expect(resolveDisplayName({ name: '   ' }, PUBKEY)).toBe(genUserName(PUBKEY));
+  });
+
+  it('uses display_name when name is empty', () => {
+    expect(resolveDisplayName({ display_name: 'Visible Name', name: '' }, PUBKEY))
+      .toBe('Visible Name');
+  });
+
+  it('generates a name when metadata is absent', () => {
+    expect(resolveDisplayName(undefined, PUBKEY)).toBe(genUserName(PUBKEY));
+  });
+
+  it.each([
+    undefined,
+    {},
+    { name: '' },
+    { display_name: '' },
+    { name: '  ', display_name: '  ' },
+  ])('never returns an empty string for metadata %j', (metadata) => {
+    expect(resolveDisplayName(metadata, PUBKEY)).not.toBe('');
+  });
+});

--- a/src/lib/resolveDisplayName.ts
+++ b/src/lib/resolveDisplayName.ts
@@ -1,12 +1,24 @@
+// ABOUTME: Single source of truth for turning profile metadata into a display name.
+// ABOUTME: Treats empty and whitespace-only values as absent - Funnelcake returns name: "" widely.
+
 import type { NostrMetadata } from '@nostrify/nostrify';
 
 import { genUserName } from '@/lib/genUserName';
 
+/** Returns the trimmed value, or undefined when it is absent, empty, or whitespace-only. */
 function presentValue(value: string | undefined): string | undefined {
   const trimmed = value?.trim();
   return trimmed || undefined;
 }
 
+/**
+ * Resolve the name to show for a pubkey.
+ * Prefers display_name, then name, then a deterministic generated name.
+ * Never returns an empty string.
+ *
+ * Display-only. Do not use where the raw name/handle is wanted: if the string is
+ * about to be prefixed with `@`, it is a handle, not a display name.
+ */
 export function resolveDisplayName(
   metadata: Pick<NostrMetadata, 'display_name' | 'name'> | undefined,
   pubkey: string,

--- a/src/lib/resolveDisplayName.ts
+++ b/src/lib/resolveDisplayName.ts
@@ -1,0 +1,17 @@
+import type { NostrMetadata } from '@nostrify/nostrify';
+
+import { genUserName } from '@/lib/genUserName';
+
+function presentValue(value: string | undefined): string | undefined {
+  const trimmed = value?.trim();
+  return trimmed || undefined;
+}
+
+export function resolveDisplayName(
+  metadata: Pick<NostrMetadata, 'display_name' | 'name'> | undefined,
+  pubkey: string,
+): string {
+  return presentValue(metadata?.display_name)
+    ?? presentValue(metadata?.name)
+    ?? genUserName(pubkey);
+}

--- a/src/pages/ConversationPage.tsx
+++ b/src/pages/ConversationPage.tsx
@@ -29,9 +29,9 @@ import { createDmClientId } from '@/lib/dmOutbox';
 import { isThreadAllowedForProtectedMinor } from '@/lib/dmInboundFilter';
 import { officialAccountsService } from '@/lib/officialAccounts';
 import { isMinorDmRestricted } from '@/lib/protectedMinor';
-import { genUserName } from '@/lib/genUserName';
+import { getConversationSubtitle } from '@/lib/conversationDisplay';
+import { resolveDisplayName } from '@/lib/resolveDisplayName';
 import { getSafeProfileImage } from '@/lib/imageUtils';
-import { getDivineNip05Info } from '@/lib/nip05Utils';
 import { formatRelativeTime } from '@/lib/notificationTransform';
 import { cn } from '@/lib/utils';
 
@@ -44,29 +44,7 @@ function getDisplayName(pubkey: string, metadata?: { display_name?: string; name
     return metadata?.display_name || metadata?.name || (t ? t('conversationPage.divineSupport') : 'Divine Support');
   }
 
-  return metadata?.display_name || metadata?.name || genUserName(pubkey);
-}
-
-function getConversationSubtitle(
-  pubkey: string,
-  metadata?: { name?: string; nip05?: string },
-  t?: TFn,
-) {
-  if (pubkey === DIVINE_SUPPORT_PUBKEY) {
-    return t ? t('conversationPage.privateSupportChat') : 'Private support chat';
-  }
-
-  const nip05 = metadata?.nip05?.trim();
-  if (nip05) {
-    const divineInfo = getDivineNip05Info(nip05);
-    if (divineInfo) {
-      return divineInfo.displayName;
-    }
-
-    return nip05.startsWith('_@') ? `@${nip05.slice(2)}` : `@${nip05}`;
-  }
-
-  return `@${metadata?.name || genUserName(pubkey)}`;
+  return resolveDisplayName(metadata, pubkey);
 }
 
 function MessageBubble({

--- a/src/pages/EventPage.tsx
+++ b/src/pages/EventPage.tsx
@@ -21,7 +21,7 @@ import {
 import { getDirectSearchTarget } from '@/lib/directSearch';
 import { appendRelayHints, parseRelayHints } from '@/lib/relayHints';
 import { getEventLookupRelayUrls } from '@/config/relays';
-import { genUserName } from '@/lib/genUserName';
+import { resolveDisplayName } from '@/lib/resolveDisplayName';
 import { getSafeProfileImage } from '@/lib/imageUtils';
 import { NoteContent } from '@/components/NoteContent';
 import { SmartLink } from '@/components/SmartLink';
@@ -172,9 +172,7 @@ export function EventPage() {
 
   const author = useAuthor(event?.pubkey || '');
   const authorName = event
-    ? author.data?.metadata?.display_name
-      || author.data?.metadata?.name
-      || genUserName(event.pubkey)
+    ? resolveDisplayName(author.data?.metadata, event.pubkey)
     : '';
   const authorImage = getSafeProfileImage(author.data?.metadata?.picture);
   const authorNpub = event ? nip19.npubEncode(event.pubkey) : '';

--- a/src/pages/ListsPage.tsx
+++ b/src/pages/ListsPage.tsx
@@ -16,7 +16,7 @@ import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigge
 import { Skeleton } from '@/components/ui/skeleton';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import { List, TrendUp as TrendingUp, Plus, Users, VideoCamera as Video, Clock } from '@phosphor-icons/react';
-import { genUserName } from '@/lib/genUserName';
+import { resolveDisplayName } from '@/lib/resolveDisplayName';
 import { buildListPath } from '@/lib/eventRouting';
 import { CreateListDialog } from '@/components/CreateListDialog';
 import { CreatePeopleListDialog } from '@/components/CreatePeopleListDialog';
@@ -28,7 +28,7 @@ function ListCard({ list }: { list: VideoListModel }) {
   const { t } = useTranslation();
   const author = useAuthor(list.pubkey);
   const authorMetadata = author.data?.metadata;
-  const authorName = authorMetadata?.name || genUserName(list.pubkey);
+  const authorName = resolveDisplayName(authorMetadata, list.pubkey);
 
   return (
     <Card className="hover:shadow-lg transition-shadow">

--- a/src/pages/ModerationSettingsPage.tsx
+++ b/src/pages/ModerationSettingsPage.tsx
@@ -34,7 +34,7 @@ import {
 import { Shield, UserMinus as UserX, Hash, TextAa as Type, Plus, Flag, Trash as Trash2, WarningCircle as AlertCircle } from '@phosphor-icons/react';
 import { useToast } from '@/hooks/useToast';
 import { MuteType, REPORT_REASON_LABELS, type MuteItem } from '@/types/moderation';
-import { genUserName } from '@/lib/genUserName';
+import { resolveDisplayName } from '@/lib/resolveDisplayName';
 import { getSafeProfileImage } from '@/lib/imageUtils';
 import {
   getFunnelcakeApiModeOverride,
@@ -66,7 +66,7 @@ function MutedUserItem({ pubkey, reason, onUnmute, actionLabel, confirmDescripti
   const { t } = useTranslation();
   const author = useAuthor(pubkey);
   const authorMetadata = author.data?.metadata;
-  const authorName = authorMetadata?.name || genUserName(pubkey);
+  const authorName = resolveDisplayName(authorMetadata, pubkey);
 
   return (
     <div className="flex items-center justify-between gap-3 p-3 rounded-lg border">

--- a/src/pages/PeopleListDetailPage.tsx
+++ b/src/pages/PeopleListDetailPage.tsx
@@ -21,7 +21,7 @@ import { usePeopleList } from '@/hooks/usePeopleLists';
 import { usePeopleListVideos } from '@/hooks/usePeopleListVideos';
 import { useShare } from '@/hooks/useShare';
 import { useToast } from '@/hooks/useToast';
-import { genUserName } from '@/lib/genUserName';
+import { resolveDisplayName } from '@/lib/resolveDisplayName';
 import { getSafeProfileImage } from '@/lib/imageUtils';
 import { buildProfileLinkPath } from '@/lib/profileLinks';
 import { parseRelayHints } from '@/lib/relayHints';
@@ -71,7 +71,7 @@ function PeopleListContent({
   const videosQuery = usePeopleListVideos(memberPubkeys);
   const videos = videosQuery.data?.pages.flatMap((page) => page.videos) ?? [];
   const authorMetadata = author.data?.metadata;
-  const authorName = authorMetadata?.display_name || authorMetadata?.name || genUserName(pubkey);
+  const authorName = resolveDisplayName(authorMetadata, pubkey);
   const isOwner = user?.pubkey === pubkey;
 
   const handleShare = () => {

--- a/src/pages/ProfilePage.tsx
+++ b/src/pages/ProfilePage.tsx
@@ -41,7 +41,7 @@ import { useLoginDialog } from '@/contexts/LoginDialogContext';
 import { toast } from '@/hooks/useToast';
 import { debugLog } from '@/lib/debug';
 import { useNip05Validation } from '@/hooks/useNip05Validation';
-import { genUserName } from '@/lib/genUserName';
+import { resolveDisplayName } from '@/lib/resolveDisplayName';
 import { parseLegacySocials } from '@/lib/legacySocials';
 import { buildProfileStats } from '@/lib/profileStats';
 import { buildProfileLinkPath } from '@/lib/profileLinks';
@@ -253,7 +253,9 @@ export function ProfilePage({ pubkeyOverride }: { pubkeyOverride?: string } = {}
     !!currentUser?.pubkey // Only check if user is logged in
   );
 
-  const displayName = metadata?.display_name || metadata?.name || (pubkey ? genUserName(pubkey) : t('profilePage.defaultUser'));
+  const displayName = pubkey
+    ? resolveDisplayName(metadata, pubkey)
+    : t('profilePage.defaultUser');
 
   // RSS auto-discovery link for feed readers (only if feed endpoints exist)
   const rssFeedAvailable = useRssFeedAvailable();

--- a/src/pages/SearchPage.tsx
+++ b/src/pages/SearchPage.tsx
@@ -23,6 +23,7 @@ import { useSearchUsers } from '@/hooks/useSearchUsers';
 import { useSearchHashtags, type HashtagResult } from '@/hooks/useSearchHashtags';
 import { getFunnelcakeBaseUrl } from '@/config/api';
 import { genUserName } from '@/lib/genUserName';
+import { resolveDisplayName } from '@/lib/resolveDisplayName';
 import { getSafeProfileImage } from '@/lib/imageUtils';
 import type { SortMode } from '@/types/nostr';
 import { SEARCH_SORT_MODES as SORT_MODES } from '@/lib/constants/sortModes';
@@ -790,7 +791,7 @@ interface UserCardMetadata {
 // User card component
 function UserCard({ user }: { user: { pubkey: string; metadata?: UserCardMetadata } }) {
   const navigate = useSubdomainNavigate();
-  const displayName = user.metadata?.display_name || user.metadata?.name || genUserName(user.pubkey);
+  const displayName = resolveDisplayName(user.metadata, user.pubkey);
   const username = user.metadata?.name || genUserName(user.pubkey);
   const nip05 = user.metadata?.nip05;
   const { state: nip05State } = useNip05Validation(nip05, user.pubkey);


### PR DESCRIPTION
## Summary

- Show profile display names in comments, reply previews, repost bylines, account switching, and other display-name surfaces when the profile handle is empty.
- Centralize display-name resolution so empty and whitespace-only values fall through consistently.
- Preserve raw `name` handling anywhere the UI builds an `@handle`.

## Motivation

Funnelcake legitimately returns profiles with an empty `name` and a populated `display_name`. Comment rendering used nullish fallback and skipped `display_name`, leaving blank name rows even though the rest of the profile loaded. Other display surfaces either generated a placeholder or duplicated slightly different fallback rules.

The fetch layer remains unchanged because `name` and `display_name` serve different purposes. Display surfaces now prefer `display_name`, while handle surfaces continue using only `name` or a generated handle. `NoteContent` and `InlineNostrText` now follow the shared display-name priority when both fields exist. Existing custom fallbacks that also consider cached video author names or reject hex-like names remain unchanged.

## Related Issue

- Closes #681

## Testing

- [x] `npm run test`
- [ ] Manual verification completed
- Added regressions for top-level comments, reply previews, account switching, reposter bylines, whitespace-only metadata, and the `@handle` boundary.

## Visuals

- [ ] UI change with screenshots/video attached
- [x] No visual style change
- [x] Visuals and text avoid sensitive external brand or partner names unless explicitly approved