### PR TITLE
fix(ci): retry dropped connections in the OG parity audit

### DIFF
--- a/scripts/verify-og-tags.sh
+++ b/scripts/verify-og-tags.sh
@@ -96,19 +96,49 @@ run_check() {
   local url="${BASE_URL}${path}"
   local tmp_headers
   local tmp_body
+  local tmp_error
   tmp_headers=$(mktemp)
   tmp_body=$(mktemp)
+  tmp_error=$(mktemp)
   local cleanup_needed=true
-  trap '[[ "${cleanup_needed:-false}" == "true" ]] && rm -f "$tmp_headers" "$tmp_body"' RETURN
+  trap '[[ "${cleanup_needed:-false}" == "true" ]] && rm -f "$tmp_headers" "$tmp_body" "$tmp_error"' RETURN
   cleanup_needed=true
 
+  # This audit makes ~64 live requests to a CDN edge per run, so a single dropped
+  # connection used to fail the whole deploy gate. Retry transport errors before
+  # calling it a parity failure. --retry-max-time keeps a genuinely unreachable
+  # origin from stacking 30s timeouts on every route.
   local http_code
-  http_code=$(curl -s -L --max-time 30 --compressed \
+  local curl_exit=0
+  http_code=$(curl -sS -L --max-time 30 --compressed \
+    --retry 2 --retry-delay 1 --retry-connrefused --retry-all-errors --retry-max-time 30 \
     -A "$ua_value" \
     -D "$tmp_headers" \
     -o "$tmp_body" \
     -w '%{http_code}' \
-    "$url" 2>/dev/null || echo "000")
+    "$url" 2>"$tmp_error") || curl_exit=$?
+
+  if [[ ${curl_exit} -ne 0 ]]; then
+    # curl's own diagnostics, not an HTTP status: report them as such so the log
+    # distinguishes "the edge served the wrong tags" from "the request never landed".
+    local curl_error
+    curl_error=$(tr -d '\r' < "$tmp_error" | grep -v '^[[:space:]]*$' | tail -1)
+    echo "  X ${ua_label} -> ${path} (network error after retries: curl exit ${curl_exit}${curl_error:+ - ${curl_error}})"
+    failed_checks=$((failed_checks + 1))
+    failures+=("${ua_label} ${path}: network error (curl exit ${curl_exit})")
+    return 1
+  fi
+
+  # curl only writes to stderr here when an attempt failed, so a non-empty file
+  # on an otherwise successful request means a retry saved us. Retries that
+  # succeeded still say something about edge health — surface them rather than
+  # swallowing the only evidence we have. (The wording of curl's retry notice
+  # varies by version, so key off "wrote anything at all", not a phrase.)
+  if [[ -s "$tmp_error" ]]; then
+    local recovered_from
+    recovered_from=$(tr -d '\r' < "$tmp_error" | grep -v '^[[:space:]]*$' | head -1)
+    echo "  ~ ${ua_label} -> ${path} (recovered after a transient network error${recovered_from:+ - ${recovered_from}})"
+  fi
 
   local body
   body=$(cat "$tmp_body")
@@ -244,13 +274,13 @@ run_check() {
     fi
     passed_checks=$((passed_checks + 1))
     cleanup_needed=false
-    rm -f "$tmp_headers" "$tmp_body"
+    rm -f "$tmp_headers" "$tmp_body" "$tmp_error"
     return 0
   else
     failed_checks=$((failed_checks + 1))
     failures+=("${ua_label} ${path} (${description})")
     cleanup_needed=false
-    rm -f "$tmp_headers" "$tmp_body"
+    rm -f "$tmp_headers" "$tmp_body" "$tmp_error"
     return 1
   fi
 }
@@ -299,10 +329,19 @@ print_summary() {
 main() {
   print_header
 
-  if ! curl -sI --max-time 10 "${BASE_URL}/" >/dev/null 2>&1; then
+  local preflight_error
+  preflight_error=$(mktemp)
+  if ! curl -sSI --max-time 10 \
+    --retry 2 --retry-delay 1 --retry-connrefused --retry-all-errors --retry-max-time 30 \
+    "${BASE_URL}/" >/dev/null 2>"$preflight_error"; then
+    # Print curl's reason. Without it an unsupported flag or a TLS failure both
+    # read as "the site is down", which sends people looking in the wrong place.
     echo "ERROR: cannot reach ${BASE_URL}"
+    tr -d '\r' < "$preflight_error" | grep -v '^[[:space:]]*$' | sed 's/^/       /'
+    rm -f "$preflight_error"
     exit 2
   fi
+  rm -f "$preflight_error"
 
   for route_entry in "${ROUTES[@]}"; do
     local path="${route_entry%%|*}"

--- a/scripts/verify-og-tags.sh
+++ b/scripts/verify-og-tags.sh
@@ -86,6 +86,23 @@ extract_meta() {
   LC_ALL=C printf '%s' "$body" | grep -aoE "<meta ${attr}=\"${key}\" content=\"[^\"]*\"" | head -1 | sed -E "s/<meta ${attr}=\"${key}\" content=\"([^\"]*)\"/\1/"
 }
 
+extract_final_response_headers() {
+  local header_file="$1"
+  local response_headers=""
+  local header_line
+
+  while IFS= read -r header_line || [[ -n "$header_line" ]]; do
+    header_line="${header_line%$'\r'}"
+    if [[ "$header_line" == HTTP/* ]]; then
+      response_headers="$header_line"
+    elif [[ -n "$response_headers" ]]; then
+      response_headers+=$'\n'"$header_line"
+    fi
+  done < "$header_file"
+
+  printf '%s' "$response_headers"
+}
+
 run_check() {
   local path="$1"
   local description="$2"
@@ -108,14 +125,14 @@ run_check() {
   # connection used to fail the whole deploy gate. Retry transport errors before
   # calling it a parity failure. --retry-max-time keeps a genuinely unreachable
   # origin from stacking 30s timeouts on every route.
-  local http_code
+  local curl_result
   local curl_exit=0
-  http_code=$(curl -sS -L --max-time 30 --compressed \
+  curl_result=$(curl -sS -L --max-time 30 --compressed \
     --retry 2 --retry-delay 1 --retry-connrefused --retry-all-errors --retry-max-time 30 \
     -A "$ua_value" \
     -D "$tmp_headers" \
     -o "$tmp_body" \
-    -w '%{http_code}' \
+    -w '%{http_code}|%{num_redirects}' \
     "$url" 2>"$tmp_error") || curl_exit=$?
 
   if [[ ${curl_exit} -ne 0 ]]; then
@@ -129,21 +146,23 @@ run_check() {
     return 1
   fi
 
-  # curl only writes to stderr here when an attempt failed, so a non-empty file
-  # on an otherwise successful request means a retry saved us. Retries that
-  # succeeded still say something about edge health — surface them rather than
-  # swallowing the only evidence we have. (The wording of curl's retry notice
-  # varies by version, so key off "wrote anything at all", not a phrase.)
+  local http_code="${curl_result%%|*}"
+  local redirect_count="${curl_result##*|}"
+  local response_count
+  response_count=$(grep -c '^HTTP/' "$tmp_headers")
+
   if [[ -s "$tmp_error" ]]; then
     local recovered_from
     recovered_from=$(tr -d '\r' < "$tmp_error" | grep -v '^[[:space:]]*$' | head -1)
     echo "  ~ ${ua_label} -> ${path} (recovered after a transient network error${recovered_from:+ - ${recovered_from}})"
+  elif [[ ${response_count} -gt $((redirect_count + 1)) ]]; then
+    echo "  ~ ${ua_label} -> ${path} (recovered after a transient HTTP error)"
   fi
 
   local body
   body=$(cat "$tmp_body")
   local headers
-  headers=$(cat "$tmp_headers")
+  headers=$(extract_final_response_headers "$tmp_headers")
 
   if [[ "$http_code" != "200" ]]; then
     echo "  X ${ua_label} -> ${path} (HTTP ${http_code})"
@@ -184,7 +203,7 @@ run_check() {
         fi
         ;;
       frame_ancestors_header)
-        if grep -qi '^content-security-policy:.*frame-ancestors' "$tmp_headers"; then
+        if grep -qi '^content-security-policy:.*frame-ancestors' <<< "$headers"; then
           :
         else
           all_passed=false
@@ -192,7 +211,7 @@ run_check() {
         fi
         ;;
       noindex_header)
-        if grep -qi '^x-robots-tag:.*noindex' "$tmp_headers"; then
+        if grep -qi '^x-robots-tag:.*noindex' <<< "$headers"; then
           :
         else
           all_passed=false

--- a/tests/verify-og-tags-network-resilience.test.ts
+++ b/tests/verify-og-tags-network-resilience.test.ts
@@ -51,7 +51,11 @@ type Fixture = {
  * @param dropPlan path -> how many times to drop the connection before serving normally.
  *   Use Infinity for a route that never recovers.
  */
-async function startFixture(dropPlan: Record<string, number> = {}): Promise<Fixture> {
+async function startFixture(
+  dropPlan: Record<string, number> = {},
+  staleHeaderPath?: string,
+  transientStatusPath?: string,
+): Promise<Fixture> {
   const drops = new Map<string, number>();
 
   const server = createServer((request, response) => {
@@ -59,6 +63,27 @@ async function startFixture(dropPlan: Record<string, number> = {}): Promise<Fixt
     const pathOnly = requestPath.split('?')[0];
     const budget = dropPlan[pathOnly] ?? 0;
     const dropped = drops.get(pathOnly) ?? 0;
+
+    if (pathOnly === transientStatusPath && dropped === 0) {
+      drops.set(pathOnly, 1);
+      response.writeHead(503, { 'content-type': 'text/plain' });
+      response.end('try again');
+      return;
+    }
+
+    if (pathOnly === staleHeaderPath && dropped === 0) {
+      drops.set(pathOnly, 1);
+      response.writeHead(200, {
+        'content-length': '10000',
+        'content-security-policy': "frame-ancestors 'self' https:",
+        'content-type': 'text/html; charset=utf-8',
+        'x-robots-tag': 'noindex',
+      });
+      response.flushHeaders();
+      response.write('<!doctype html>');
+      setTimeout(() => response.socket?.destroy(), 10);
+      return;
+    }
 
     if (dropped < budget) {
       drops.set(pathOnly, dropped + 1);
@@ -68,11 +93,14 @@ async function startFixture(dropPlan: Record<string, number> = {}): Promise<Fixt
 
     const baseUrl = `http://127.0.0.1:${(server.address() as AddressInfo).port}`;
 
-    response.writeHead(200, {
-      'content-security-policy': "frame-ancestors 'self' https:",
+    const headers: Record<string, string> = {
       'content-type': 'text/html; charset=utf-8',
-      'x-robots-tag': 'noindex',
-    });
+    };
+    if (pathOnly !== staleHeaderPath) {
+      headers['content-security-policy'] = "frame-ancestors 'self' https:";
+      headers['x-robots-tag'] = 'noindex';
+    }
+    response.writeHead(200, headers);
     response.end(request.method === 'HEAD' ? '' : pageFor(baseUrl, requestPath));
   });
 
@@ -143,5 +171,28 @@ describe('verify-og-tags.sh network resilience', () => {
     expect(output).toMatch(/network error.*curl exit \d+/);
     expect(output).toContain('FAILED: 1 of 16 checks did not pass');
     expect(status).toBe(1);
+  }, 60_000);
+
+  it('does not accept headers from a discarded retry attempt', async () => {
+    const embedPath = '/embed/3ca833a0027dd6240b2956dec98643032ff43ee75c0f0cde9d2096186b4b2605';
+    fixture = await startFixture({}, embedPath);
+
+    const { output, status } = await runAudit(fixture.baseUrl);
+
+    expect(fixture.drops.get(embedPath)).toBe(1);
+    expect(output).toContain('missing Content-Security-Policy: frame-ancestors header');
+    expect(output).toContain('missing X-Robots-Tag: noindex header');
+    expect(status).toBe(1);
+  }, 60_000);
+
+  it('reports a recovered HTTP retry', async () => {
+    fixture = await startFixture({}, undefined, '/discovery');
+
+    const { output, status } = await runAudit(fixture.baseUrl);
+
+    expect(fixture.drops.get('/discovery')).toBe(1);
+    expect(output).toContain('recovered after a transient HTTP error');
+    expect(output).toContain('All checks passed.');
+    expect(status).toBe(0);
   }, 60_000);
 });

--- a/tests/verify-og-tags-network-resilience.test.ts
+++ b/tests/verify-og-tags-network-resilience.test.ts
@@ -1,0 +1,147 @@
+// ABOUTME: Pins verify-og-tags.sh to survive a transient network blip against the live edge
+// ABOUTME: One dropped connection out of 64 must not fail the deploy-gating OG parity audit
+
+import { spawn } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { createServer, type Server } from 'node:http';
+import type { AddressInfo } from 'node:net';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+const SCRIPT = 'scripts/verify-og-tags.sh';
+
+// Must match the SPA shell fallback the script asserts on.
+const BRAND_TITLE = 'Divine Web - Short-form Looping Videos on Nostr';
+
+// Read from the script so the fixture cannot drift from the route table.
+const SYNTHETIC_NPUB = (() => {
+  const source = readFileSync(SCRIPT, 'utf8');
+  const match = source.match(/^SYNTHETIC_NPUB="([^"]+)"/m);
+
+  if (!match) {
+    throw new Error(`Could not read SYNTHETIC_NPUB from ${SCRIPT}`);
+  }
+
+  return match[1];
+})();
+
+/** Body that satisfies every assertion the script makes, for every route. */
+function pageFor(baseUrl: string, requestPath: string): string {
+  const title = requestPath.includes(SYNTHETIC_NPUB) ? BRAND_TITLE : 'Test Route Title';
+
+  return [
+    '<!doctype html><html><head>',
+    `<meta property="og:title" content="${title}">`,
+    `<meta property="og:url" content="${baseUrl}${requestPath}">`,
+    '<meta property="og:video" content="https://example.test/v.mp4">',
+    '<meta name="twitter:card" content="player">',
+    '<meta name="twitter:player" content="https://example.test/embed">',
+    '</head><body><video src="https://example.test/v.mp4"></video></body></html>',
+  ].join('');
+}
+
+type Fixture = {
+  baseUrl: string;
+  /** Number of connections dropped so far, keyed by path. */
+  drops: Map<string, number>;
+  server: Server;
+};
+
+/**
+ * @param dropPlan path -> how many times to drop the connection before serving normally.
+ *   Use Infinity for a route that never recovers.
+ */
+async function startFixture(dropPlan: Record<string, number> = {}): Promise<Fixture> {
+  const drops = new Map<string, number>();
+
+  const server = createServer((request, response) => {
+    const requestPath = request.url ?? '/';
+    const pathOnly = requestPath.split('?')[0];
+    const budget = dropPlan[pathOnly] ?? 0;
+    const dropped = drops.get(pathOnly) ?? 0;
+
+    if (dropped < budget) {
+      drops.set(pathOnly, dropped + 1);
+      request.socket.destroy();
+      return;
+    }
+
+    const baseUrl = `http://127.0.0.1:${(server.address() as AddressInfo).port}`;
+
+    response.writeHead(200, {
+      'content-security-policy': "frame-ancestors 'self' https:",
+      'content-type': 'text/html; charset=utf-8',
+      'x-robots-tag': 'noindex',
+    });
+    response.end(request.method === 'HEAD' ? '' : pageFor(baseUrl, requestPath));
+  });
+
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+
+  return {
+    baseUrl: `http://127.0.0.1:${(server.address() as AddressInfo).port}`,
+    drops,
+    server,
+  };
+}
+
+/**
+ * Must stay async: the fixture server shares this process's event loop, so a
+ * synchronous spawn would deadlock the audit's own requests.
+ */
+function runAudit(baseUrl: string): Promise<{ output: string; status: number | null }> {
+  return new Promise((resolve) => {
+    const child = spawn('bash', [SCRIPT], {
+      env: { ...process.env, BASE_URL: baseUrl, UA_ONLY: 'slackbot' },
+    });
+
+    let output = '';
+    child.stdout.on('data', (chunk) => (output += chunk));
+    child.stderr.on('data', (chunk) => (output += chunk));
+    child.on('close', (status) => resolve({ output, status }));
+  });
+}
+
+describe('verify-og-tags.sh network resilience', () => {
+  let fixture: Fixture | undefined;
+
+  afterEach(async () => {
+    if (fixture) {
+      // curl leaves keep-alive sockets open; close() alone would wait them out.
+      fixture.server.closeAllConnections();
+      await new Promise<void>((resolve) => fixture!.server.close(() => resolve()));
+      fixture = undefined;
+    }
+  });
+
+  it('passes when every route responds', async () => {
+    fixture = await startFixture();
+
+    const { output, status } = await runAudit(fixture.baseUrl);
+
+    expect(output).toContain('All checks passed.');
+    expect(status).toBe(0);
+  }, 60_000);
+
+  it('retries a route whose connection is dropped once', async () => {
+    fixture = await startFixture({ '/discovery': 1 });
+
+    const { output, status } = await runAudit(fixture.baseUrl);
+
+    expect(fixture.drops.get('/discovery')).toBe(1);
+    expect(output).toContain('recovered after a transient network error');
+    expect(output).toContain('All checks passed.');
+    expect(status).toBe(0);
+  }, 60_000);
+
+  it('reports a persistent connection drop as a network error, not HTTP 000000', async () => {
+    fixture = await startFixture({ '/discovery': Number.POSITIVE_INFINITY });
+
+    const { output, status } = await runAudit(fixture.baseUrl);
+
+    expect(output).not.toContain('000000');
+    expect(output).toMatch(/network error.*curl exit \d+/);
+    expect(output).toContain('FAILED: 1 of 16 checks did not pass');
+    expect(status).toBe(1);
+  }, 60_000);
+});


### PR DESCRIPTION
## Summary

- Retry transport failures and curl's built-in transient HTTP set before calling a check a parity failure. The audit fires ~64 live requests at the CDN edge per run with no retry, so one dropped connection failed the whole deploy gate.
- Report network errors *as* network errors, with curl's exit code and message. Transport failures were previously printed as an HTTP status, and curl's stderr was discarded — the log read `HTTP 000000` with no way to tell a reset connection from a real bad response. (The doubled `000` was `http_code=$(curl … || echo "000")` concatenating curl's `%{http_code}` output with the fallback.)
- Log recovered transport and transient HTTP retries so edge flakiness stays observable instead of silently swallowed.
- Validate headers only from curl's final response. Failed retry attempts and redirects can no longer satisfy the embed-page CSP or `X-Robots-Tag` assertions.
- Print curl's reason when the preflight reachability check fails, so a TLS error or an unsupported flag no longer reads as "the site is down".

Wrong-tag responses and persistent HTTP failures still fail the gate. Curl retries transport errors plus its built-in transient HTTP statuses (408, 429, 500, 502, 503, and 504).

## Motivation

[Run 32740711299](https://github.com/divinevideo/divine-web/actions/runs/32740711299) failed on 3 of 64 checks in the production audit:

```
X discord /discovery: HTTP 000000
X twitter /discovery/classics: HTTP 000000
X discord /: HTTP 000000
```

Nothing was actually broken in the app:

- The failures are scattered across unrelated UA/route pairs, and the same paths passed for other UAs milliseconds later.
- The Cloudflare job on the same commit was green.
- The head commit (#679) touches nothing OG-related.
- Running the audit against production by hand passes 64/64.

`000` is curl's "no HTTP response at all" — a dropped connection, not a bad page. A single transient blip against a CDN edge should not fail a deploy-gating workflow, and when it does the log should say so plainly.

## Related Issue

- No linked issue — regression surfaced by the CI run linked above.

## Testing

- [x] `npm run test`
- [x] Manual verification completed

`tests/verify-og-tags-network-resilience.test.ts` runs the script against a local server and covers a clean pass, a recovered dropped connection, a persistent dropped connection, stale headers from a discarded attempt, and a recovered transient HTTP response.

Manual verification:

- Live audit against production: 64/64, no spurious retry notices.
- Preflight failure against a dead port now prints curl's reason and exits 2.
- `bash -n` and shellcheck clean on the changed code (one pre-existing `SC2034` left alone).

## Visuals

- [ ] UI change with screenshots/video attached
- [x] No visual change
- [x] Visuals and text avoid sensitive external brand or partner names unless explicitly approved
