### PR TITLE
feat(exit): let hosted users take their account key with them

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -197,6 +197,14 @@ time, verifies advertised SHA-256 hashes, and records partial failures without
 changing signed events. Viewer authorization is retried only for the exact
 `https://media.divine.video` origin; third-party media requests remain bare.
 
+The same page shows the signed-in account's full npub and separates hosted,
+local-nsec, and external-signer key ownership. Hosted accounts may export their
+nsec through Keycast's password-confirmed `/api/user/export-key` endpoint. The
+secret exists only in transient component state, is cleared on hide or account
+change, and is never added to the archive. Keycast remains authoritative for
+raw-key policy: a policy denial changes only the key section and leaves every
+other portability step available.
+
 After an archive is built, the same page can mirror its unique source blobs to a
 custom HTTPS Blossom destination with BUD-04 `PUT /mirror`. Destination URLs
 normalize to the domain root because BUD-01 serves every Blossom endpoint there.

--- a/src/components/exit/AccountKeySection.test.tsx
+++ b/src/components/exit/AccountKeySection.test.tsx
@@ -28,7 +28,7 @@ describe("AccountKeySection", () => {
   });
 
   it("shows the full npub for every signed-in account", () => {
-    render(<AccountKeySection pubkey={PUBKEY} hostedToken={null} localNsec={null} />);
+    render(<AccountKeySection pubkey={PUBKEY} hostedToken={null} isHostedAccount={false} localNsec={null} />);
 
     expect(screen.getByText(NPUB)).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Copy public key" })).toBeInTheDocument();
@@ -38,7 +38,7 @@ describe("AccountKeySection", () => {
     const user = userEvent.setup();
     const writeText = vi.spyOn(navigator.clipboard, "writeText")
       .mockRejectedValue(new DOMException("Denied", "NotAllowedError"));
-    render(<AccountKeySection pubkey={PUBKEY} hostedToken={null} localNsec={null} />);
+    render(<AccountKeySection pubkey={PUBKEY} hostedToken={null} isHostedAccount={false} localNsec={null} />);
 
     await user.click(screen.getByRole("button", { name: "Copy public key" }));
 
@@ -48,21 +48,21 @@ describe("AccountKeySection", () => {
 
   it("renders signed-out, local-key, and external-signer states distinctly", () => {
     const { rerender } = render(
-      <AccountKeySection pubkey={undefined} hostedToken={null} localNsec={null} />,
+      <AccountKeySection pubkey={undefined} hostedToken={null} isHostedAccount={false} localNsec={null} />,
     );
     expect(screen.getByText(/Sign in to see the public key/)).toBeInTheDocument();
 
-    rerender(<AccountKeySection pubkey={PUBKEY} hostedToken={null} localNsec={NSEC} />);
+    rerender(<AccountKeySection pubkey={PUBKEY} hostedToken={null} isHostedAccount={false} localNsec={NSEC} />);
     expect(screen.getByText(/stored in this browser/)).toBeInTheDocument();
     expect(screen.getByText(`Local backup for ${NSEC}`)).toBeInTheDocument();
 
-    rerender(<AccountKeySection pubkey={PUBKEY} hostedToken={null} localNsec={null} />);
+    rerender(<AccountKeySection pubkey={PUBKEY} hostedToken={null} isHostedAccount={false} localNsec={null} />);
     expect(screen.getByText(/browser extension or another signer/)).toBeInTheDocument();
   });
 
   it("requires confirmation, clears the password, and reveals the full nsec", async () => {
     mockExportAccountKey.mockResolvedValue({ nsec: NSEC });
-    render(<AccountKeySection pubkey={PUBKEY} hostedToken="token" localNsec={null} />);
+    render(<AccountKeySection pubkey={PUBKEY} hostedToken="token" isHostedAccount localNsec={null} />);
 
     const password = screen.getByLabelText("Divine account password");
     const reveal = screen.getByRole("button", { name: "Show my secret key" });
@@ -78,10 +78,13 @@ describe("AccountKeySection", () => {
       token: "token",
       password: "correct horse",
     }));
+
+    await userEvent.click(screen.getByRole('button', { name: 'Copy secret key' }));
+    expect(screen.getByRole('status')).toHaveAttribute('data-sentry-mask');
   });
 
   it("keeps the local backup control available for a hosted account with a local key", () => {
-    render(<AccountKeySection pubkey={PUBKEY} hostedToken="token" localNsec={NSEC} />);
+    render(<AccountKeySection pubkey={PUBKEY} hostedToken="token" isHostedAccount localNsec={NSEC} />);
 
     expect(screen.getByLabelText("Divine account password")).toBeInTheDocument();
     expect(screen.getByText(`Local backup for ${NSEC}`)).toBeInTheDocument();
@@ -90,7 +93,7 @@ describe("AccountKeySection", () => {
   it("clears the revealed nsec on Hide and on account change", async () => {
     mockExportAccountKey.mockResolvedValue({ nsec: NSEC });
     const { rerender } = render(
-      <AccountKeySection pubkey={PUBKEY} hostedToken="token" localNsec={null} />,
+      <AccountKeySection pubkey={PUBKEY} hostedToken="token" isHostedAccount localNsec={null} />,
     );
 
     await userEvent.type(screen.getByLabelText("Divine account password"), "password");
@@ -106,7 +109,7 @@ describe("AccountKeySection", () => {
     await userEvent.click(screen.getByRole("button", { name: "Show my secret key" }));
     expect(await screen.findByText(NSEC)).toBeInTheDocument();
 
-    rerender(<AccountKeySection pubkey={OTHER_PUBKEY} hostedToken="other-token" localNsec={null} />);
+    rerender(<AccountKeySection pubkey={OTHER_PUBKEY} hostedToken="other-token" isHostedAccount localNsec={null} />);
     await waitFor(() => expect(screen.queryByText(NSEC)).not.toBeInTheDocument());
   });
 
@@ -114,13 +117,13 @@ describe("AccountKeySection", () => {
     let resolveExport: ((value: { nsec: string }) => void) | undefined;
     mockExportAccountKey.mockReturnValue(new Promise((resolve) => { resolveExport = resolve; }));
     const { rerender } = render(
-      <AccountKeySection pubkey={PUBKEY} hostedToken="token" localNsec={null} />,
+      <AccountKeySection pubkey={PUBKEY} hostedToken="token" isHostedAccount localNsec={null} />,
     );
 
     await userEvent.type(screen.getByLabelText("Divine account password"), "password");
     await userEvent.click(screen.getByRole("checkbox", { name: /I understand/ }));
     await userEvent.click(screen.getByRole("button", { name: "Show my secret key" }));
-    rerender(<AccountKeySection pubkey={OTHER_PUBKEY} hostedToken="other-token" localNsec={null} />);
+    rerender(<AccountKeySection pubkey={OTHER_PUBKEY} hostedToken="other-token" isHostedAccount localNsec={null} />);
     resolveExport?.({ nsec: NSEC });
 
     await waitFor(() => expect(screen.queryByText(NSEC)).not.toBeInTheDocument());
@@ -131,13 +134,13 @@ describe("AccountKeySection", () => {
     let resolveExport: ((value: { nsec: string }) => void) | undefined;
     mockExportAccountKey.mockReturnValue(new Promise((resolve) => { resolveExport = resolve; }));
     const { rerender } = render(
-      <AccountKeySection pubkey={PUBKEY} hostedToken="token-a" localNsec={null} />,
+      <AccountKeySection pubkey={PUBKEY} hostedToken="token-a" isHostedAccount localNsec={null} />,
     );
 
     await userEvent.type(screen.getByLabelText("Divine account password"), "password");
     await userEvent.click(screen.getByRole("checkbox", { name: /I understand/ }));
     await userEvent.click(screen.getByRole("button", { name: "Show my secret key" }));
-    rerender(<AccountKeySection pubkey={PUBKEY} hostedToken="token-b" localNsec={null} />);
+    rerender(<AccountKeySection pubkey={PUBKEY} hostedToken="token-b" isHostedAccount localNsec={null} />);
     resolveExport?.({ nsec: NSEC });
 
     expect(await screen.findByText(NSEC)).toHaveAttribute("data-sentry-mask");
@@ -150,13 +153,37 @@ describe("AccountKeySection", () => {
       "Divine cannot export the secret key for this account.",
       403,
     ));
-    render(<AccountKeySection pubkey={PUBKEY} hostedToken="token" localNsec={null} />);
+    render(<AccountKeySection pubkey={PUBKEY} hostedToken="token" isHostedAccount localNsec={null} />);
 
     await userEvent.type(screen.getByLabelText("Divine account password"), "password");
     await userEvent.click(screen.getByRole("checkbox", { name: /I understand/ }));
     await userEvent.click(screen.getByRole("button", { name: "Show my secret key" }));
 
     expect(await screen.findByText(/Secret-key export is restricted/)).toBeInTheDocument();
+    expect(screen.getByRole('alert')).toHaveAttribute('data-sentry-mask');
     expect(screen.queryByRole("button", { name: "Show my secret key" })).not.toBeInTheDocument();
+  });
+
+  it('prompts an expired hosted account to sign in again', () => {
+    render(<AccountKeySection pubkey={PUBKEY} hostedToken={null} isHostedAccount localNsec={null} />);
+
+    expect(screen.getByRole('alert')).toHaveTextContent(/session expired/i);
+    expect(screen.getByRole('alert')).toHaveAttribute('data-sentry-mask');
+    expect(screen.queryByText(/browser extension or another signer/)).not.toBeInTheDocument();
+  });
+
+  it('masks password failure from replay', async () => {
+    mockExportAccountKey.mockRejectedValue(new KeyExportError(
+      'invalid-password',
+      'That password did not match this account.',
+      401,
+    ));
+    render(<AccountKeySection pubkey={PUBKEY} hostedToken="token" isHostedAccount localNsec={null} />);
+
+    await userEvent.type(screen.getByLabelText('Divine account password'), 'wrong password');
+    await userEvent.click(screen.getByRole('checkbox', { name: /I understand/ }));
+    await userEvent.click(screen.getByRole('button', { name: 'Show my secret key' }));
+
+    expect(await screen.findByRole('alert')).toHaveAttribute('data-sentry-mask');
   });
 });

--- a/src/components/exit/AccountKeySection.test.tsx
+++ b/src/components/exit/AccountKeySection.test.tsx
@@ -72,12 +72,19 @@ describe("AccountKeySection", () => {
     await userEvent.click(screen.getByRole("checkbox", { name: /I understand/ }));
     await userEvent.click(reveal);
 
-    expect(await screen.findByText(NSEC)).toBeInTheDocument();
+    expect(await screen.findByText(NSEC)).toHaveAttribute("data-sentry-mask");
     expect(password).toHaveValue("");
     expect(mockExportAccountKey).toHaveBeenCalledWith(expect.objectContaining({
       token: "token",
       password: "correct horse",
     }));
+  });
+
+  it("keeps the local backup control available for a hosted account with a local key", () => {
+    render(<AccountKeySection pubkey={PUBKEY} hostedToken="token" localNsec={NSEC} />);
+
+    expect(screen.getByLabelText("Divine account password")).toBeInTheDocument();
+    expect(screen.getByText(`Local backup for ${NSEC}`)).toBeInTheDocument();
   });
 
   it("clears the revealed nsec on Hide and on account change", async () => {
@@ -118,6 +125,23 @@ describe("AccountKeySection", () => {
 
     await waitFor(() => expect(screen.queryByText(NSEC)).not.toBeInTheDocument());
     expect(mockExportAccountKey.mock.calls[0][0].signal.aborted).toBe(true);
+  });
+
+  it("keeps an in-flight export when the hosted token refreshes for the same account", async () => {
+    let resolveExport: ((value: { nsec: string }) => void) | undefined;
+    mockExportAccountKey.mockReturnValue(new Promise((resolve) => { resolveExport = resolve; }));
+    const { rerender } = render(
+      <AccountKeySection pubkey={PUBKEY} hostedToken="token-a" localNsec={null} />,
+    );
+
+    await userEvent.type(screen.getByLabelText("Divine account password"), "password");
+    await userEvent.click(screen.getByRole("checkbox", { name: /I understand/ }));
+    await userEvent.click(screen.getByRole("button", { name: "Show my secret key" }));
+    rerender(<AccountKeySection pubkey={PUBKEY} hostedToken="token-b" localNsec={null} />);
+    resolveExport?.({ nsec: NSEC });
+
+    expect(await screen.findByText(NSEC)).toHaveAttribute("data-sentry-mask");
+    expect(mockExportAccountKey.mock.calls[0][0].signal.aborted).toBe(false);
   });
 
   it("turns policy denial into a restriction state", async () => {

--- a/src/components/exit/AccountKeySection.test.tsx
+++ b/src/components/exit/AccountKeySection.test.tsx
@@ -1,0 +1,138 @@
+import { nip19 } from "nostr-tools";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { KeyExportError } from "@/lib/exit/keyExportClient";
+
+import { AccountKeySection } from "./AccountKeySection";
+
+const PUBKEY = "a".repeat(64);
+const OTHER_PUBKEY = "b".repeat(64);
+const NPUB = nip19.npubEncode(PUBKEY);
+const NSEC = nip19.nsecEncode(new Uint8Array(32).fill(9));
+const mockExportAccountKey = vi.fn();
+
+vi.mock("@/lib/exit/keyExportClient", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/exit/keyExportClient")>();
+  return { ...actual, exportAccountKey: (...args: unknown[]) => mockExportAccountKey(...args) };
+});
+
+vi.mock("@/components/auth/LocalNsecBanner", () => ({
+  LocalNsecBanner: ({ nsec }: { nsec: string }) => <div>Local backup for {nsec}</div>,
+}));
+
+describe("AccountKeySection", () => {
+  beforeEach(() => {
+    mockExportAccountKey.mockReset();
+  });
+
+  it("shows the full npub for every signed-in account", () => {
+    render(<AccountKeySection pubkey={PUBKEY} hostedToken={null} localNsec={null} />);
+
+    expect(screen.getByText(NPUB)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Copy public key" })).toBeInTheDocument();
+  });
+
+  it("copies the full npub and explains a clipboard rejection", async () => {
+    const user = userEvent.setup();
+    const writeText = vi.spyOn(navigator.clipboard, "writeText")
+      .mockRejectedValue(new DOMException("Denied", "NotAllowedError"));
+    render(<AccountKeySection pubkey={PUBKEY} hostedToken={null} localNsec={null} />);
+
+    await user.click(screen.getByRole("button", { name: "Copy public key" }));
+
+    expect(writeText).toHaveBeenCalledWith(NPUB);
+    expect(screen.getByRole("status")).toHaveTextContent(/could not be copied/);
+  });
+
+  it("renders signed-out, local-key, and external-signer states distinctly", () => {
+    const { rerender } = render(
+      <AccountKeySection pubkey={undefined} hostedToken={null} localNsec={null} />,
+    );
+    expect(screen.getByText(/Sign in to see the public key/)).toBeInTheDocument();
+
+    rerender(<AccountKeySection pubkey={PUBKEY} hostedToken={null} localNsec={NSEC} />);
+    expect(screen.getByText(/stored in this browser/)).toBeInTheDocument();
+    expect(screen.getByText(`Local backup for ${NSEC}`)).toBeInTheDocument();
+
+    rerender(<AccountKeySection pubkey={PUBKEY} hostedToken={null} localNsec={null} />);
+    expect(screen.getByText(/browser extension or another signer/)).toBeInTheDocument();
+  });
+
+  it("requires confirmation, clears the password, and reveals the full nsec", async () => {
+    mockExportAccountKey.mockResolvedValue({ nsec: NSEC });
+    render(<AccountKeySection pubkey={PUBKEY} hostedToken="token" localNsec={null} />);
+
+    const password = screen.getByLabelText("Divine account password");
+    const reveal = screen.getByRole("button", { name: "Show my secret key" });
+    await userEvent.type(password, "correct horse");
+    expect(reveal).toBeDisabled();
+
+    await userEvent.click(screen.getByRole("checkbox", { name: /I understand/ }));
+    await userEvent.click(reveal);
+
+    expect(await screen.findByText(NSEC)).toBeInTheDocument();
+    expect(password).toHaveValue("");
+    expect(mockExportAccountKey).toHaveBeenCalledWith(expect.objectContaining({
+      token: "token",
+      password: "correct horse",
+    }));
+  });
+
+  it("clears the revealed nsec on Hide and on account change", async () => {
+    mockExportAccountKey.mockResolvedValue({ nsec: NSEC });
+    const { rerender } = render(
+      <AccountKeySection pubkey={PUBKEY} hostedToken="token" localNsec={null} />,
+    );
+
+    await userEvent.type(screen.getByLabelText("Divine account password"), "password");
+    await userEvent.click(screen.getByRole("checkbox", { name: /I understand/ }));
+    await userEvent.click(screen.getByRole("button", { name: "Show my secret key" }));
+    expect(await screen.findByText(NSEC)).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole("button", { name: "Hide secret key" }));
+    expect(screen.queryByText(NSEC)).not.toBeInTheDocument();
+
+    await userEvent.type(screen.getByLabelText("Divine account password"), "password");
+    await userEvent.click(screen.getByRole("checkbox", { name: /I understand/ }));
+    await userEvent.click(screen.getByRole("button", { name: "Show my secret key" }));
+    expect(await screen.findByText(NSEC)).toBeInTheDocument();
+
+    rerender(<AccountKeySection pubkey={OTHER_PUBKEY} hostedToken="other-token" localNsec={null} />);
+    await waitFor(() => expect(screen.queryByText(NSEC)).not.toBeInTheDocument());
+  });
+
+  it("ignores an export response that arrives after the account changes", async () => {
+    let resolveExport: ((value: { nsec: string }) => void) | undefined;
+    mockExportAccountKey.mockReturnValue(new Promise((resolve) => { resolveExport = resolve; }));
+    const { rerender } = render(
+      <AccountKeySection pubkey={PUBKEY} hostedToken="token" localNsec={null} />,
+    );
+
+    await userEvent.type(screen.getByLabelText("Divine account password"), "password");
+    await userEvent.click(screen.getByRole("checkbox", { name: /I understand/ }));
+    await userEvent.click(screen.getByRole("button", { name: "Show my secret key" }));
+    rerender(<AccountKeySection pubkey={OTHER_PUBKEY} hostedToken="other-token" localNsec={null} />);
+    resolveExport?.({ nsec: NSEC });
+
+    await waitFor(() => expect(screen.queryByText(NSEC)).not.toBeInTheDocument());
+    expect(mockExportAccountKey.mock.calls[0][0].signal.aborted).toBe(true);
+  });
+
+  it("turns policy denial into a restriction state", async () => {
+    mockExportAccountKey.mockRejectedValue(new KeyExportError(
+      "policy-denied",
+      "Divine cannot export the secret key for this account.",
+      403,
+    ));
+    render(<AccountKeySection pubkey={PUBKEY} hostedToken="token" localNsec={null} />);
+
+    await userEvent.type(screen.getByLabelText("Divine account password"), "password");
+    await userEvent.click(screen.getByRole("checkbox", { name: /I understand/ }));
+    await userEvent.click(screen.getByRole("button", { name: "Show my secret key" }));
+
+    expect(await screen.findByText(/Secret-key export is restricted/)).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Show my secret key" })).not.toBeInTheDocument();
+  });
+});

--- a/src/components/exit/AccountKeySection.test.tsx
+++ b/src/components/exit/AccountKeySection.test.tsx
@@ -147,6 +147,25 @@ describe("AccountKeySection", () => {
     expect(mockExportAccountKey.mock.calls[0][0].signal.aborted).toBe(false);
   });
 
+  it("clears a revealed secret when the hosted session expires", async () => {
+    mockExportAccountKey.mockResolvedValue({ nsec: NSEC });
+    const { rerender } = render(
+      <AccountKeySection pubkey={PUBKEY} hostedToken="token-a" isHostedAccount localNsec={null} />,
+    );
+
+    await userEvent.type(screen.getByLabelText("Divine account password"), "password");
+    await userEvent.click(screen.getByRole("checkbox", { name: /I understand/ }));
+    await userEvent.click(screen.getByRole("button", { name: "Show my secret key" }));
+    expect(await screen.findByText(NSEC)).toBeInTheDocument();
+
+    rerender(<AccountKeySection pubkey={PUBKEY} hostedToken={null} isHostedAccount localNsec={null} />);
+    await waitFor(() => expect(screen.queryByText(NSEC)).not.toBeInTheDocument());
+
+    rerender(<AccountKeySection pubkey={PUBKEY} hostedToken="token-b" isHostedAccount localNsec={null} />);
+    expect(screen.getByLabelText("Divine account password")).toBeInTheDocument();
+    expect(screen.queryByText(NSEC)).not.toBeInTheDocument();
+  });
+
   it("turns policy denial into a restriction state", async () => {
     mockExportAccountKey.mockRejectedValue(new KeyExportError(
       "policy-denied",

--- a/src/components/exit/AccountKeySection.tsx
+++ b/src/components/exit/AccountKeySection.tsx
@@ -1,0 +1,252 @@
+// ABOUTME: Explains account-key ownership and exports hosted keys after explicit confirmation
+// ABOUTME: Keeps revealed secrets transient and cancels stale exports when identity changes
+
+import { Copy, EyeSlash, WarningCircle } from "@phosphor-icons/react";
+import { nip19 } from "nostr-tools";
+import { type FormEvent, useEffect, useId, useRef, useState } from "react";
+
+import { LocalNsecBanner } from "@/components/auth/LocalNsecBanner";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { exportAccountKey, KeyExportError } from "@/lib/exit/keyExportClient";
+
+interface AccountKeySectionProps {
+  pubkey: string | undefined;
+  hostedToken: string | null;
+  localNsec: string | null;
+}
+
+function retryCopy(retryAfterMs?: number): string {
+  if (!retryAfterMs) return "Too many attempts. Wait a bit, then try again.";
+  return `Too many attempts. Try again in about ${Math.max(1, Math.ceil(retryAfterMs / 1_000))} seconds.`;
+}
+
+function exportFailureMessage(error: KeyExportError): string {
+  switch (error.code) {
+    case "email-unverified":
+      return "Verify the email on this account, then try again.";
+    case "invalid-password":
+      return "That password did not match this account.";
+    case "auth-required":
+      return "Your Divine session expired. Sign in again, then return here.";
+    case "rate-limited":
+      return retryCopy(error.retryAfterMs);
+    case "no-hosted-key":
+      return "Divine does not hold a secret key for this account.";
+    case "service-unavailable":
+      return error.retryAfterMs
+        ? `The key service is busy. Try again in about ${Math.max(1, Math.ceil(error.retryAfterMs / 1_000))} seconds.`
+        : "The key service is busy right now. Try again shortly.";
+    case "network-failure":
+      return "Divine could not be reached. Check your connection and try again.";
+    case "malformed-response":
+      return "Divine returned a response this page could not use. Try again.";
+    case "cancelled":
+    case "policy-denied":
+      return "";
+  }
+}
+
+export function AccountKeySection(props: AccountKeySectionProps) {
+  const { pubkey, hostedToken, localNsec } = props;
+  const passwordId = useId();
+  const confirmationId = useId();
+  const [confirmed, setConfirmed] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [nsec, setNsec] = useState<string | null>(null);
+  const [restricted, setRestricted] = useState(false);
+  const [failure, setFailure] = useState<string | null>(null);
+  const [copyStatus, setCopyStatus] = useState<string | null>(null);
+  const activeRequest = useRef<AbortController | null>(null);
+  const attempt = useRef(0);
+  const npub = pubkey ? nip19.npubEncode(pubkey) : null;
+
+  useEffect(() => {
+    attempt.current += 1;
+    activeRequest.current?.abort();
+    activeRequest.current = null;
+    setConfirmed(false);
+    setLoading(false);
+    setNsec(null);
+    setRestricted(false);
+    setFailure(null);
+    setCopyStatus(null);
+
+    return () => {
+      attempt.current += 1;
+      activeRequest.current?.abort();
+    };
+  }, [pubkey, hostedToken]);
+
+  async function copyValue(value: string, label: string) {
+    try {
+      await navigator.clipboard.writeText(value);
+      setCopyStatus(`${label} copied.`);
+    } catch {
+      setCopyStatus(`${label} could not be copied. Select it and copy it manually.`);
+    }
+  }
+
+  function hideSecret() {
+    attempt.current += 1;
+    activeRequest.current?.abort();
+    activeRequest.current = null;
+    setLoading(false);
+    setNsec(null);
+    setFailure(null);
+  }
+
+  async function revealSecret(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    if (!hostedToken || !confirmed) return;
+
+    const form = event.currentTarget;
+    if (!form.reportValidity()) return;
+    const password = String(new FormData(form).get("password") ?? "");
+    form.reset();
+    setConfirmed(false);
+
+    activeRequest.current?.abort();
+    const controller = new AbortController();
+    const requestAttempt = ++attempt.current;
+    activeRequest.current = controller;
+    setLoading(true);
+    setFailure(null);
+    setNsec(null);
+
+    try {
+      const result = await exportAccountKey({
+        token: hostedToken,
+        password,
+        signal: controller.signal,
+      });
+      if (attempt.current === requestAttempt && !controller.signal.aborted) {
+        setNsec(result.nsec);
+      }
+    } catch (error) {
+      if (attempt.current !== requestAttempt || controller.signal.aborted) return;
+      if (error instanceof KeyExportError && error.code === "policy-denied") {
+        setRestricted(true);
+      } else if (error instanceof KeyExportError) {
+        setFailure(exportFailureMessage(error));
+      } else {
+        setFailure("The secret key could not be shown. Try again.");
+      }
+    } finally {
+      if (attempt.current === requestAttempt) {
+        activeRequest.current = null;
+        setLoading(false);
+      }
+    }
+  }
+
+  return (
+    <div className="space-y-5">
+      <Card variant="brand" accent={restricted ? "orange" : "blue"}>
+        <CardContent className="space-y-5 pt-6 text-base leading-relaxed text-muted-foreground">
+          {npub ? (
+            <div className="space-y-2">
+              <p className="font-medium text-foreground">Your public key</p>
+              <p className="break-all font-mono text-sm text-foreground">{npub}</p>
+              <Button type="button" variant="outline" onClick={() => void copyValue(npub, "Public key")}>
+                <Copy className="mr-2 h-4 w-4" />
+                Copy public key
+              </Button>
+            </div>
+          ) : (
+            <p>Sign in to see the public key for your account.</p>
+          )}
+
+          {hostedToken && pubkey ? (
+            restricted ? (
+              <Alert className="border-brand-orange/50 bg-brand-orange/10">
+                <WarningCircle className="h-5 w-5" weight="fill" />
+                <AlertTitle>Secret-key export is restricted</AlertTitle>
+                <AlertDescription>
+                  This account cannot export its secret key. You can still download your archive,
+                  move your media, republish your posts, and publish pointers to your new home.
+                </AlertDescription>
+              </Alert>
+            ) : nsec ? (
+              <div className="space-y-3">
+                <p className="font-medium text-foreground">Your secret key</p>
+                <p className="break-all font-mono text-sm text-foreground">{nsec}</p>
+                <div className="flex flex-wrap gap-2">
+                  <Button type="button" variant="sticker" onClick={() => void copyValue(nsec, "Secret key")}>
+                    <Copy className="mr-2 h-4 w-4" />
+                    Copy secret key
+                  </Button>
+                  <Button type="button" variant="outline" onClick={hideSecret}>
+                    <EyeSlash className="mr-2 h-4 w-4" />
+                    Hide secret key
+                  </Button>
+                </div>
+              </div>
+            ) : (
+              <form className="space-y-4" onSubmit={(event) => void revealSecret(event)}>
+                <div className="space-y-2">
+                  <p>
+                    Divine holds this account&apos;s key for signing. Confirm your account password
+                    to reveal it here. Before typing it, check that your address bar shows divine.video.
+                  </p>
+                  <label className="font-medium text-foreground" htmlFor={passwordId}>
+                    Divine account password
+                  </label>
+                  <Input
+                    autoComplete="current-password"
+                    disabled={loading}
+                    id={passwordId}
+                    name="password"
+                    required
+                    type="password"
+                  />
+                </div>
+                <div className="flex items-start gap-3">
+                  <input
+                    checked={confirmed}
+                    className="mt-1 h-4 w-4 accent-primary"
+                    disabled={loading}
+                    id={confirmationId}
+                    onChange={(event) => setConfirmed(event.currentTarget.checked)}
+                    type="checkbox"
+                  />
+                  <label htmlFor={confirmationId}>
+                    I understand this secret key is the password to my account. It can never be
+                    reset, and nobody can recover it for me.
+                  </label>
+                </div>
+                <Button disabled={!confirmed || loading} type="submit" variant="sticker">
+                  {loading ? "Checking password..." : "Show my secret key"}
+                </Button>
+              </form>
+            )
+          ) : localNsec && pubkey ? (
+            <div className="space-y-3">
+              <p>
+                This account has its own key, stored in this browser rather than on a Divine server.
+                Keep a copy somewhere safe. If it is lost, nobody can restore it for you.
+              </p>
+              <LocalNsecBanner nsec={localNsec} />
+            </div>
+          ) : pubkey ? (
+            <div className="space-y-3">
+              <p>
+                This account signs through a browser extension or another signer. This page cannot
+                reveal a key it does not hold.
+              </p>
+              <p>
+                Your public identity stays yours. Signing new events depends on whichever signer
+                this account uses, while everything in your downloaded archive stays verifiable.
+              </p>
+            </div>
+          ) : null}
+
+          {failure ? <p role="alert" className="text-destructive">{failure}</p> : null}
+          {copyStatus ? <p role="status" className="text-sm">{copyStatus}</p> : null}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/components/exit/AccountKeySection.tsx
+++ b/src/components/exit/AccountKeySection.tsx
@@ -20,7 +20,11 @@ interface AccountKeySectionProps {
 
 function retryCopy(retryAfterMs?: number): string {
   if (!retryAfterMs) return "Too many attempts. Wait a bit, then try again.";
-  return `Too many attempts. Try again in about ${Math.max(1, Math.ceil(retryAfterMs / 1_000))} seconds.`;
+  return `Too many attempts. Try again in about ${retrySeconds(retryAfterMs)} seconds.`;
+}
+
+function retrySeconds(retryAfterMs: number): number {
+  return Math.max(1, Math.ceil(retryAfterMs / 1_000));
 }
 
 function exportFailureMessage(error: KeyExportError): string {
@@ -37,7 +41,7 @@ function exportFailureMessage(error: KeyExportError): string {
       return "Divine does not hold a secret key for this account.";
     case "service-unavailable":
       return error.retryAfterMs
-        ? `The key service is busy. Try again in about ${Math.max(1, Math.ceil(error.retryAfterMs / 1_000))} seconds.`
+        ? `The key service is busy. Try again in about ${retrySeconds(error.retryAfterMs)} seconds.`
         : "The key service is busy right now. Try again shortly.";
     case "network-failure":
       return "Divine could not be reached. Check your connection and try again.";
@@ -62,6 +66,7 @@ export function AccountKeySection(props: AccountKeySectionProps) {
   const activeRequest = useRef<AbortController | null>(null);
   const attempt = useRef(0);
   const npub = pubkey ? nip19.npubEncode(pubkey) : null;
+  const isHostedAccount = !!hostedToken && !!pubkey;
 
   useEffect(() => {
     attempt.current += 1;
@@ -78,7 +83,7 @@ export function AccountKeySection(props: AccountKeySectionProps) {
       attempt.current += 1;
       activeRequest.current?.abort();
     };
-  }, [pubkey, hostedToken]);
+  }, [pubkey, isHostedAccount]);
 
   async function copyValue(value: string, label: string) {
     try {
@@ -159,7 +164,7 @@ export function AccountKeySection(props: AccountKeySectionProps) {
             <p>Sign in to see the public key for your account.</p>
           )}
 
-          {hostedToken && pubkey ? (
+          {isHostedAccount ? (
             restricted ? (
               <Alert className="border-brand-orange/50 bg-brand-orange/10">
                 <WarningCircle className="h-5 w-5" weight="fill" />
@@ -172,7 +177,7 @@ export function AccountKeySection(props: AccountKeySectionProps) {
             ) : nsec ? (
               <div className="space-y-3">
                 <p className="font-medium text-foreground">Your secret key</p>
-                <p className="break-all font-mono text-sm text-foreground">{nsec}</p>
+                <p data-sentry-mask className="break-all font-mono text-sm text-foreground">{nsec}</p>
                 <div className="flex flex-wrap gap-2">
                   <Button type="button" variant="sticker" onClick={() => void copyValue(nsec, "Secret key")}>
                     <Copy className="mr-2 h-4 w-4" />
@@ -228,7 +233,6 @@ export function AccountKeySection(props: AccountKeySectionProps) {
                 This account has its own key, stored in this browser rather than on a Divine server.
                 Keep a copy somewhere safe. If it is lost, nobody can restore it for you.
               </p>
-              <LocalNsecBanner nsec={localNsec} />
             </div>
           ) : pubkey ? (
             <div className="space-y-3">
@@ -242,6 +246,8 @@ export function AccountKeySection(props: AccountKeySectionProps) {
               </p>
             </div>
           ) : null}
+
+          {localNsec && pubkey ? <LocalNsecBanner nsec={localNsec} /> : null}
 
           {failure ? <p role="alert" className="text-destructive">{failure}</p> : null}
           {copyStatus ? <p role="status" className="text-sm">{copyStatus}</p> : null}

--- a/src/components/exit/AccountKeySection.tsx
+++ b/src/components/exit/AccountKeySection.tsx
@@ -67,6 +67,7 @@ export function AccountKeySection(props: AccountKeySectionProps) {
   const activeRequest = useRef<AbortController | null>(null);
   const attempt = useRef(0);
   const npub = pubkey ? nip19.npubEncode(pubkey) : null;
+  const hasHostedToken = !!hostedToken;
 
   useEffect(() => {
     attempt.current += 1;
@@ -83,7 +84,7 @@ export function AccountKeySection(props: AccountKeySectionProps) {
       attempt.current += 1;
       activeRequest.current?.abort();
     };
-  }, [pubkey, isHostedAccount]);
+  }, [pubkey, isHostedAccount, hasHostedToken]);
 
   async function copyValue(value: string, label: string) {
     try {

--- a/src/components/exit/AccountKeySection.tsx
+++ b/src/components/exit/AccountKeySection.tsx
@@ -15,6 +15,7 @@ import { exportAccountKey, KeyExportError } from "@/lib/exit/keyExportClient";
 interface AccountKeySectionProps {
   pubkey: string | undefined;
   hostedToken: string | null;
+  isHostedAccount: boolean;
   localNsec: string | null;
 }
 
@@ -54,7 +55,7 @@ function exportFailureMessage(error: KeyExportError): string {
 }
 
 export function AccountKeySection(props: AccountKeySectionProps) {
-  const { pubkey, hostedToken, localNsec } = props;
+  const { pubkey, hostedToken, isHostedAccount, localNsec } = props;
   const passwordId = useId();
   const confirmationId = useId();
   const [confirmed, setConfirmed] = useState(false);
@@ -66,7 +67,6 @@ export function AccountKeySection(props: AccountKeySectionProps) {
   const activeRequest = useRef<AbortController | null>(null);
   const attempt = useRef(0);
   const npub = pubkey ? nip19.npubEncode(pubkey) : null;
-  const isHostedAccount = !!hostedToken && !!pubkey;
 
   useEffect(() => {
     attempt.current += 1;
@@ -165,8 +165,16 @@ export function AccountKeySection(props: AccountKeySectionProps) {
           )}
 
           {isHostedAccount ? (
-            restricted ? (
-              <Alert className="border-brand-orange/50 bg-brand-orange/10">
+            !hostedToken ? (
+              <Alert data-sentry-mask>
+                <WarningCircle className="h-5 w-5" weight="fill" />
+                <AlertTitle>Your Divine session expired</AlertTitle>
+                <AlertDescription>
+                  Sign in again, then return here to reveal this account&apos;s secret key.
+                </AlertDescription>
+              </Alert>
+            ) : restricted ? (
+              <Alert data-sentry-mask className="border-brand-orange/50 bg-brand-orange/10">
                 <WarningCircle className="h-5 w-5" weight="fill" />
                 <AlertTitle>Secret-key export is restricted</AlertTitle>
                 <AlertDescription>
@@ -249,8 +257,8 @@ export function AccountKeySection(props: AccountKeySectionProps) {
 
           {localNsec && pubkey ? <LocalNsecBanner nsec={localNsec} /> : null}
 
-          {failure ? <p role="alert" className="text-destructive">{failure}</p> : null}
-          {copyStatus ? <p role="status" className="text-sm">{copyStatus}</p> : null}
+          {failure ? <p data-sentry-mask role="alert" className="text-destructive">{failure}</p> : null}
+          {copyStatus ? <p data-sentry-mask role="status" className="text-sm">{copyStatus}</p> : null}
         </CardContent>
       </Card>
     </div>

--- a/src/hooks/useCurrentUser.test.ts
+++ b/src/hooks/useCurrentUser.test.ts
@@ -172,6 +172,7 @@ describe('useCurrentUser', () => {
 
     await waitFor(() => expect(result.current.user?.pubkey).toBe('e'.repeat(64)));
     expect(result.current.hostedToken).toBeNull();
+    expect(result.current.isHostedAccount).toBe(true);
   });
 
   it('does not fall back to a manual account while a JWT session is still initializing', () => {

--- a/src/hooks/useCurrentUser.test.ts
+++ b/src/hooks/useCurrentUser.test.ts
@@ -6,12 +6,14 @@ import { NIP07_GRACE_MS, NIP07_POLL_INTERVAL_MS } from './useNip07Availability';
 
 const {
   mockGetValidToken,
+  mockIsExpired,
   mockJwtSigner,
   mockLogins,
   mockReleaseBunkerSignersExcept,
   mockUseAuthor,
 } = vi.hoisted(() => ({
   mockGetValidToken: vi.fn<() => string | null>(() => null),
+  mockIsExpired: { value: false },
   mockJwtSigner: {
     getPublicKey: vi.fn<() => Promise<string>>(),
     signEvent: vi.fn(),
@@ -45,6 +47,7 @@ vi.mock('./useAuthor.ts', () => ({
 vi.mock('@/hooks/useDivineSession', () => ({
   useDivineSession: () => ({
     getValidToken: mockGetValidToken,
+    isExpired: mockIsExpired.value,
   }),
 }));
 
@@ -78,6 +81,7 @@ describe('useCurrentUser', () => {
     mockLogins.length = 0;
     mockGetValidToken.mockReset();
     mockGetValidToken.mockReturnValue(null);
+    mockIsExpired.value = false;
     mockJwtSigner.getPublicKey.mockReset();
     mockJwtSigner.signEvent.mockReset();
     mockUseAuthor.mockClear();
@@ -132,6 +136,7 @@ describe('useCurrentUser', () => {
 
     expect(result.current.users).toHaveLength(1);
     expect(result.current.signer).toBe(mockJwtSigner);
+    expect(result.current.hostedToken).toBe('jwt-token');
     expect(mockUseAuthor).toHaveBeenCalledWith('b'.repeat(64));
   });
 
@@ -156,6 +161,17 @@ describe('useCurrentUser', () => {
 
     expect(result.current.users).toHaveLength(1);
     expect(result.current.signer).toBe(mockJwtSigner);
+  });
+
+  it('does not expose an expired hosted token for key export', async () => {
+    mockGetValidToken.mockReturnValue('expired-token');
+    mockIsExpired.value = true;
+    mockJwtSigner.getPublicKey.mockResolvedValue('e'.repeat(64));
+
+    const { result } = renderHook(() => useCurrentUser());
+
+    await waitFor(() => expect(result.current.user?.pubkey).toBe('e'.repeat(64)));
+    expect(result.current.hostedToken).toBeNull();
   });
 
   it('does not fall back to a manual account while a JWT session is still initializing', () => {
@@ -199,6 +215,7 @@ describe('useCurrentUser', () => {
     });
     expect(result.current.users).toHaveLength(1);
     expect(result.current.signer).toBeDefined();
+    expect(result.current.hostedToken).toBeNull();
   });
 
   it('reports isResolvingJwt while the session initializes, then clears it', async () => {

--- a/src/hooks/useCurrentUser.test.ts
+++ b/src/hooks/useCurrentUser.test.ts
@@ -218,6 +218,17 @@ describe('useCurrentUser', () => {
     expect(result.current.hostedToken).toBeNull();
   });
 
+  it('does not expose a hosted token when JWT resolution fails without a current user', async () => {
+    mockGetValidToken.mockReturnValue('jwt-token');
+    mockJwtSigner.getPublicKey.mockRejectedValue(new Error('rpc failed'));
+
+    const { result } = renderHook(() => useCurrentUser());
+
+    await waitFor(() => expect(result.current.isResolvingJwt).toBe(false));
+    expect(result.current.user).toBeUndefined();
+    expect(result.current.hostedToken).toBeNull();
+  });
+
   it('reports isResolvingJwt while the session initializes, then clears it', async () => {
     mockGetValidToken.mockReturnValue('jwt-token');
     let resolvePubkey: (pubkey: string) => void = () => {};

--- a/src/hooks/useCurrentUser.ts
+++ b/src/hooks/useCurrentUser.ts
@@ -134,7 +134,7 @@ export function useCurrentUser() {
   const user = users[0];
   const signer = useMemo(() => getSafeUserSigner(user), [user]);
   const author = useAuthor(user?.pubkey);
-  const hostedToken = !isExpired && user?.pubkey === jwtPubkey ? token : null;
+  const hostedToken = !isExpired && !!user?.pubkey && user.pubkey === jwtPubkey ? token : null;
 
   return {
     user,

--- a/src/hooks/useCurrentUser.ts
+++ b/src/hooks/useCurrentUser.ts
@@ -24,7 +24,7 @@ type JwtResolution =
 
 export function useCurrentUser() {
   const { logins } = useNostrLogin();
-  const { getValidToken } = useDivineSession();
+  const { getValidToken, isExpired } = useDivineSession();
   const token = getValidToken();
   const [jwtResolution, setJwtResolution] = useState<JwtResolution>();
   const jwtSigner = useMemo(() => (
@@ -134,11 +134,13 @@ export function useCurrentUser() {
   const user = users[0];
   const signer = useMemo(() => getSafeUserSigner(user), [user]);
   const author = useAuthor(user?.pubkey);
+  const hostedToken = !isExpired && user?.pubkey === jwtPubkey ? token : null;
 
   return {
     user,
     users,
     signer,
+    hostedToken,
     isResolvingJwt,
     ...author.data,
   };

--- a/src/hooks/useCurrentUser.ts
+++ b/src/hooks/useCurrentUser.ts
@@ -134,13 +134,15 @@ export function useCurrentUser() {
   const user = users[0];
   const signer = useMemo(() => getSafeUserSigner(user), [user]);
   const author = useAuthor(user?.pubkey);
-  const hostedToken = !isExpired && !!user?.pubkey && user.pubkey === jwtPubkey ? token : null;
+  const isHostedAccount = !!user?.pubkey && user.pubkey === jwtPubkey;
+  const hostedToken = !isExpired && isHostedAccount ? token : null;
 
   return {
     user,
     users,
     signer,
     hostedToken,
+    isHostedAccount,
     isResolvingJwt,
     ...author.data,
   };

--- a/src/lib/exit/keyExportClient.test.ts
+++ b/src/lib/exit/keyExportClient.test.ts
@@ -1,0 +1,107 @@
+import { nip19 } from "nostr-tools";
+import { describe, expect, it, vi } from "vitest";
+
+import { exportAccountKey, KeyExportError } from "./keyExportClient";
+
+const NSEC = nip19.nsecEncode(new Uint8Array(32).fill(7));
+
+function response(status: number, body: unknown, headers?: HeadersInit): Response {
+  return new Response(typeof body === "string" ? body : JSON.stringify(body), {
+    status,
+    headers,
+  });
+}
+
+async function expectCode(fetcher: typeof fetch, code: KeyExportError["code"]) {
+  await expect(exportAccountKey({ token: "token", password: "password", fetcher }))
+    .rejects.toMatchObject({ code });
+}
+
+describe("exportAccountKey", () => {
+  it("posts the password and returns a validated nsec", async () => {
+    const fetcher = vi.fn<typeof fetch>().mockResolvedValue(response(200, { key: NSEC }));
+
+    await expect(exportAccountKey({ token: "token", password: "password", fetcher }))
+      .resolves.toEqual({ nsec: NSEC });
+    expect(fetcher).toHaveBeenCalledWith(
+      "https://login.divine.video/api/user/export-key",
+      expect.objectContaining({
+        method: "POST",
+        headers: expect.objectContaining({ Authorization: "Bearer token" }),
+        body: JSON.stringify({ password: "password", format: "nsec" }),
+      }),
+    );
+  });
+
+  it.each([
+    [403, { error: "Operation denied by policy", code: "KEY_EGRESS_DENIED" }, "policy-denied"],
+    [403, { error: "Verify your email", code: "EMAIL_NOT_VERIFIED" }, "email-unverified"],
+    [401, "Invalid email or password. Please check your credentials and try again.", "invalid-password"],
+    [401, "Invalid or expired token. Please log in again.", "auth-required"],
+    [404, "No account found with this email. Please register first.", "no-hosted-key"],
+    [503, { error: "Password verification timed out. Please retry." }, "service-unavailable"],
+  ] as const)("maps status %s to %s", async (status, body, code) => {
+    await expectCode(vi.fn<typeof fetch>().mockResolvedValue(response(status, body)), code);
+  });
+
+  it("maps rate limits by code and caps Retry-After", async () => {
+    const fetcher = vi.fn<typeof fetch>().mockResolvedValue(response(
+      429,
+      { error: "Too many attempts", code: "TOO_MANY_ATTEMPTS" },
+      { "Retry-After": "3600" },
+    ));
+
+    await expect(exportAccountKey({ token: "token", password: "password", fetcher }))
+      .rejects.toMatchObject({ code: "rate-limited", retryAfterMs: 60_000 });
+  });
+
+  it("parses an HTTP-date Retry-After value", async () => {
+    const now = Date.now();
+    const fetcher = vi.fn<typeof fetch>().mockResolvedValue(response(
+      503,
+      { error: "Busy" },
+      { "Retry-After": new Date(now + 5_000).toUTCString() },
+    ));
+
+    try {
+      await exportAccountKey({ token: "token", password: "password", fetcher, now: () => now });
+    } catch (error) {
+      expect(error).toMatchObject({ code: "service-unavailable" });
+      expect((error as KeyExportError).retryAfterMs).toBeGreaterThanOrEqual(4_000);
+      expect((error as KeyExportError).retryAfterMs).toBeLessThanOrEqual(5_000);
+    }
+  });
+
+  it.each([
+    {},
+    { key: "not-an-nsec" },
+    { key: nip19.npubEncode("a".repeat(64)) },
+  ])("rejects a malformed successful response", async (body) => {
+    await expectCode(
+      vi.fn<typeof fetch>().mockResolvedValue(response(200, body)),
+      "malformed-response",
+    );
+  });
+
+  it("distinguishes cancellation from network failure", async () => {
+    const cancelled = vi.fn<typeof fetch>().mockRejectedValue(new DOMException("Aborted", "AbortError"));
+    const failed = vi.fn<typeof fetch>().mockRejectedValue(new TypeError("offline"));
+
+    await expectCode(cancelled, "cancelled");
+    await expectCode(failed, "network-failure");
+  });
+
+  it("never includes a returned key in errors or console output", async () => {
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    const consoleWarn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    const fetcher = vi.fn<typeof fetch>().mockResolvedValue(response(500, { error: NSEC }));
+
+    try {
+      await exportAccountKey({ token: "token", password: "password", fetcher });
+    } catch (error) {
+      expect(String(error)).not.toContain(NSEC);
+    }
+    expect(consoleError).not.toHaveBeenCalled();
+    expect(consoleWarn).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/exit/keyExportClient.test.ts
+++ b/src/lib/exit/keyExportClient.test.ts
@@ -44,6 +44,14 @@ describe("exportAccountKey", () => {
     await expectCode(vi.fn<typeof fetch>().mockResolvedValue(response(status, body)), code);
   });
 
+  it.each([
+    [401, '', 'auth-required'],
+    [401, 'Unauthorized', 'auth-required'],
+    [403, 'Forbidden', 'policy-denied'],
+  ] as const)('fails closed for ambiguous status %s as %s', async (status, body, code) => {
+    await expectCode(vi.fn<typeof fetch>().mockResolvedValue(response(status, body)), code);
+  });
+
   it("maps rate limits by code and caps Retry-After", async () => {
     const fetcher = vi.fn<typeof fetch>().mockResolvedValue(response(
       429,

--- a/src/lib/exit/keyExportClient.ts
+++ b/src/lib/exit/keyExportClient.ts
@@ -117,7 +117,7 @@ function failureFor(
       404,
     );
   }
-  if (response.status === 503 || response.status >= 500) {
+  if (response.status >= 500) {
     return new KeyExportError(
       "service-unavailable",
       "The key service is busy right now. Try again shortly.",

--- a/src/lib/exit/keyExportClient.ts
+++ b/src/lib/exit/keyExportClient.ts
@@ -69,11 +69,12 @@ async function readFailure(response: Response): Promise<{ code?: string; message
   }
 }
 
-function isAuthFailure(message?: string): boolean {
+function isInvalidPassword(message?: string): boolean {
   const normalized = message?.toLowerCase() ?? "";
-  return normalized.includes("authentication required")
-    || normalized.includes("invalid or expired token")
-    || normalized.includes("valid token");
+  return normalized.includes("invalid email or password")
+    || normalized.includes("invalid password")
+    || normalized.includes("incorrect password")
+    || normalized.includes("password did not match");
 }
 
 function failureFor(
@@ -106,9 +107,16 @@ function failureFor(
     );
   }
   if (response.status === 401) {
-    return isAuthFailure(body.message)
-      ? new KeyExportError("auth-required", "Your Divine session expired. Sign in again.", 401)
-      : new KeyExportError("invalid-password", "That password did not match this account.", 401);
+    return isInvalidPassword(body.message)
+      ? new KeyExportError("invalid-password", "That password did not match this account.", 401)
+      : new KeyExportError("auth-required", "Your Divine session expired. Sign in again.", 401);
+  }
+  if (response.status === 403) {
+    return new KeyExportError(
+      "policy-denied",
+      "Divine cannot export the secret key for this account.",
+      403,
+    );
   }
   if (response.status === 404) {
     return new KeyExportError(

--- a/src/lib/exit/keyExportClient.ts
+++ b/src/lib/exit/keyExportClient.ts
@@ -1,0 +1,195 @@
+// ABOUTME: Re-authenticates hosted accounts and retrieves their portable Nostr secret key
+// ABOUTME: Converts Keycast responses into safe typed failures without exposing response secrets
+
+import { nip19 } from "nostr-tools";
+
+import { DIVINE_LOGIN_ORIGIN } from "@/lib/divineLoginOrigin";
+
+export type KeyExportFailureCode =
+  | "policy-denied"
+  | "email-unverified"
+  | "invalid-password"
+  | "auth-required"
+  | "rate-limited"
+  | "no-hosted-key"
+  | "service-unavailable"
+  | "malformed-response"
+  | "network-failure"
+  | "cancelled";
+
+export class KeyExportError extends Error {
+  constructor(
+    public readonly code: KeyExportFailureCode,
+    message: string,
+    public readonly status?: number,
+    public readonly retryAfterMs?: number,
+  ) {
+    super(message);
+    this.name = "KeyExportError";
+  }
+}
+
+interface KeyExportOptions {
+  token: string;
+  password: string;
+  signal?: AbortSignal;
+  fetcher?: typeof fetch;
+  now?: () => number;
+}
+
+const MAX_RETRY_AFTER_MS = 60_000;
+
+function parseRetryAfter(response: Response, now: () => number): number | undefined {
+  const value = response.headers.get("retry-after");
+  if (!value) return undefined;
+
+  const seconds = Number(value);
+  const milliseconds = Number.isFinite(seconds)
+    ? seconds * 1_000
+    : Date.parse(value) - now();
+
+  if (!Number.isFinite(milliseconds) || milliseconds < 0) return undefined;
+  return Math.min(milliseconds, MAX_RETRY_AFTER_MS);
+}
+
+async function readFailure(response: Response): Promise<{ code?: string; message?: string }> {
+  try {
+    const text = await response.text();
+    try {
+      const body = JSON.parse(text) as { code?: unknown; error?: unknown };
+      return {
+        code: typeof body.code === "string" ? body.code : undefined,
+        message: typeof body.error === "string" ? body.error : undefined,
+      };
+    } catch {
+      return { message: text };
+    }
+  } catch {
+    return {};
+  }
+}
+
+function isAuthFailure(message?: string): boolean {
+  const normalized = message?.toLowerCase() ?? "";
+  return normalized.includes("authentication required")
+    || normalized.includes("invalid or expired token")
+    || normalized.includes("valid token");
+}
+
+function failureFor(
+  response: Response,
+  body: { code?: string; message?: string },
+  now: () => number,
+): KeyExportError {
+  const retryAfterMs = parseRetryAfter(response, now);
+
+  if (body.code === "KEY_EGRESS_DENIED") {
+    return new KeyExportError(
+      "policy-denied",
+      "Divine cannot export the secret key for this account.",
+      response.status,
+    );
+  }
+  if (body.code === "EMAIL_NOT_VERIFIED") {
+    return new KeyExportError(
+      "email-unverified",
+      "Verify the email on this account before exporting its secret key.",
+      response.status,
+    );
+  }
+  if (body.code === "TOO_MANY_ATTEMPTS" || response.status === 429) {
+    return new KeyExportError(
+      "rate-limited",
+      "Too many attempts. Wait a bit, then try again.",
+      response.status,
+      retryAfterMs,
+    );
+  }
+  if (response.status === 401) {
+    return isAuthFailure(body.message)
+      ? new KeyExportError("auth-required", "Your Divine session expired. Sign in again.", 401)
+      : new KeyExportError("invalid-password", "That password did not match this account.", 401);
+  }
+  if (response.status === 404) {
+    return new KeyExportError(
+      "no-hosted-key",
+      "Divine does not hold a secret key for this account.",
+      404,
+    );
+  }
+  if (response.status === 503 || response.status >= 500) {
+    return new KeyExportError(
+      "service-unavailable",
+      "The key service is busy right now. Try again shortly.",
+      response.status,
+      retryAfterMs,
+    );
+  }
+
+  return new KeyExportError(
+    "malformed-response",
+    "Divine returned a response this page could not use.",
+    response.status,
+  );
+}
+
+function validateNsec(body: unknown): string {
+  if (!body || typeof body !== "object" || Array.isArray(body)) {
+    throw new KeyExportError("malformed-response", "Divine returned a response this page could not use.");
+  }
+
+  const key = (body as { key?: unknown }).key;
+  if (typeof key !== "string") {
+    throw new KeyExportError("malformed-response", "Divine returned a response this page could not use.");
+  }
+
+  try {
+    const decoded = nip19.decode(key);
+    if (decoded.type !== "nsec" || !(decoded.data instanceof Uint8Array) || decoded.data.length !== 32) {
+      throw new Error("invalid nsec");
+    }
+  } catch {
+    throw new KeyExportError("malformed-response", "Divine returned a response this page could not use.");
+  }
+
+  return key;
+}
+
+export async function exportAccountKey(options: KeyExportOptions): Promise<{ nsec: string }> {
+  const {
+    token,
+    password,
+    signal,
+    fetcher = fetch,
+    now = Date.now,
+  } = options;
+
+  let response: Response;
+  try {
+    response = await fetcher(`${DIVINE_LOGIN_ORIGIN}/api/user/export-key`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ password, format: "nsec" }),
+      signal,
+    });
+  } catch (error) {
+    if (error instanceof DOMException && error.name === "AbortError") {
+      throw new KeyExportError("cancelled", "The key export was cancelled.");
+    }
+    throw new KeyExportError("network-failure", "Divine could not be reached. Check your connection and try again.");
+  }
+
+  if (!response.ok) {
+    throw failureFor(response, await readFailure(response), now);
+  }
+
+  try {
+    return { nsec: validateNsec(await response.json()) };
+  } catch (error) {
+    if (error instanceof KeyExportError) throw error;
+    throw new KeyExportError("malformed-response", "Divine returned a response this page could not use.");
+  }
+}

--- a/src/lib/sentry.ts
+++ b/src/lib/sentry.ts
@@ -3,6 +3,7 @@
 
 import * as Sentry from '@sentry/react';
 import {
+  shouldDropHandledKeyExportHttpClientEvent,
   shouldDropFunnelcakeHttpClientEvent,
   shouldDropHandledMediaHttpClientEvent,
 } from '@/lib/sentryHttpClientFilter';
@@ -204,6 +205,10 @@ export function initializeSentry() {
 
     // Don't send PII
     beforeSend(event) {
+      if (shouldDropHandledKeyExportHttpClientEvent(event)) {
+        return null;
+      }
+
       if (shouldDropHandledMediaHttpClientEvent(event)) {
         return null;
       }

--- a/src/lib/sentry.ts
+++ b/src/lib/sentry.ts
@@ -4,6 +4,7 @@
 import * as Sentry from '@sentry/react';
 import {
   shouldDropHandledKeyExportHttpClientEvent,
+  shouldDropKeyExportReplayEvent,
   shouldDropFunnelcakeHttpClientEvent,
   shouldDropHandledMediaHttpClientEvent,
 } from '@/lib/sentryHttpClientFilter';
@@ -140,6 +141,9 @@ export function initializeSentry() {
       Sentry.replayIntegration({
         maskAllText: false,
         blockAllMedia: false,
+        beforeAddRecordingEvent(event) {
+          return shouldDropKeyExportReplayEvent(event) ? null : event;
+        },
       }),
       Sentry.httpClientIntegration({ failedRequestStatusCodes: [[400, 599]] }),
       Sentry.captureConsoleIntegration({ levels: ['error', 'warn'] }),

--- a/src/lib/sentry.ts
+++ b/src/lib/sentry.ts
@@ -4,6 +4,7 @@
 import * as Sentry from '@sentry/react';
 import {
   shouldDropHandledKeyExportHttpClientEvent,
+  shouldDropKeyExportBreadcrumb,
   shouldDropKeyExportReplayEvent,
   shouldDropFunnelcakeHttpClientEvent,
   shouldDropHandledMediaHttpClientEvent,
@@ -148,6 +149,10 @@ export function initializeSentry() {
       Sentry.httpClientIntegration({ failedRequestStatusCodes: [[400, 599]] }),
       Sentry.captureConsoleIntegration({ levels: ['error', 'warn'] }),
     ],
+
+    beforeBreadcrumb(breadcrumb) {
+      return shouldDropKeyExportBreadcrumb(breadcrumb) ? null : breadcrumb;
+    },
 
     // Filter out noise - browser environment errors we can't fix
     ignoreErrors: [

--- a/src/lib/sentryHttpClientFilter.test.ts
+++ b/src/lib/sentryHttpClientFilter.test.ts
@@ -1,8 +1,38 @@
 import { describe, expect, it } from 'vitest';
 import {
+  shouldDropHandledKeyExportHttpClientEvent,
   shouldDropFunnelcakeHttpClientEvent,
   shouldDropHandledMediaHttpClientEvent,
 } from '@/lib/sentryHttpClientFilter';
+
+describe('shouldDropHandledKeyExportHttpClientEvent', () => {
+  it.each([401, 403, 404, 429])('drops handled key-export status %s', (statusCode) => {
+    const event = createHttpClientEvent({
+      url: 'https://login.divine.video/api/user/export-key',
+      statusCode,
+    });
+
+    expect(shouldDropHandledKeyExportHttpClientEvent(event)).toBe(true);
+  });
+
+  it('keeps server failures from the key-export endpoint', () => {
+    const event = createHttpClientEvent({
+      url: 'https://login.divine.video/api/user/export-key',
+      statusCode: 503,
+    });
+
+    expect(shouldDropHandledKeyExportHttpClientEvent(event)).toBe(false);
+  });
+
+  it('keeps failures from other login endpoints', () => {
+    const event = createHttpClientEvent({
+      url: 'https://login.divine.video/api/user/change-key',
+      statusCode: 403,
+    });
+
+    expect(shouldDropHandledKeyExportHttpClientEvent(event)).toBe(false);
+  });
+});
 
 interface TestEventOptions {
   url?: string;

--- a/src/lib/sentryHttpClientFilter.test.ts
+++ b/src/lib/sentryHttpClientFilter.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import {
   shouldDropHandledKeyExportHttpClientEvent,
+  shouldDropKeyExportBreadcrumb,
   shouldDropKeyExportReplayEvent,
   shouldDropFunnelcakeHttpClientEvent,
   shouldDropHandledMediaHttpClientEvent,
@@ -32,6 +33,27 @@ describe('shouldDropHandledKeyExportHttpClientEvent', () => {
     });
 
     expect(shouldDropHandledKeyExportHttpClientEvent(event)).toBe(false);
+  });
+});
+
+describe('shouldDropKeyExportBreadcrumb', () => {
+  it.each(['fetch', 'xhr'])('drops key-export %s breadcrumbs', (category) => {
+    expect(shouldDropKeyExportBreadcrumb({
+      category,
+      type: 'http',
+      data: {
+        url: 'https://login.divine.video/api/user/export-key',
+        status_code: 403,
+      },
+    })).toBe(true);
+  });
+
+  it('keeps breadcrumbs for other login endpoints', () => {
+    expect(shouldDropKeyExportBreadcrumb({
+      category: 'fetch',
+      type: 'http',
+      data: { url: 'https://login.divine.video/api/user/account' },
+    })).toBe(false);
   });
 });
 

--- a/src/lib/sentryHttpClientFilter.test.ts
+++ b/src/lib/sentryHttpClientFilter.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import {
   shouldDropHandledKeyExportHttpClientEvent,
+  shouldDropKeyExportReplayEvent,
   shouldDropFunnelcakeHttpClientEvent,
   shouldDropHandledMediaHttpClientEvent,
 } from '@/lib/sentryHttpClientFilter';
@@ -31,6 +32,52 @@ describe('shouldDropHandledKeyExportHttpClientEvent', () => {
     });
 
     expect(shouldDropHandledKeyExportHttpClientEvent(event)).toBe(false);
+  });
+});
+
+describe('shouldDropKeyExportReplayEvent', () => {
+  it.each(['resource.fetch', 'resource.xhr'])('drops key-export %s spans', (op) => {
+    const event = {
+      data: {
+        tag: 'performanceSpan',
+        payload: {
+          op,
+          description: 'https://login.divine.video/api/user/export-key',
+          data: { statusCode: 403, request: { size: 52 } },
+        },
+      },
+    };
+
+    expect(shouldDropKeyExportReplayEvent(event)).toBe(true);
+  });
+
+  it('keeps other replay network spans', () => {
+    const event = {
+      data: {
+        tag: 'performanceSpan',
+        payload: {
+          op: 'resource.fetch',
+          description: 'https://login.divine.video/api/user/account',
+          data: { statusCode: 403 },
+        },
+      },
+    };
+
+    expect(shouldDropKeyExportReplayEvent(event)).toBe(false);
+  });
+
+  it('keeps non-network replay events', () => {
+    const event = {
+      data: {
+        tag: 'breadcrumb',
+        payload: {
+          op: 'resource.fetch',
+          description: 'https://login.divine.video/api/user/export-key',
+        },
+      },
+    };
+
+    expect(shouldDropKeyExportReplayEvent(event)).toBe(false);
   });
 });
 

--- a/src/lib/sentryHttpClientFilter.test.ts
+++ b/src/lib/sentryHttpClientFilter.test.ts
@@ -55,6 +55,13 @@ describe('shouldDropKeyExportBreadcrumb', () => {
       data: { url: 'https://login.divine.video/api/user/account' },
     })).toBe(false);
   });
+
+  it('drops the exact key-export URL even when the breadcrumb shape changes', () => {
+    expect(shouldDropKeyExportBreadcrumb({
+      category: 'request',
+      data: { url: 'https://login.divine.video/api/user/export-key' },
+    })).toBe(true);
+  });
 });
 
 describe('shouldDropKeyExportReplayEvent', () => {

--- a/src/lib/sentryHttpClientFilter.ts
+++ b/src/lib/sentryHttpClientFilter.ts
@@ -30,6 +30,12 @@ type ReplayRecordingEventLike = {
   };
 };
 
+type BreadcrumbLike = {
+  category?: unknown;
+  type?: unknown;
+  data?: Record<string, unknown>;
+};
+
 const MEDIA_HOSTNAME = 'media.divine.video';
 const FUNNELCAKE_API_HOSTNAMES = new Set([
   'api.divine.video',
@@ -215,6 +221,16 @@ export function shouldDropHandledKeyExportHttpClientEvent(event: SentryEventLike
     || statusCode === 403
     || statusCode === 404
     || statusCode === 429;
+}
+
+export function shouldDropKeyExportBreadcrumb(breadcrumb: BreadcrumbLike): boolean {
+  if (breadcrumb.type !== 'http'
+    || (breadcrumb.category !== 'fetch' && breadcrumb.category !== 'xhr')) {
+    return false;
+  }
+
+  const requestUrl = toSafeString(breadcrumb.data?.url);
+  return requestUrl ? isKeyExportUrl(requestUrl) : false;
 }
 
 export function shouldDropKeyExportReplayEvent(event: ReplayRecordingEventLike): boolean {

--- a/src/lib/sentryHttpClientFilter.ts
+++ b/src/lib/sentryHttpClientFilter.ts
@@ -224,11 +224,6 @@ export function shouldDropHandledKeyExportHttpClientEvent(event: SentryEventLike
 }
 
 export function shouldDropKeyExportBreadcrumb(breadcrumb: BreadcrumbLike): boolean {
-  if (breadcrumb.type !== 'http'
-    || (breadcrumb.category !== 'fetch' && breadcrumb.category !== 'xhr')) {
-    return false;
-  }
-
   const requestUrl = toSafeString(breadcrumb.data?.url);
   return requestUrl ? isKeyExportUrl(requestUrl) : false;
 }

--- a/src/lib/sentryHttpClientFilter.ts
+++ b/src/lib/sentryHttpClientFilter.ts
@@ -1,3 +1,5 @@
+import { DIVINE_LOGIN_ORIGIN } from '@/lib/divineLoginOrigin';
+
 type SentryExceptionValue = {
   value?: unknown;
   mechanism?: {
@@ -21,8 +23,14 @@ type SentryEventLike = {
   };
 };
 
+type ReplayRecordingEventLike = {
+  data?: {
+    tag?: unknown;
+    payload?: unknown;
+  };
+};
+
 const MEDIA_HOSTNAME = 'media.divine.video';
-const DIVINE_LOGIN_HOSTNAME = 'login.divine.video';
 const FUNNELCAKE_API_HOSTNAMES = new Set([
   'api.divine.video',
   'api.staging.divine.video',
@@ -141,6 +149,17 @@ function isFunnelcakeFallbackReportedPath(pathname: string): boolean {
   return false;
 }
 
+function isKeyExportUrl(value: string): boolean {
+  try {
+    const requestUrl = new URL(value);
+    const loginUrl = new URL(DIVINE_LOGIN_ORIGIN);
+    return requestUrl.origin === loginUrl.origin
+      && requestUrl.pathname === '/api/user/export-key';
+  } catch {
+    return false;
+  }
+}
+
 /**
  * Filters raw "HTTP Client Error" events for Funnelcake REST API requests.
  *
@@ -187,17 +206,7 @@ export function shouldDropHandledKeyExportHttpClientEvent(event: SentryEventLike
     return false;
   }
 
-  let parsedUrl: URL;
-  try {
-    parsedUrl = new URL(requestUrl);
-  } catch {
-    return false;
-  }
-
-  if (
-    parsedUrl.hostname !== DIVINE_LOGIN_HOSTNAME
-    || parsedUrl.pathname !== '/api/user/export-key'
-  ) {
+  if (!isKeyExportUrl(requestUrl)) {
     return false;
   }
 
@@ -206,6 +215,24 @@ export function shouldDropHandledKeyExportHttpClientEvent(event: SentryEventLike
     || statusCode === 403
     || statusCode === 404
     || statusCode === 429;
+}
+
+export function shouldDropKeyExportReplayEvent(event: ReplayRecordingEventLike): boolean {
+  if (event.data?.tag !== 'performanceSpan') {
+    return false;
+  }
+
+  const payload = event.data.payload;
+  if (!payload || typeof payload !== 'object') {
+    return false;
+  }
+
+  const { op, description } = payload as { op?: unknown; description?: unknown };
+  if (op !== 'resource.fetch' && op !== 'resource.xhr') {
+    return false;
+  }
+
+  return typeof description === 'string' && isKeyExportUrl(description);
 }
 
 /**

--- a/src/lib/sentryHttpClientFilter.ts
+++ b/src/lib/sentryHttpClientFilter.ts
@@ -22,6 +22,7 @@ type SentryEventLike = {
 };
 
 const MEDIA_HOSTNAME = 'media.divine.video';
+const DIVINE_LOGIN_HOSTNAME = 'login.divine.video';
 const FUNNELCAKE_API_HOSTNAMES = new Set([
   'api.divine.video',
   'api.staging.divine.video',
@@ -174,6 +175,37 @@ export function shouldDropFunnelcakeHttpClientEvent(event: SentryEventLike): boo
 
   return FUNNELCAKE_RELAY_HOSTNAMES.has(parsedUrl.hostname)
     && parsedUrl.pathname.startsWith('/api/');
+}
+
+export function shouldDropHandledKeyExportHttpClientEvent(event: SentryEventLike): boolean {
+  if (!isHttpClientEvent(event)) {
+    return false;
+  }
+
+  const requestUrl = toSafeString(event.request?.url);
+  if (!requestUrl) {
+    return false;
+  }
+
+  let parsedUrl: URL;
+  try {
+    parsedUrl = new URL(requestUrl);
+  } catch {
+    return false;
+  }
+
+  if (
+    parsedUrl.hostname !== DIVINE_LOGIN_HOSTNAME
+    || parsedUrl.pathname !== '/api/user/export-key'
+  ) {
+    return false;
+  }
+
+  const statusCode = extractStatusCode(event);
+  return statusCode === 401
+    || statusCode === 403
+    || statusCode === 404
+    || statusCode === 429;
 }
 
 /**

--- a/src/pages/ExitStartPage.test.tsx
+++ b/src/pages/ExitStartPage.test.tsx
@@ -5,6 +5,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { TestApp } from "@/test/TestApp";
 import { createFixtureFetch } from "@/lib/exit/__fixtures__/fixtureFetch";
 import { FixtureSigner } from "@/lib/exit/__fixtures__/fixtureSigner";
+import { KeyExportError } from "@/lib/exit/keyExportClient";
 import {
   fixturePubkey,
   fixtureMediaHash,
@@ -23,12 +24,18 @@ vi.mock("@/hooks/useCurrentUser", () => ({
   useCurrentUser: () => mockUseCurrentUser(),
 }));
 
-const { mockGetActiveLocalNsecLogin, mockBannerRender } = vi.hoisted(() => ({
+const { mockGetActiveLocalNsecLogin, mockBannerRender, mockExportAccountKey } = vi.hoisted(() => ({
   mockGetActiveLocalNsecLogin: vi.fn(
     (_logins: unknown[] = [], _pubkey = "") => null as { data: { nsec: string } } | null
   ),
   mockBannerRender: vi.fn(() => null as React.ReactNode),
+  mockExportAccountKey: vi.fn(),
 }));
+
+vi.mock("@/lib/exit/keyExportClient", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/exit/keyExportClient")>();
+  return { ...actual, exportAccountKey: (...args: unknown[]) => mockExportAccountKey(...args) };
+});
 
 vi.mock("@/lib/localNsecAccount", () => ({
   getLocalNsecLogin: (logins: unknown[], pubkey: string) =>
@@ -43,7 +50,12 @@ vi.mock("@/components/auth/LocalNsecBanner", () => ({
 
 function signedIn() {
   const signer = new FixtureSigner();
-  return { user: { pubkey: fixturePubkey, signer }, signer, isResolvingJwt: false };
+  return { user: { pubkey: fixturePubkey, signer }, signer, hostedToken: null, isResolvingJwt: false };
+}
+
+function hostedSignedIn() {
+  const signer = new FixtureSigner();
+  return { user: { pubkey: fixturePubkey, signer }, signer, hostedToken: "token", isResolvingJwt: false };
 }
 
 function signedOut() {
@@ -55,6 +67,7 @@ describe("ExitStartPage", () => {
     mockUseCurrentUser.mockReturnValue(signedOut());
     mockGetActiveLocalNsecLogin.mockReturnValue(null);
     mockBannerRender.mockReturnValue(null);
+    mockExportAccountKey.mockReset();
   });
 
   afterEach(() => {
@@ -385,8 +398,47 @@ describe("ExitStartPage", () => {
 
     expect(screen.getByText(/signs through a browser extension or another signer/)).toBeInTheDocument();
     expect(
-      screen.getByText(/Creating an archive still requires that signer/)
+      screen.getByText(/everything in your downloaded archive stays verifiable/)
     ).toBeInTheDocument();
+  });
+
+  it("keeps portability controls available when hosted key export is restricted", async () => {
+    mockUseCurrentUser.mockReturnValue(hostedSignedIn());
+    mockExportAccountKey.mockRejectedValue(new KeyExportError(
+      "policy-denied",
+      "Divine cannot export the secret key for this account.",
+      403,
+    ));
+    vi.stubGlobal("fetch", createFixtureFetch("one-page"));
+    render(<TestApp><ExitStartPage /></TestApp>);
+
+    await userEvent.type(screen.getByLabelText("Divine account password"), "password");
+    await userEvent.click(screen.getByRole("checkbox", { name: /I understand/ }));
+    await userEvent.click(screen.getByRole("button", { name: "Show my secret key" }));
+    expect(await screen.findByText(/Secret-key export is restricted/)).toBeInTheDocument();
+
+    const archiveButton = screen.getByRole("button", { name: /Create my archive/ });
+    expect(archiveButton).toBeEnabled();
+    await userEvent.click(archiveButton);
+    await waitFor(() => expect(screen.getByRole("heading", { name: "Move your media" })).toBeInTheDocument());
+
+    vi.stubGlobal("fetch", vi.fn<typeof fetch>()
+      .mockResolvedValueOnce(new Response(JSON.stringify({
+        url: `https://blossom.example/${fixtureMediaHash}`,
+        sha256: fixtureMediaHash,
+        size: 5,
+        type: "video/mp4",
+      }), { status: 200 }))
+      .mockResolvedValueOnce(new Response(null, { status: 200, headers: { "content-length": "5" } })));
+    await userEvent.type(screen.getByLabelText("Blossom server URL"), "https://blossom.example");
+    const mirrorButton = screen.getByRole("button", { name: "Copy my media" });
+    expect(mirrorButton).toBeEnabled();
+    await userEvent.click(mirrorButton);
+
+    await waitFor(() => expect(screen.getByRole("button", { name: "Publish my posts" })).toBeInTheDocument());
+    await userEvent.type(screen.getByLabelText("Relay URL"), "wss://relay.example");
+    expect(screen.getByRole("button", { name: "Publish my posts" })).toBeEnabled();
+    expect(screen.getByText(/Secret-key export is restricted/)).toBeInTheDocument();
   });
 
   it("still explains the keys section when the backup banner renders nothing", () => {

--- a/src/pages/ExitStartPage.test.tsx
+++ b/src/pages/ExitStartPage.test.tsx
@@ -50,12 +50,24 @@ vi.mock("@/components/auth/LocalNsecBanner", () => ({
 
 function signedIn() {
   const signer = new FixtureSigner();
-  return { user: { pubkey: fixturePubkey, signer }, signer, hostedToken: null, isResolvingJwt: false };
+  return {
+    user: { pubkey: fixturePubkey, signer },
+    signer,
+    hostedToken: null,
+    isHostedAccount: false,
+    isResolvingJwt: false,
+  };
 }
 
 function hostedSignedIn() {
   const signer = new FixtureSigner();
-  return { user: { pubkey: fixturePubkey, signer }, signer, hostedToken: "token", isResolvingJwt: false };
+  return {
+    user: { pubkey: fixturePubkey, signer },
+    signer,
+    hostedToken: "token",
+    isHostedAccount: true,
+    isResolvingJwt: false,
+  };
 }
 
 function signedOut() {

--- a/src/pages/ExitStartPage.tsx
+++ b/src/pages/ExitStartPage.tsx
@@ -87,7 +87,7 @@ export function ExitStartPage() {
     ],
   });
 
-  const { user, signer, hostedToken, isResolvingJwt } = useCurrentUser();
+  const { user, signer, hostedToken, isHostedAccount, isResolvingJwt } = useCurrentUser();
   const { logins } = useNostrLogin();
   const localNsecLogin = user ? getLocalNsecLogin(logins, user.pubkey) : null;
 
@@ -507,6 +507,7 @@ export function ExitStartPage() {
           <AccountKeySection
             pubkey={user?.pubkey}
             hostedToken={hostedToken}
+            isHostedAccount={isHostedAccount}
             localNsec={localNsecLogin?.data.nsec ?? null}
           />
 

--- a/src/pages/ExitStartPage.tsx
+++ b/src/pages/ExitStartPage.tsx
@@ -17,13 +17,13 @@ import { useHead } from "@unhead/react";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { Link } from "react-router-dom";
 
+import { AccountKeySection } from "@/components/exit/AccountKeySection";
 import { DestinationForm } from "@/components/exit/DestinationForm";
 import { DiscoveryPointerForm } from "@/components/exit/DiscoveryPointerForm";
 import { KeySafetyNotice } from "@/components/exit/KeySafetyNotice";
 import { MediaProgressList } from "@/components/exit/MediaProgressList";
 import { RelayDestinationForm } from "@/components/exit/RelayDestinationForm";
 import { LoginArea } from "@/components/auth/LoginArea";
-import { LocalNsecBanner } from "@/components/auth/LocalNsecBanner";
 import { MarketingLayout } from "@/components/MarketingLayout";
 import { SectionHero } from "@/components/static-pages";
 import { Button } from "@/components/ui/button";
@@ -87,7 +87,7 @@ export function ExitStartPage() {
     ],
   });
 
-  const { user, signer, isResolvingJwt } = useCurrentUser();
+  const { user, signer, hostedToken, isResolvingJwt } = useCurrentUser();
   const { logins } = useNostrLogin();
   const localNsecLogin = user ? getLocalNsecLogin(logins, user.pubkey) : null;
 
@@ -504,51 +504,11 @@ export function ExitStartPage() {
             lead="Your account is a key, not a username. Whether you can hold that key yourself depends on how you signed up."
           />
 
-          {/* This card always renders. The backup controls below gate themselves for
-              protected minors by rendering null (#182), so if the explanation lived
-              inside that component this section would collapse to a bare heading for
-              exactly the readers least able to fill in the gap themselves. */}
-          <Card variant="brand" accent="blue">
-            <CardContent className="pt-6 space-y-3 text-base leading-relaxed text-muted-foreground">
-              {localNsecLogin ? (
-                <>
-                  <p>
-                    This account has its own key, stored in this browser rather than on a
-                    Divine server. That key is what proves the account is yours, here and
-                    anywhere else that speaks the same protocol.
-                  </p>
-                  <p>
-                    Keep a copy of it somewhere safe. If it is lost, nobody can restore it
-                    for you &mdash; not Divine, not anyone.
-                  </p>
-                </>
-              ) : (
-                <>
-                  <p>
-                    This account signs through a browser extension or another signer,
-                    rather than a secret key stored directly by this page. This page
-                    cannot reveal a key it does not hold.
-                  </p>
-                  <p>
-                    What that means for moving: your public identity &mdash; the name other
-                    apps know you by &mdash; is yours and does not change. The ability to
-                    sign new events depends on whichever signer this account uses.
-                  </p>
-                  <p>
-                    Creating an archive still requires that signer to approve the request.
-                    Once downloaded, everything in the archive is already signed and stays
-                    verifiable no matter what happens to how you sign in.
-                  </p>
-                </>
-              )}
-            </CardContent>
-          </Card>
-
-          {localNsecLogin ? (
-            <div className="mt-5">
-              <LocalNsecBanner nsec={localNsecLogin.data.nsec} />
-            </div>
-          ) : null}
+          <AccountKeySection
+            pubkey={user?.pubkey}
+            hostedToken={hostedToken ?? null}
+            localNsec={localNsecLogin?.data.nsec ?? null}
+          />
 
           <div className="mt-5">
             <KeySafetyNotice />

--- a/src/pages/ExitStartPage.tsx
+++ b/src/pages/ExitStartPage.tsx
@@ -506,7 +506,7 @@ export function ExitStartPage() {
 
           <AccountKeySection
             pubkey={user?.pubkey}
-            hostedToken={hostedToken ?? null}
+            hostedToken={hostedToken}
             localNsec={localNsecLogin?.data.nsec ?? null}
           />
 

--- a/tests/visual/a11y.spec.ts
+++ b/tests/visual/a11y.spec.ts
@@ -11,6 +11,7 @@ const ROUTES = [
   '/age-review',
   '/kids',
   '/download',
+  '/exit/start',
   `/profile/${PUBKEY}`,
   `/profile/${PUBKEY}/lists`,
   `/people-lists/${PUBKEY}/friends`,


### PR DESCRIPTION
## Summary

- Hosted-signer users could download their account data but had no way to take the signing key needed to use that data elsewhere. `/exit/start` now shows every signed-in user their full public key and lets eligible hosted users reveal and copy their secret key after password confirmation.
- The page keeps hosted, browser-local, external-signer, restricted, and signed-out states distinct. Secret-key policy remains authoritative in the hosted signer: a policy denial explains the restriction without disabling archive, media-copy, republication, or discovery-pointer steps.

## Motivation

- Account portability stopped one step short for hosted users: their archive remained verifiable, but they could not sign or publish with the same identity on other infrastructure.
- The implementation reuses the existing password-confirmed export endpoint and never puts the password in React state. A returned secret key is schema-validated, held only in transient component state, cleared on hide or identity/session changes, and never logged, cached, stored, or added to the archive.
- Local-key behavior and its existing protected-minor gate are unchanged. External signers still correctly explain that this page never holds their key.

## Related Issue

- Closes #603

## Testing

- [x] `npm run test` (329 files, 2,785 tests; type-check, lint, and production build)
- [x] Manual verification completed
- [x] `npx playwright test tests/visual/a11y.spec.ts --grep '/exit/start'` (light and dark WCAG 2.1 A/AA)

## Visuals

- [x] UI change verified in the [deployed preview](https://424e4a4a.divine-web.pages.dev/exit/start)
- [ ] No visual change
- [x] Visuals and text avoid sensitive external brand or partner names unless explicitly approved

The signed-out state was visually inspected in the deployed preview. Hosted, local-key, external-signer, policy-denied, secret-reveal, secret-hide, account-change, and token-refresh states are covered by component tests. No secret or real account identifier is included in the visual record.
