### PR TITLE
fix(ci): alert on OG parity audit failures instead of failing the build

### DIFF
--- a/.github/workflows/og-audit.yml
+++ b/.github/workflows/og-audit.yml
@@ -3,6 +3,20 @@
 
 name: OG/Twitter Card parity audit
 
+# This audits a LIVE third-party edge, and it runs after production is already
+# serving, so a red run rolls nothing back. It is a monitor, not a gate: results
+# go to #divine-alerts (alongside deploy failures and the uptime heartbeat)
+# rather than failing the build. Run 32740711299 failed on three dropped
+# connections out of 64 — nothing was wrong with the site, and a monitor that
+# cries wolf gets ignored.
+#
+# The parity logic itself IS gated before merge, where a gate can actually
+# prevent a bad ship: compute-js/src/ogTags.test.ts and crawlerHandlers.test.ts
+# run in `npm run test`.
+#
+# The one exception is workflow_dispatch: if a human ran this on purpose, they
+# want a verdict, so a manual run still fails.
+
 on:
   workflow_run:
     workflows: ['Deploy to Production']
@@ -29,14 +43,29 @@ jobs:
 
       - name: Run OG parity audit against production
         id: audit-prod
-        continue-on-error: ${{ github.event_name == 'schedule' }}
+        continue-on-error: true
         env:
           BASE_URL: https://divine.video
-        run: bash scripts/verify-og-tags.sh
+        run: |
+          set -o pipefail
+          bash scripts/verify-og-tags.sh 2>&1 | tee /tmp/og-audit-production.log
 
-      - name: Annotate scheduled production audit result
-        if: github.event_name == 'schedule' && steps.audit-prod.outcome == 'failure'
-        run: echo "::warning::Scheduled production OG audit failed. This monitors live production state and is warning-only on schedule."
+      - name: 'Alert #divine-alerts about the production audit failure'
+        if: steps.audit-prod.outcome == 'failure'
+        env:
+          AUDIT_LOG: /tmp/og-audit-production.log
+          AUDIT_TARGET: production (divine.video)
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          SLACK_WEBHOOK: ${{ secrets.SLACK_DIVINE_ALERTS_WEBHOOK }}
+        run: |
+          echo "::warning::OG parity audit failed against production; alerted #divine-alerts. The run stays green because this monitors a live edge, not this commit."
+          bash scripts/notify-og-audit-failure.sh
+
+      - name: Fail a manually dispatched production audit
+        if: github.event_name == 'workflow_dispatch' && steps.audit-prod.outcome == 'failure'
+        run: |
+          echo "::error::OG parity audit failed against production. See the step output above."
+          exit 1
 
   audit-cloudflare-production:
     if: github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success'
@@ -54,7 +83,7 @@ jobs:
 
       - name: Find latest Cloudflare Pages main-branch production deployment URL
         id: find-production
-        continue-on-error: ${{ github.event_name == 'schedule' }}
+        continue-on-error: true
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
@@ -88,18 +117,40 @@ jobs:
           fi
           echo "production_url=$URL" >> "$GITHUB_OUTPUT"
 
-      - name: Annotate scheduled Cloudflare production discovery result
-        if: github.event_name == 'schedule' && steps.find-production.outcome == 'failure'
-        run: echo "::warning::Scheduled Cloudflare production discovery failed. This monitors live deployment state and is warning-only on schedule."
+      - name: 'Alert #divine-alerts that the Cloudflare audit could not run'
+        if: steps.find-production.outcome == 'failure'
+        env:
+          AUDIT_TARGET: Cloudflare production
+          AUDIT_UNAVAILABLE_REASON: Could not find the latest main-branch Cloudflare Pages deployment, so no checks ran.
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          SLACK_WEBHOOK: ${{ secrets.SLACK_DIVINE_ALERTS_WEBHOOK }}
+        run: |
+          echo "::warning::Could not find the latest Cloudflare production deployment; the Cloudflare OG audit was skipped."
+          bash scripts/notify-og-audit-failure.sh
 
       - name: Run OG parity audit against Cloudflare production
         id: audit-production-cf
         if: steps.find-production.outputs.production_url != ''
-        continue-on-error: ${{ github.event_name == 'schedule' }}
+        continue-on-error: true
         env:
           BASE_URL: ${{ steps.find-production.outputs.production_url }}
-        run: bash scripts/verify-og-tags.sh
+        run: |
+          set -o pipefail
+          bash scripts/verify-og-tags.sh 2>&1 | tee /tmp/og-audit-cloudflare.log
 
-      - name: Annotate scheduled Cloudflare production audit result
-        if: github.event_name == 'schedule' && steps.audit-production-cf.outcome == 'failure'
-        run: echo "::warning::Scheduled Cloudflare production OG audit failed. This monitors live deployment state and is warning-only on schedule."
+      - name: 'Alert #divine-alerts about the Cloudflare audit failure'
+        if: steps.audit-production-cf.outcome == 'failure'
+        env:
+          AUDIT_LOG: /tmp/og-audit-cloudflare.log
+          AUDIT_TARGET: Cloudflare production (${{ steps.find-production.outputs.production_url }})
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          SLACK_WEBHOOK: ${{ secrets.SLACK_DIVINE_ALERTS_WEBHOOK }}
+        run: |
+          echo "::warning::OG parity audit failed against Cloudflare production; alerted #divine-alerts. The run stays green because this monitors a live deployment, not this commit."
+          bash scripts/notify-og-audit-failure.sh
+
+      - name: Fail a manually dispatched Cloudflare audit
+        if: github.event_name == 'workflow_dispatch' && (steps.audit-production-cf.outcome == 'failure' || steps.find-production.outcome == 'failure')
+        run: |
+          echo "::error::OG parity audit failed against Cloudflare production. See the step output above."
+          exit 1

--- a/scripts/notify-og-audit-failure.sh
+++ b/scripts/notify-og-audit-failure.sh
@@ -74,7 +74,7 @@ fi
 # so there is no failure list to report — just curl's reason.
 if grep -q '^ERROR: cannot reach' "$AUDIT_LOG"; then
   reason="$(grep -A5 '^ERROR: cannot reach' "$AUDIT_LOG" | sed -n '2,3p' | sed 's/^[[:space:]]*//' | head -1)"
-  post "$(printf '🔴 *OG parity audit failed* — %s\nThe target could not be reached, so no checks ran.%s%s' \
+  post "$(printf '🟠 *OG parity audit could not run* — %s\nThe target could not be reached, so no checks ran.%s%s' \
     "$AUDIT_TARGET" "${reason:+$(printf '\n%s' "$reason")}" "$run_line")"
   exit 0
 fi
@@ -104,7 +104,8 @@ while IFS= read -r failure; do
 done < <(sed -n '/^Failures:/,/^$/p' "$AUDIT_LOG" | sed -n 's/^  X //p')
 
 if [[ ${failure_count} -eq 0 ]]; then
-  echo "WARNING: no failure list found in '${AUDIT_LOG}'; not alerting on an unparseable log."
+  post "$(printf '🟠 *OG parity audit could not run* — %s\nThe notifier could not interpret the failed audit output.%s' \
+    "$AUDIT_TARGET" "$run_line")"
   exit 0
 fi
 

--- a/scripts/notify-og-audit-failure.sh
+++ b/scripts/notify-og-audit-failure.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+# ABOUTME: Posts an OG/Twitter Card parity audit failure to #divine-alerts
+# ABOUTME: Alert-only by design — a live-edge monitor must not fail the build.
+#
+# The audit probes a live CDN edge, so it cannot tell "we shipped bad OG tags"
+# apart from "a connection got dropped" on its own. It runs after production is
+# already live, so failing the build rolls nothing back — it just paints main
+# red and teaches people to ignore it. This routes the result to the channel
+# that already carries deploy failures and the uptime heartbeat, and says which
+# of the two classes it is so the reader knows whether to act.
+#
+# Usage (from .github/workflows/og-audit.yml):
+#   AUDIT_LOG=/tmp/og-audit-production.log \
+#   AUDIT_TARGET='production (divine.video)' \
+#   RUN_URL=... SLACK_WEBHOOK=... bash scripts/notify-og-audit-failure.sh
+#
+# Environment variables:
+#   AUDIT_LOG     - Path to the captured audit output (required)
+#   AUDIT_TARGET  - Human-readable name of what was audited (required)
+#   RUN_URL       - Link to the Actions run (optional)
+#   SLACK_WEBHOOK - Incoming Webhook URL; unset means no-op (optional)
+#
+# Always exits 0: a notifier must never mask, or become, the thing it reports.
+
+set -uo pipefail
+
+AUDIT_LOG="${AUDIT_LOG:-}"
+AUDIT_TARGET="${AUDIT_TARGET:-an unnamed target}"
+RUN_URL="${RUN_URL:-}"
+SLACK_WEBHOOK="${SLACK_WEBHOOK:-}"
+
+# How many failing checks to name before summarising the rest. A total outage
+# would otherwise post 64 lines into the channel.
+MAX_LISTED=10
+
+if [[ -z "$SLACK_WEBHOOK" ]]; then
+  echo "SLACK_DIVINE_ALERTS_WEBHOOK not set; skipping OG audit alert."
+  exit 0
+fi
+
+post() {
+  # $1 = message text. Built via jq --arg so no audit output can break the JSON.
+  local payload
+  payload="$(jq -n --arg t "$1" '{text: $t}')"
+
+  if curl -sS -X POST -H 'Content-type: application/json' \
+       --max-time 15 --data "$payload" "$SLACK_WEBHOOK" >/dev/null; then
+    echo "Posted OG audit alert to #divine-alerts."
+  else
+    echo "WARNING: failed to POST to Slack webhook (the audit failure still stands)."
+  fi
+}
+
+run_line=""
+if [[ -n "$RUN_URL" ]]; then
+  run_line="$(printf '\n<%s|View the audit run>' "$RUN_URL")"
+fi
+
+# The audit never got to run (e.g. we could not resolve which deployment to
+# audit). Say so out loud: a monitor that quietly stops monitoring is worse
+# than one that fails, which is the trap this whole workflow is avoiding.
+if [[ -n "${AUDIT_UNAVAILABLE_REASON:-}" ]]; then
+  post "$(printf '🟠 *OG parity audit could not run* — %s\n%s%s' \
+    "$AUDIT_TARGET" "$AUDIT_UNAVAILABLE_REASON" "$run_line")"
+  exit 0
+fi
+
+if [[ ! -r "$AUDIT_LOG" ]]; then
+  echo "WARNING: audit log '${AUDIT_LOG}' is missing or unreadable; nothing to report."
+  exit 0
+fi
+
+# The audit exits 2 without running any checks when the target is unreachable,
+# so there is no failure list to report — just curl's reason.
+if grep -q '^ERROR: cannot reach' "$AUDIT_LOG"; then
+  reason="$(grep -A5 '^ERROR: cannot reach' "$AUDIT_LOG" | sed -n '2,3p' | sed 's/^[[:space:]]*//' | head -1)"
+  post "$(printf '🔴 *OG parity audit failed* — %s\nThe target could not be reached, so no checks ran.%s%s' \
+    "$AUDIT_TARGET" "${reason:+$(printf '\n%s' "$reason")}" "$run_line")"
+  exit 0
+fi
+
+# Read into counters rather than an array: macOS still ships bash 3.2, which has
+# no mapfile and treats an empty array under `set -u` as an unbound variable.
+failure_count=0
+network_failures=0
+truncated=0
+listed=""
+
+while IFS= read -r failure; do
+  [[ -z "$failure" ]] && continue
+  failure_count=$((failure_count + 1))
+
+  # A dropped connection is not an OG regression. Only call it one when at least
+  # one failure is about the tags the edge actually served.
+  case "$failure" in
+    *"network error"*) network_failures=$((network_failures + 1)) ;;
+  esac
+
+  if [[ ${failure_count} -le ${MAX_LISTED} ]]; then
+    listed+="$(printf '\n• %s' "$failure")"
+  else
+    truncated=$((truncated + 1))
+  fi
+done < <(sed -n '/^Failures:/,/^$/p' "$AUDIT_LOG" | sed -n 's/^  X //p')
+
+if [[ ${failure_count} -eq 0 ]]; then
+  echo "WARNING: no failure list found in '${AUDIT_LOG}'; not alerting on an unparseable log."
+  exit 0
+fi
+
+if [[ ${truncated} -gt 0 ]]; then
+  listed+="$(printf '\n• …and %s more (see the run log)' "$truncated")"
+fi
+
+headline="$(grep -m1 '^FAILED: ' "$AUDIT_LOG" | sed 's/^FAILED: //')"
+headline="${headline:-${failure_count} checks did not pass}"
+
+if [[ ${network_failures} -eq ${failure_count} ]]; then
+  severity='🟡'
+  verdict="$(printf 'Every failure was network-level — the edge dropped the connection rather than serving the wrong tags. Most likely a transient blip; worth a look if it repeats.')"
+else
+  severity='🔴'
+  verdict="$(printf 'Link previews may be broken on the routes below.')"
+fi
+
+post "$(printf '%s *OG parity audit failed* — %s\n%s\n%s%s%s' \
+  "$severity" "$AUDIT_TARGET" "$headline" "$verdict" "$listed" "$run_line")"

--- a/tests/og-audit-alerting.test.ts
+++ b/tests/og-audit-alerting.test.ts
@@ -1,0 +1,249 @@
+// ABOUTME: Pins the OG audit's alert-on-failure path and the workflow wiring behind it
+// ABOUTME: A live-edge monitor must page #divine-alerts, not paint main red (see run 32740711299)
+
+import { spawn } from 'node:child_process';
+import { mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
+import { createServer, type Server } from 'node:http';
+import type { AddressInfo } from 'node:net';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+const SCRIPT = 'scripts/notify-og-audit-failure.sh';
+const WORKFLOW = readFileSync('.github/workflows/og-audit.yml', 'utf8');
+
+const scratch = mkdtempSync(join(tmpdir(), 'og-audit-alert-'));
+
+function auditLog(failureLines: string[], total = 64): string {
+  const path = join(scratch, `audit-${failureLines.length}-${total}.log`);
+  writeFileSync(
+    path,
+    [
+      'Summary',
+      `Total checks:  ${total}`,
+      `Passed:        ${total - failureLines.length}`,
+      `Failed:        ${failureLines.length}`,
+      '',
+      'Failures:',
+      ...failureLines.map((line) => `  X ${line}`),
+      '',
+      `FAILED: ${failureLines.length} of ${total} checks did not pass`,
+    ].join('\n'),
+  );
+
+  return path;
+}
+
+type Capture = { bodies: string[]; server: Server; url: string };
+
+async function startWebhook(status = 200): Promise<Capture> {
+  const bodies: string[] = [];
+
+  const server = createServer((request, response) => {
+    let body = '';
+    request.on('data', (chunk) => (body += chunk));
+    request.on('end', () => {
+      bodies.push(body);
+      response.writeHead(status);
+      response.end('ok');
+    });
+  });
+
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+
+  return {
+    bodies,
+    server,
+    url: `http://127.0.0.1:${(server.address() as AddressInfo).port}/hook`,
+  };
+}
+
+function runNotifier(env: Record<string, string>): Promise<{ output: string; status: number | null }> {
+  return new Promise((resolve) => {
+    const child = spawn('bash', [SCRIPT], { env: { ...process.env, ...env } });
+
+    let output = '';
+    child.stdout.on('data', (chunk) => (output += chunk));
+    child.stderr.on('data', (chunk) => (output += chunk));
+    child.on('close', (status) => resolve({ output, status }));
+  });
+}
+
+const RUN_URL = 'https://github.com/divinevideo/divine-web/actions/runs/32740711299';
+
+describe('notify-og-audit-failure.sh', () => {
+  let capture: Capture | undefined;
+
+  afterEach(async () => {
+    if (capture) {
+      capture.server.closeAllConnections();
+      await new Promise<void>((resolve) => capture!.server.close(() => resolve()));
+      capture = undefined;
+    }
+  });
+
+  it('posts the failing routes and a link to the run', async () => {
+    capture = await startWebhook();
+
+    const { status } = await runNotifier({
+      AUDIT_LOG: auditLog(['discord /discovery: HTTP 404', 'twitter /kids (kids policy page)']),
+      AUDIT_TARGET: 'production (divine.video)',
+      RUN_URL,
+      SLACK_WEBHOOK: capture.url,
+    });
+
+    expect(status).toBe(0);
+    expect(capture.bodies).toHaveLength(1);
+
+    const text = JSON.parse(capture.bodies[0]).text as string;
+    expect(text).toContain('OG parity audit failed');
+    expect(text).toContain('production (divine.video)');
+    expect(text).toContain('2 of 64');
+    expect(text).toContain('discord /discovery: HTTP 404');
+    expect(text).toContain('twitter /kids (kids policy page)');
+    expect(text).toContain(RUN_URL);
+  }, 30_000);
+
+  it('calls out an all-network-error failure as an edge blip, not an OG regression', async () => {
+    capture = await startWebhook();
+
+    await runNotifier({
+      AUDIT_LOG: auditLog([
+        'discord /discovery: network error (curl exit 52)',
+        'twitter /discovery/classics: network error (curl exit 52)',
+      ]),
+      AUDIT_TARGET: 'production (divine.video)',
+      RUN_URL,
+      SLACK_WEBHOOK: capture.url,
+    });
+
+    const text = JSON.parse(capture.bodies[0]).text as string;
+    expect(text).toContain('network-level');
+    expect(text).not.toContain('🔴');
+  }, 30_000);
+
+  it('treats any content failure as a real regression even when mixed with network errors', async () => {
+    capture = await startWebhook();
+
+    await runNotifier({
+      AUDIT_LOG: auditLog([
+        'discord /discovery: network error (curl exit 52)',
+        'twitter /kids (kids policy page)',
+      ]),
+      AUDIT_TARGET: 'production (divine.video)',
+      RUN_URL,
+      SLACK_WEBHOOK: capture.url,
+    });
+
+    const text = JSON.parse(capture.bodies[0]).text as string;
+    expect(text).toContain('🔴');
+    expect(text).not.toContain('network-level');
+  }, 30_000);
+
+  it('states how many failures it truncated instead of silently capping', async () => {
+    capture = await startWebhook();
+
+    const many = Array.from({ length: 13 }, (_, index) => `discord /route-${index}: HTTP 404`);
+    await runNotifier({
+      AUDIT_LOG: auditLog(many),
+      AUDIT_TARGET: 'production (divine.video)',
+      RUN_URL,
+      SLACK_WEBHOOK: capture.url,
+    });
+
+    const text = JSON.parse(capture.bodies[0]).text as string;
+    expect(text).toContain('discord /route-0: HTTP 404');
+    expect(text).toContain('3 more');
+    expect(text).not.toContain('/route-12:');
+  }, 30_000);
+
+  it('reports an unreachable target when the audit never got to run checks', async () => {
+    capture = await startWebhook();
+
+    const path = join(scratch, 'unreachable.log');
+    writeFileSync(path, 'ERROR: cannot reach https://divine.video\n       curl: (35) TLS connect error\n');
+
+    await runNotifier({
+      AUDIT_LOG: path,
+      AUDIT_TARGET: 'production (divine.video)',
+      RUN_URL,
+      SLACK_WEBHOOK: capture.url,
+    });
+
+    const text = JSON.parse(capture.bodies[0]).text as string;
+    expect(text).toContain('could not be reached');
+    expect(text).toContain('TLS connect error');
+  }, 30_000);
+
+  it('reports when the audit could not run at all, so a broken monitor is not silent', async () => {
+    capture = await startWebhook();
+
+    const { status } = await runNotifier({
+      AUDIT_TARGET: 'Cloudflare production',
+      AUDIT_UNAVAILABLE_REASON: 'Could not list Cloudflare Pages deployments.',
+      RUN_URL,
+      SLACK_WEBHOOK: capture.url,
+    });
+
+    expect(status).toBe(0);
+
+    const text = JSON.parse(capture.bodies[0]).text as string;
+    expect(text).toContain('could not run');
+    expect(text).toContain('Could not list Cloudflare Pages deployments.');
+    expect(text).toContain(RUN_URL);
+  }, 30_000);
+
+  it('no-ops when no webhook is configured', async () => {
+    const { output, status } = await runNotifier({
+      AUDIT_LOG: auditLog(['discord /discovery: HTTP 404']),
+      AUDIT_TARGET: 'production (divine.video)',
+      RUN_URL,
+      SLACK_WEBHOOK: '',
+    });
+
+    expect(status).toBe(0);
+    expect(output).toContain('skipping');
+  }, 30_000);
+
+  it('never fails the job when the webhook POST fails', async () => {
+    const { output, status } = await runNotifier({
+      AUDIT_LOG: auditLog(['discord /discovery: HTTP 404']),
+      AUDIT_TARGET: 'production (divine.video)',
+      RUN_URL,
+      SLACK_WEBHOOK: 'http://127.0.0.1:59997/dead',
+    });
+
+    expect(status).toBe(0);
+    expect(output).toContain('WARNING');
+  }, 30_000);
+});
+
+describe('og-audit workflow wiring', () => {
+  it('never lets an automated audit run fail the build', () => {
+    // continue-on-error must be unconditional. The old `${{ github.event_name ==
+    // 'schedule' }}` form left post-deploy runs hard-failing on a dropped
+    // connection, which is what run 32740711299 did.
+    const conditional = WORKFLOW.match(/continue-on-error:\s*\$\{\{[^\n]*event_name[^\n]*\}\}/g);
+    expect(conditional).toBeNull();
+
+    const audits = WORKFLOW.match(/verify-og-tags\.sh/g) ?? [];
+    const alwaysOn = WORKFLOW.match(/continue-on-error:\s*true/g) ?? [];
+    expect(audits.length).toBeGreaterThan(0);
+    expect(alwaysOn.length).toBeGreaterThanOrEqual(audits.length);
+  });
+
+  it('alerts #divine-alerts for every audit it runs', () => {
+    // >= because a target that could not be discovered also alerts, without
+    // having an audit step of its own to pair with.
+    const audits = (WORKFLOW.match(/verify-og-tags\.sh/g) ?? []).length;
+    const alerts = (WORKFLOW.match(/notify-og-audit-failure\.sh/g) ?? []).length;
+    expect(audits).toBeGreaterThan(0);
+    expect(alerts).toBeGreaterThanOrEqual(audits);
+    expect(WORKFLOW).toContain('SLACK_DIVINE_ALERTS_WEBHOOK');
+  });
+
+  it('still fails a manually dispatched audit so an on-demand check gives a verdict', () => {
+    expect(WORKFLOW).toMatch(/github\.event_name == 'workflow_dispatch'[\s\S]{0,400}?exit 1/);
+  });
+});

--- a/tests/og-audit-alerting.test.ts
+++ b/tests/og-audit-alerting.test.ts
@@ -172,8 +172,28 @@ describe('notify-og-audit-failure.sh', () => {
     });
 
     const text = JSON.parse(capture.bodies[0]).text as string;
+    expect(text).toContain('🟠');
     expect(text).toContain('could not be reached');
     expect(text).toContain('TLS connect error');
+  }, 30_000);
+
+  it('alerts when a failed audit log cannot be parsed', async () => {
+    capture = await startWebhook();
+
+    const path = join(scratch, 'unparseable.log');
+    writeFileSync(path, 'The audit exited before it could print a summary.\n');
+
+    await runNotifier({
+      AUDIT_LOG: path,
+      AUDIT_TARGET: 'production (divine.video)',
+      RUN_URL,
+      SLACK_WEBHOOK: capture.url,
+    });
+
+    const text = JSON.parse(capture.bodies[0]).text as string;
+    expect(text).toContain('🟠');
+    expect(text).toContain('could not interpret the failed audit output');
+    expect(text).toContain(RUN_URL);
   }, 30_000);
 
   it('reports when the audit could not run at all, so a broken monitor is not silent', async () => {


### PR DESCRIPTION
## Summary

Turns the OG/Twitter Card parity audit from a build gate into a monitor that alerts `#divine-alerts`.

- Automated runs (post-deploy and scheduled) alert and stay green.
- A manual `workflow_dispatch` run still fails — if a human ran it on purpose, they want a verdict.
- The alert says which class of failure it is, so the reader knows whether to act:
  - 🟡 every failure was network-level → the edge dropped the connection rather than serving the wrong tags
  - 🔴 anything touching the tags actually served → link previews may be broken
  - 🟠 the audit could not run at all (target unreachable, or no Cloudflare deployment found)
- Failure lists are capped at 10 and state how many were truncated, so a total outage doesn't post 64 lines and nothing is silently dropped.

Scheduled runs previously only wrote a `::warning::` annotation that nobody reads. Now they alert like everything else.

## Motivation

[Run 32740711299](https://github.com/divinevideo/divine-web/actions/runs/32740711299) turned main red over three dropped connections out of 64. Nothing was wrong with the site.

The deeper problem is that this workflow was wired as a gate when it can't be one:

- **It runs after production is already serving.** It's triggered by `workflow_run` on a completed deploy, so a red run rolls nothing back.
- **It can't tell a regression from a hiccup.** It probes a live third-party CDN edge. "We shipped bad OG tags" and "a connection got dropped" arrive looking identical.
- **The asymmetry was backwards.** On `schedule` it was already `continue-on-error: true`; only on `workflow_run` did it hard-fail — and the post-deploy run has the *least* signal, firing seconds after a full `fastly purge --all`.

A gate that fires false positives on a live edge, after the fact, teaches people to ignore red. That's worse than no check.

The parity logic itself is already gated where a gate can actually prevent a bad ship: `compute-js/src/ogTags.test.ts` and `crawlerHandlers.test.ts` run in `npm run test` before merge. This change doesn't remove a safety net — it moves a monitor to the channel that already carries deploy failures and the uptime heartbeat.

What the alert would have looked like for that run:

```
🟡 *OG parity audit failed* — production (divine.video)
3 of 64 checks did not pass
Every failure was network-level — the edge dropped the connection rather than
serving the wrong tags. Most likely a transient blip; worth a look if it repeats.
• discord /discovery: network error (curl exit 52)
• twitter /discovery/classics: network error (curl exit 52)
• discord /: network error (curl exit 52)
<…|View the audit run>
```

Versus a real regression:

```
🔴 *OG parity audit failed* — production (divine.video)
2 of 64 checks did not pass
Link previews may be broken on the routes below.
• slackbot /kids (kids policy page)
• facebook /kids (kids policy page)
```

The 🟡/🔴 split uses merged PR #685, which makes the audit report transport failures as network errors instead of `HTTP 000000`. Without it the classifier just never picks the amber branch — no breakage, and the two PRs share no files.

## Related Issue

- No linked issue — surfaced by the CI run linked above.

## Testing

- [x] `npm run test`
- [x] Manual verification completed

New: `tests/og-audit-alerting.test.ts` (12 tests) drives the notifier against a local webhook server and asserts the workflow wiring — the failure list and run link reach Slack, the amber/red/orange classification, the truncation notice, the no-webhook no-op, and that a failed POST never fails the job.

Manual verification:

- Rendered both alert variants against a local webhook and read the actual Slack payload (quoted above).
- Parsed the workflow YAML and walked every step's `if:` / `continue-on-error:` to confirm which paths alert and which fail.
- `bash -n` and shellcheck clean on the new script.

Two things the YAML parse caught that review would likely have missed: `#divine-alerts` in an unquoted step name starts a YAML comment (all three alert steps were silently named just "Alert"), and `mapfile` is bash 4+ so the notifier would have worked in CI but not on a Mac.

## Visuals

- [ ] UI change with screenshots/video attached
- [x] No visual change
- [x] Visuals and text avoid sensitive external brand or partner names unless explicitly approved
