### PR TITLE
feat(exit): let banned account owners recover preserved data

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -205,6 +205,17 @@ change, and is never added to the archive. Keycast remains authoritative for
 raw-key policy: a policy denial changes only the key section and leaves every
 other portability step available.
 
+The same page can lazily check for a private pre-ban snapshot and redeem it with
+the signed-in owner's NIP-98 proof. Snapshot status and redemption keep their
+lifecycle validation and HTTP error classification in
+[`banSnapshotClient.ts`](./src/lib/exit/banSnapshotClient.ts); ordinary and
+snapshot exports share only signed GET transport, event-envelope validation,
+and the bounded cursor walk. Every page URL is completed before signing so the
+NIP-98 `u` tag includes the enforcement id and opaque cursor. Recovered events
+enter the existing archive, media verification, mirror, and republish pipeline.
+The manifest records snapshot provenance, while partial pages remain usable if
+the snapshot expires or becomes unavailable during retrieval.
+
 After an archive is built, the same page can mirror its unique source blobs to a
 custom HTTPS Blossom destination with BUD-04 `PUT /mirror`. Destination URLs
 normalize to the domain root because BUD-01 serves every Blossom endpoint there.

--- a/src/components/exit/SnapshotRecovery.test.tsx
+++ b/src/components/exit/SnapshotRecovery.test.tsx
@@ -23,6 +23,7 @@ describe("SnapshotRecovery", () => {
   it("renders the exact expiry date and starts available recovery", () => {
     const onRecover = vi.fn();
     render(<SnapshotRecovery {...base} onRecover={onRecover} status={{ state: "available", enforcement_id: "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd", enforced_at: "2026-08-01T12:00:00Z", created_at: "2026-08-01T12:01:00Z", expires_at: "2026-08-31T12:01:00Z", days_remaining: 3 }} />);
+    expect(screen.getByText(/Preserved on August 1, 2026/)).toBeInTheDocument();
     expect(screen.getByText(/August 31, 2026/)).toBeInTheDocument();
     fireEvent.click(screen.getByRole("button", { name: "Recover snapshot" }));
     expect(onRecover).toHaveBeenCalledOnce();

--- a/src/components/exit/SnapshotRecovery.test.tsx
+++ b/src/components/exit/SnapshotRecovery.test.tsx
@@ -28,4 +28,9 @@ describe("SnapshotRecovery", () => {
     fireEvent.click(screen.getByRole("button", { name: "Recover snapshot" }));
     expect(onRecover).toHaveBeenCalledOnce();
   });
+
+  it("does not start recovery while another archive is running", () => {
+    render(<SnapshotRecovery {...base} disabled status={{ state: "available", enforcement_id: "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd", enforced_at: "2026-08-01T12:00:00Z", created_at: "2026-08-01T12:01:00Z", expires_at: "2026-08-31T12:01:00Z", days_remaining: 3 }} />);
+    expect(screen.getByRole("button", { name: "Recover snapshot" })).toBeDisabled();
+  });
 });

--- a/src/components/exit/SnapshotRecovery.test.tsx
+++ b/src/components/exit/SnapshotRecovery.test.tsx
@@ -1,0 +1,30 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { SnapshotRecovery } from "./SnapshotRecovery";
+
+const base = { checkError: null, checking: false, recovering: false, disabled: false, onCheck: vi.fn(), onRecover: vi.fn() };
+
+describe("SnapshotRecovery", () => {
+  it("presents an absent result without implying the account was banned", () => {
+    render(<SnapshotRecovery {...base} status={{ state: "absent", enforcement_id: null, enforced_at: null, created_at: null, expires_at: null, days_remaining: null }} />);
+    expect(screen.getByText("No pre-ban snapshot is available for this account. You can still create the ordinary account archive above.")).toBeInTheDocument();
+  });
+
+  it.each([
+    ["capture_failed", "Divine could not preserve a complete pre-ban snapshot"],
+    ["expired", "The preserved snapshot has expired"],
+    ["temporarily_unavailable", "The preserved snapshot exists, but it is temporarily unavailable"],
+  ] as const)("presents the %s state distinctly", (state, message) => {
+    render(<SnapshotRecovery {...base} status={{ state, enforcement_id: null, enforced_at: null, created_at: null, expires_at: null, days_remaining: null }} />);
+    expect(screen.getByText(new RegExp(message))).toBeInTheDocument();
+  });
+
+  it("renders the exact expiry date and starts available recovery", () => {
+    const onRecover = vi.fn();
+    render(<SnapshotRecovery {...base} onRecover={onRecover} status={{ state: "available", enforcement_id: "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd", enforced_at: "2026-08-01T12:00:00Z", created_at: "2026-08-01T12:01:00Z", expires_at: "2026-08-31T12:01:00Z", days_remaining: 3 }} />);
+    expect(screen.getByText(/August 31, 2026/)).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Recover snapshot" }));
+    expect(onRecover).toHaveBeenCalledOnce();
+  });
+});

--- a/src/components/exit/SnapshotRecovery.tsx
+++ b/src/components/exit/SnapshotRecovery.tsx
@@ -18,15 +18,15 @@ interface SnapshotRecoveryProps {
   onRecover: (status: SnapshotStatus & { state: "available"; enforcement_id: string; expires_at: string }) => void;
 }
 
-function formatExpiry(value: string) {
+function formatDate(value: string) {
   return new Intl.DateTimeFormat(undefined, {
     year: "numeric", month: "long", day: "numeric", hour: "numeric", minute: "2-digit", timeZoneName: "short",
   }).format(new Date(value));
 }
 
 export function SnapshotRecovery(props: SnapshotRecoveryProps) {
-  const available = props.status?.state === "available" && props.status.enforcement_id && props.status.expires_at
-    ? props.status as SnapshotStatus & { state: "available"; enforcement_id: string; expires_at: string }
+  const available = props.status?.state === "available" && props.status.enforcement_id && props.status.created_at && props.status.expires_at
+    ? props.status as SnapshotStatus & { state: "available"; enforcement_id: string; created_at: string; expires_at: string }
     : null;
 
   return (
@@ -55,7 +55,7 @@ export function SnapshotRecovery(props: SnapshotRecoveryProps) {
                 <WarningCircle weight="fill" className="mt-1 h-5 w-5 flex-shrink-0 text-brand-dark-green dark:text-brand-green" />
                 <div>
                   <p className="font-semibold text-foreground">A pre-ban snapshot is ready to recover.</p>
-                  <p className="text-base leading-relaxed text-muted-foreground">It expires on {formatExpiry(available.expires_at)}. {available.days_remaining} day{available.days_remaining === 1 ? "" : "s"} remaining.</p>
+                  <p className="text-base leading-relaxed text-muted-foreground">Preserved on {formatDate(available.created_at)}. It expires on {formatDate(available.expires_at)}. {available.days_remaining} day{available.days_remaining === 1 ? "" : "s"} remaining.</p>
                 </div>
               </div>
               <Button type="button" variant="sticker" onClick={() => props.onRecover(available)} disabled={props.recovering}>

--- a/src/components/exit/SnapshotRecovery.tsx
+++ b/src/components/exit/SnapshotRecovery.tsx
@@ -58,7 +58,7 @@ export function SnapshotRecovery(props: SnapshotRecoveryProps) {
                   <p className="text-base leading-relaxed text-muted-foreground">Preserved on {formatDate(available.created_at)}. It expires on {formatDate(available.expires_at)}. {available.days_remaining} day{available.days_remaining === 1 ? "" : "s"} remaining.</p>
                 </div>
               </div>
-              <Button type="button" variant="sticker" onClick={() => props.onRecover(available)} disabled={props.recovering}>
+              <Button type="button" variant="sticker" onClick={() => props.onRecover(available)} disabled={props.disabled || props.recovering}>
                 {props.recovering ? <ArrowClockwise className="h-4 w-4 animate-spin" aria-hidden="true" /> : <Archive className="h-4 w-4" aria-hidden="true" />}
                 {props.recovering ? "Recovering your snapshot" : "Recover snapshot"}
               </Button>

--- a/src/components/exit/SnapshotRecovery.tsx
+++ b/src/components/exit/SnapshotRecovery.tsx
@@ -1,0 +1,71 @@
+// ABOUTME: Presents pre-ban snapshot lifecycle states and starts recovery for available snapshots
+// ABOUTME: Keeps absent and failed outcomes explicit without implying that an ordinary account was banned
+
+import { Archive, ArrowClockwise, ClockCounterClockwise, WarningCircle } from "@phosphor-icons/react";
+
+import { SectionHero } from "@/components/static-pages";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import type { SnapshotStatus } from "@/lib/exit/banSnapshotClient";
+
+interface SnapshotRecoveryProps {
+  status: SnapshotStatus | null;
+  checkError: string | null;
+  checking: boolean;
+  recovering: boolean;
+  disabled: boolean;
+  onCheck: () => void;
+  onRecover: (status: SnapshotStatus & { state: "available"; enforcement_id: string; expires_at: string }) => void;
+}
+
+function formatExpiry(value: string) {
+  return new Intl.DateTimeFormat(undefined, {
+    year: "numeric", month: "long", day: "numeric", hour: "numeric", minute: "2-digit", timeZoneName: "short",
+  }).format(new Date(value));
+}
+
+export function SnapshotRecovery(props: SnapshotRecoveryProps) {
+  const available = props.status?.state === "available" && props.status.enforcement_id && props.status.expires_at
+    ? props.status as SnapshotStatus & { state: "available"; enforcement_id: string; expires_at: string }
+    : null;
+
+  return (
+    <section>
+      <SectionHero
+        eyebrow="Pre-ban recovery"
+        icon={<ClockCounterClockwise weight="fill" className="h-7 w-7" />}
+        title="Check for a preserved snapshot"
+        lead="If enforcement removed your account data, Divine may have preserved a private recovery snapshot for 30 days. Only your signed-in account can check or retrieve it."
+      />
+      <Card variant="brand" accent={available ? "yellow" : "blue"}>
+        <CardContent className="pt-6 space-y-4">
+          <Button type="button" variant="outline" onClick={props.onCheck} disabled={props.disabled || props.checking || props.recovering}>
+            {props.checking ? <ArrowClockwise className="h-4 w-4 animate-spin" aria-hidden="true" /> : <ClockCounterClockwise className="h-4 w-4" aria-hidden="true" />}
+            {props.checking ? "Checking for a snapshot" : "Check for a snapshot"}
+          </Button>
+
+          {props.checkError && <p className="text-base text-destructive" role="alert">{props.checkError}</p>}
+          {props.status?.state === "absent" && <p className="text-base leading-relaxed text-muted-foreground" role="status">No pre-ban snapshot is available for this account. You can still create the ordinary account archive above.</p>}
+          {props.status?.state === "capture_failed" && <p className="text-base leading-relaxed text-muted-foreground" role="status">Divine could not preserve a complete pre-ban snapshot for this account. The ordinary account archive above may still contain data that remains available.</p>}
+          {props.status?.state === "expired" && <p className="text-base leading-relaxed text-muted-foreground" role="status">The preserved snapshot has expired and can no longer be recovered.</p>}
+          {props.status?.state === "temporarily_unavailable" && <p className="text-base leading-relaxed text-muted-foreground" role="status">The preserved snapshot exists, but it is temporarily unavailable. Try checking again later.</p>}
+          {available && (
+            <div className="space-y-3" role="status">
+              <div className="flex items-start gap-3">
+                <WarningCircle weight="fill" className="mt-1 h-5 w-5 flex-shrink-0 text-brand-dark-green dark:text-brand-green" />
+                <div>
+                  <p className="font-semibold text-foreground">A pre-ban snapshot is ready to recover.</p>
+                  <p className="text-base leading-relaxed text-muted-foreground">It expires on {formatExpiry(available.expires_at)}. {available.days_remaining} day{available.days_remaining === 1 ? "" : "s"} remaining.</p>
+                </div>
+              </div>
+              <Button type="button" variant="sticker" onClick={() => props.onRecover(available)} disabled={props.recovering}>
+                {props.recovering ? <ArrowClockwise className="h-4 w-4 animate-spin" aria-hidden="true" /> : <Archive className="h-4 w-4" aria-hidden="true" />}
+                {props.recovering ? "Recovering your snapshot" : "Recover snapshot"}
+              </Button>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </section>
+  );
+}

--- a/src/hooks/useArchiveMediaExport.ts
+++ b/src/hooks/useArchiveMediaExport.ts
@@ -16,7 +16,9 @@ export function useArchiveMediaExport(input: { files: ArchiveFiles | null; signe
   const [progress, setProgress] = useState<MediaProgress | null>(null);
   const [failure, setFailure] = useState<string | null>(null);
   const activeController = useRef<AbortController | null>(null);
-  const archivePubkey = input.files?.["manifest.json"].pubkey;
+  const archiveIdentity = input.files
+    ? `${input.files["manifest.json"].pubkey}:${input.files["manifest.json"].snapshot?.enforcement_id ?? "owner"}`
+    : undefined;
 
   useEffect(() => {
     activeController.current?.abort();
@@ -24,7 +26,7 @@ export function useArchiveMediaExport(input: { files: ArchiveFiles | null; signe
     setProgress(null);
     setFailure(null);
     return () => activeController.current?.abort();
-  }, [archivePubkey]);
+  }, [archiveIdentity]);
 
   async function start() {
     if (!input.files || !input.signer || !supportsStreamingArchive()) return;

--- a/src/hooks/useBanSnapshotStatus.test.tsx
+++ b/src/hooks/useBanSnapshotStatus.test.tsx
@@ -1,0 +1,40 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import type { PropsWithChildren } from "react";
+import { describe, expect, it, vi } from "vitest";
+
+import { BanSnapshotError, fetchSnapshotStatus } from "@/lib/exit/banSnapshotClient";
+
+import { useBanSnapshotStatus } from "./useBanSnapshotStatus";
+
+vi.mock("@/config/api", () => ({ getFunnelcakeBaseUrl: () => "https://api.divine.video" }));
+vi.mock("@/lib/exit/banSnapshotClient", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/exit/banSnapshotClient")>();
+  return { ...actual, fetchSnapshotStatus: vi.fn() };
+});
+
+const signer = {} as Parameters<typeof useBanSnapshotStatus>[0]["signer"];
+const pubkeyA = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+const pubkeyB = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+
+describe("useBanSnapshotStatus", () => {
+  it("aborts and discards an in-flight check when the account changes", async () => {
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const wrapper = ({ children }: PropsWithChildren) => <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+    let firstSignal: AbortSignal | undefined;
+    vi.mocked(fetchSnapshotStatus).mockImplementation(({ pubkey, signal }) => {
+      if (pubkey === pubkeyA) {
+        firstSignal = signal;
+        return new Promise((_resolve, reject) => signal?.addEventListener("abort", () => reject(new BanSnapshotError("cancelled", "cancelled")), { once: true }));
+      }
+      return Promise.resolve({ state: "absent", enforcement_id: null, enforced_at: null, created_at: null, expires_at: null, days_remaining: null });
+    });
+
+    const { result, rerender } = renderHook(({ pubkey }) => useBanSnapshotStatus({ pubkey, signer }), { initialProps: { pubkey: pubkeyA }, wrapper });
+    act(() => { void result.current.refetch(); });
+    await waitFor(() => expect(firstSignal).toBeDefined());
+    rerender({ pubkey: pubkeyB });
+    await waitFor(() => expect(firstSignal?.aborted).toBe(true));
+    expect(result.current.data).toBeUndefined();
+  });
+});

--- a/src/hooks/useBanSnapshotStatus.ts
+++ b/src/hooks/useBanSnapshotStatus.ts
@@ -1,0 +1,24 @@
+// ABOUTME: Lazily checks the signed-in account's private pre-ban snapshot status
+// ABOUTME: Keeps results account-scoped, uncached after unmount, and retries temporary server failures only
+
+import type { NostrSigner } from "@nostrify/nostrify";
+import { useQuery } from "@tanstack/react-query";
+
+import { getFunnelcakeBaseUrl } from "@/config/api";
+import { BanSnapshotError, fetchSnapshotStatus } from "@/lib/exit/banSnapshotClient";
+
+export function useBanSnapshotStatus(input: { pubkey?: string; signer?: NostrSigner | null }) {
+  return useQuery({
+    queryKey: ["ban-snapshot-status", input.pubkey],
+    queryFn: ({ signal }) => fetchSnapshotStatus({
+      endpointBase: getFunnelcakeBaseUrl(),
+      pubkey: input.pubkey ?? "",
+      signer: input.signer!,
+      signal,
+    }),
+    enabled: false,
+    gcTime: 0,
+    staleTime: 0,
+    retry: (failureCount, error) => error instanceof BanSnapshotError && error.status === 503 && failureCount < 2,
+  });
+}

--- a/src/hooks/useDestinationMirror.ts
+++ b/src/hooks/useDestinationMirror.ts
@@ -24,7 +24,9 @@ export function useDestinationMirror(input: { files: ArchiveFiles | null; signer
   const [failure, setFailure] = useState<string | null>(null);
   const [destination, setDestination] = useState<string | null>(null);
   const activeController = useRef<AbortController | null>(null);
-  const archivePubkey = input.files?.["manifest.json"].pubkey;
+  const archiveIdentity = input.files
+    ? `${input.files["manifest.json"].pubkey}:${input.files["manifest.json"].snapshot?.enforcement_id ?? "owner"}`
+    : undefined;
 
   useEffect(() => {
     activeController.current?.abort();
@@ -35,7 +37,7 @@ export function useDestinationMirror(input: { files: ArchiveFiles | null; signer
     setFailure(null);
     setDestination(null);
     return () => activeController.current?.abort();
-  }, [archivePubkey]);
+  }, [archiveIdentity]);
 
   async function start(destinationValue: string) {
     if (!input.files || !input.signer) return;

--- a/src/hooks/useDestinationRepublish.ts
+++ b/src/hooks/useDestinationRepublish.ts
@@ -30,7 +30,9 @@ export function useDestinationRepublish(input: {
   const [failure, setFailure] = useState<string | null>(null);
   const [destination, setDestination] = useState<string | null>(null);
   const activeController = useRef<AbortController | null>(null);
-  const archivePubkey = input.files?.["manifest.json"].pubkey;
+  const archiveIdentity = input.files
+    ? `${input.files["manifest.json"].pubkey}:${input.files["manifest.json"].snapshot?.enforcement_id ?? "owner"}`
+    : undefined;
 
   useEffect(() => {
     activeController.current?.abort();
@@ -41,7 +43,7 @@ export function useDestinationRepublish(input: {
     setFailure(null);
     setDestination(null);
     return () => activeController.current?.abort();
-  }, [archivePubkey, input.mirrorResults]);
+  }, [archiveIdentity, input.mirrorResults]);
 
   async function start(destinationValue: string) {
     if (!input.files || !input.mirrorResults || !input.signer) return;

--- a/src/lib/exit/archive.test.ts
+++ b/src/lib/exit/archive.test.ts
@@ -27,6 +27,28 @@ describe("archive builder", () => {
     });
   });
 
+  it("records snapshot provenance without changing the archive model", () => {
+    const snapshot = {
+      enforcement_id: "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+      enforced_at: "2026-08-01T12:00:00Z",
+      expires_at: "2026-08-31T12:01:00Z",
+    };
+    const archive = buildArchiveFiles({
+      events: [makeFixtureEvent()],
+      pubkey: fixturePubkey,
+      sourceEndpoint: "https://api.divine.video",
+      sourceName: "Divine pre-ban snapshot",
+      pageCount: 1,
+      failures: [],
+      snapshot,
+    });
+
+    expect(archive["manifest.json"]).toMatchObject({
+      source_name: "Divine pre-ban snapshot",
+      snapshot,
+    });
+  });
+
   it("discovers media URLs and hashes from tags", () => {
     const references = discoverMediaReferences([
       makeFixtureEvent(),

--- a/src/lib/exit/archive.ts
+++ b/src/lib/exit/archive.ts
@@ -4,8 +4,12 @@
 import type { NostrEvent } from "@nostrify/nostrify";
 
 import { isHex64 } from "./hex";
-import type { OwnerExportError } from "./ownerExportClient";
 import type { MediaDownloadResult, MediaVerification } from "./mediaDownloader";
+
+export interface ArchiveFailure extends Error {
+  code: string;
+  status?: number;
+}
 
 export interface MediaReference {
   event_id: string;
@@ -26,6 +30,11 @@ export interface ArchiveManifest {
     message: string;
     status?: number;
   }>;
+  snapshot?: {
+    enforcement_id: string;
+    enforced_at: string | null;
+    expires_at: string;
+  };
   media?: MediaSummary;
 }
 
@@ -162,7 +171,9 @@ export function buildArchiveFiles(input: {
   pubkey: string;
   sourceEndpoint: string;
   pageCount: number;
-  failures: OwnerExportError[];
+  failures: ArchiveFailure[];
+  sourceName?: string;
+  snapshot?: ArchiveManifest["snapshot"];
   generatedAt?: Date;
 }): ArchiveFiles {
   return {
@@ -171,14 +182,15 @@ export function buildArchiveFiles(input: {
       pubkey: input.pubkey,
       generated_at: (input.generatedAt ?? new Date()).toISOString(),
       event_count: input.events.length,
-      source_name: "Divine relay",
+      source_name: input.sourceName ?? "Divine relay",
       source_endpoint: input.sourceEndpoint,
       page_count: input.pageCount,
       failures: input.failures.map((failure) => ({
         code: failure.code,
         message: failure.message,
         status: failure.status
-      }))
+      })),
+      ...(input.snapshot ? { snapshot: input.snapshot } : {}),
     },
     "media.json": discoverMediaReferences(input.events)
   };

--- a/src/lib/exit/banSnapshotClient.test.ts
+++ b/src/lib/exit/banSnapshotClient.test.ts
@@ -101,4 +101,18 @@ describe("redeemSnapshotEvents", () => {
     });
     expect(sleeps).toEqual([60_000]);
   });
+
+  it("retries a temporary server overload", async () => {
+    const sleeps: number[] = [];
+    let requests = 0;
+    await redeemSnapshotEvents({
+      endpointBase: "https://api.divine.video", pubkey: fixturePubkey, enforcementId, signer: new FixtureSigner(),
+      fetcher: async () => ++requests === 1
+        ? new Response("temporarily unavailable", { status: 503, headers: { "retry-after": "1" } })
+        : json({ data: [], pagination: { has_more: false, next_cursor: null } }),
+      sleep: async (ms) => { sleeps.push(ms); },
+    });
+    expect(requests).toBe(2);
+    expect(sleeps).toEqual([1000]);
+  });
 });

--- a/src/lib/exit/banSnapshotClient.test.ts
+++ b/src/lib/exit/banSnapshotClient.test.ts
@@ -34,6 +34,15 @@ describe("fetchSnapshotStatus", () => {
     await expect(fetchSnapshotStatus({ endpointBase: "https://api.divine.video", pubkey: fixturePubkey, signer: new FixtureSigner(), fetcher: async () => json({ state: "available", enforcement_id: enforcementId }) })).rejects.toMatchObject({ code: "malformed-response" });
   });
 
+  it("requires a creation date for an available snapshot", async () => {
+    await expect(fetchSnapshotStatus({
+      endpointBase: "https://api.divine.video",
+      pubkey: fixturePubkey,
+      signer: new FixtureSigner(),
+      fetcher: async () => json({ ...available, created_at: null }),
+    })).rejects.toMatchObject({ code: "malformed-response" });
+  });
+
   it.each([[401, "auth-required"], [403, "pubkey-mismatch"]] as const)("classifies status HTTP %s as %s", async (status, code) => {
     await expect(fetchSnapshotStatus({ endpointBase: "https://api.divine.video", pubkey: fixturePubkey, signer: new FixtureSigner(), fetcher: async () => json({ error: "denied" }, status) })).rejects.toMatchObject({ code });
   });

--- a/src/lib/exit/banSnapshotClient.test.ts
+++ b/src/lib/exit/banSnapshotClient.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from "vitest";
+
+import { fixturePubkey, makeFixtureEvent } from "./__fixtures__/exportFixtures";
+import { FixtureSigner } from "./__fixtures__/fixtureSigner";
+import { fetchSnapshotStatus, redeemSnapshotEvents } from "./banSnapshotClient";
+
+const enforcementId = "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd";
+const available = {
+  state: "available",
+  enforcement_id: enforcementId,
+  enforced_at: "2026-08-01T12:00:00Z",
+  created_at: "2026-08-01T12:01:00Z",
+  expires_at: "2026-08-31T12:01:00Z",
+  days_remaining: 3,
+};
+
+function json(value: unknown, status = 200) {
+  return new Response(JSON.stringify(value), { status, headers: { "content-type": "application/json" } });
+}
+
+describe("fetchSnapshotStatus", () => {
+  it.each(["available", "absent", "capture_failed", "expired", "temporarily_unavailable"] as const)("validates the %s lifecycle state on 200", async (state) => {
+    const body = state === "available" ? available : {
+      state, enforcement_id: null, enforced_at: null, created_at: null, expires_at: null, days_remaining: null,
+    };
+    await expect(fetchSnapshotStatus({ endpointBase: "https://api.divine.video", pubkey: fixturePubkey, signer: new FixtureSigner(), fetcher: async () => json(body) })).resolves.toEqual(body);
+  });
+
+  it("treats a 503 lifecycle-shaped body as a transport failure", async () => {
+    await expect(fetchSnapshotStatus({ endpointBase: "https://api.divine.video", pubkey: fixturePubkey, signer: new FixtureSigner(), fetcher: async () => json({ ...available, state: "temporarily_unavailable" }, 503) })).rejects.toMatchObject({ code: "server-failure", status: 503 });
+  });
+
+  it("rejects malformed successful responses", async () => {
+    await expect(fetchSnapshotStatus({ endpointBase: "https://api.divine.video", pubkey: fixturePubkey, signer: new FixtureSigner(), fetcher: async () => json({ state: "available", enforcement_id: enforcementId }) })).rejects.toMatchObject({ code: "malformed-response" });
+  });
+
+  it.each([[401, "auth-required"], [403, "pubkey-mismatch"]] as const)("classifies status HTTP %s as %s", async (status, code) => {
+    await expect(fetchSnapshotStatus({ endpointBase: "https://api.divine.video", pubkey: fixturePubkey, signer: new FixtureSigner(), fetcher: async () => json({ error: "denied" }, status) })).rejects.toMatchObject({ code });
+  });
+});
+
+describe("redeemSnapshotEvents", () => {
+  it("signs every full page URL including enforcement id and cursor", async () => {
+    const signer = new FixtureSigner();
+    let page = 0;
+    const result = await redeemSnapshotEvents({
+      endpointBase: "https://api.divine.video", pubkey: fixturePubkey, enforcementId, signer,
+      fetcher: async () => {
+        page += 1;
+        return json(page === 1
+          ? { data: [makeFixtureEvent()], pagination: { has_more: true, next_cursor: "opaque cursor" } }
+          : { data: [makeFixtureEvent({ id: "2222222222222222222222222222222222222222222222222222222222222222" })], pagination: { has_more: false, next_cursor: null } });
+      },
+    });
+    expect(result.events).toHaveLength(2);
+    expect(signer.signedUrls).toEqual([
+      `https://api.divine.video/api/users/${fixturePubkey}/export/snapshot?enforcement_id=${enforcementId}&limit=500`,
+      `https://api.divine.video/api/users/${fixturePubkey}/export/snapshot?enforcement_id=${enforcementId}&limit=500&cursor=opaque+cursor`,
+    ]);
+  });
+
+  it.each([
+    [400, { error: "Invalid enforcement_id" }, "invalid-enforcement"],
+    [400, { error: "Invalid cursor format" }, "bad-cursor"],
+    [403, { error: "You can only access your own account" }, "pubkey-mismatch"],
+    [403, { error: "Temporary export snapshot is unavailable" }, "snapshot-unavailable"],
+  ] as const)("classifies overloaded %s responses as %s", async (status, body, code) => {
+    await expect(redeemSnapshotEvents({ endpointBase: "https://api.divine.video", pubkey: fixturePubkey, enforcementId, signer: new FixtureSigner(), fetcher: async () => json(body, status) })).rejects.toMatchObject({ code });
+  });
+
+  it("preserves earlier pages when the snapshot vanishes mid-walk", async () => {
+    let page = 0;
+    const result = await redeemSnapshotEvents({
+      endpointBase: "https://api.divine.video", pubkey: fixturePubkey, enforcementId, signer: new FixtureSigner(),
+      fetcher: async () => ++page === 1
+        ? json({ data: [makeFixtureEvent()], pagination: { has_more: true, next_cursor: "next" } })
+        : json({ error: "Temporary export snapshot is unavailable" }, 403),
+    });
+    expect(result.events).toHaveLength(1);
+    expect(result.failures).toEqual([expect.objectContaining({ code: "snapshot-unavailable" })]);
+  });
+
+  it("retries rate limits and caps Retry-After", async () => {
+    const sleeps: number[] = [];
+    let requests = 0;
+    await redeemSnapshotEvents({
+      endpointBase: "https://api.divine.video", pubkey: fixturePubkey, enforcementId, signer: new FixtureSigner(),
+      fetcher: async () => ++requests === 1
+        ? new Response("slow down", { status: 429, headers: { "retry-after": "86400" } })
+        : json({ data: [], pagination: { has_more: false, next_cursor: null } }),
+      sleep: async (ms) => { sleeps.push(ms); },
+    });
+    expect(sleeps).toEqual([60_000]);
+  });
+});

--- a/src/lib/exit/banSnapshotClient.ts
+++ b/src/lib/exit/banSnapshotClient.ts
@@ -116,6 +116,7 @@ async function fetchSnapshotPage(input: RedeemSnapshotOptions & { url: string; r
   if (response.status === 403 && body.toLowerCase().includes("own account")) throw new BanSnapshotError("pubkey-mismatch", "This sign-in does not match the account being recovered.", 403);
   if (response.status === 403) throw new BanSnapshotError("snapshot-unavailable", "The snapshot became unavailable, so this archive ends where recovery stopped.", 403);
   if (response.status === 429) throw new BanSnapshotError("rate-limited", "Divine asked this recovery to slow down. Wait a moment and try again.", 429, exportRetryDelayMs(response, input.retryCount));
+  if (response.status === 503) throw new BanSnapshotError("server-failure", "Divine could not finish this recovery right now. Try again later.", 503, exportRetryDelayMs(response, input.retryCount));
   if (!response.ok) throw new BanSnapshotError("server-failure", "Divine could not finish this recovery right now. Try again later.", response.status);
   try { return validateExportPage(await response.json(), input.pubkey, () => new BanSnapshotError("malformed-response", "Divine returned snapshot data this page could not read.")); } catch (error) {
     if (error instanceof BanSnapshotError) throw error;

--- a/src/lib/exit/banSnapshotClient.ts
+++ b/src/lib/exit/banSnapshotClient.ts
@@ -1,0 +1,143 @@
+// ABOUTME: Checks and redeems pre-ban account snapshots with NIP-98 ownership proof
+// ABOUTME: Keeps snapshot lifecycle, validation, and overloaded HTTP errors endpoint-specific
+
+import type { NostrSigner } from "@nostrify/nostrify";
+
+import { walkExportCursor, type CursorWalkProgress } from "./cursorWalk";
+import { exportRetryDelayMs, readExportErrorBody, signedExportGet, validateExportPage, type ExportPage } from "./exportTransport";
+import { isHex64 } from "./hex";
+
+export type SnapshotLifecycleState = "available" | "absent" | "capture_failed" | "expired" | "temporarily_unavailable";
+
+export interface SnapshotStatus {
+  state: SnapshotLifecycleState;
+  enforcement_id: string | null;
+  enforced_at: string | null;
+  created_at: string | null;
+  expires_at: string | null;
+  days_remaining: number | null;
+}
+
+export type SnapshotFailureCode = "invalid-pubkey" | "invalid-enforcement" | "bad-cursor" | "expired-cursor" | "auth-required" | "pubkey-mismatch" | "snapshot-unavailable" | "rate-limited" | "server-failure" | "malformed-response" | "network-failure" | "cancelled" | "stalled-cursor" | "page-limit";
+
+export class BanSnapshotError extends Error {
+  constructor(public readonly code: SnapshotFailureCode, message: string, public readonly status?: number, public readonly retryAfterMs?: number) {
+    super(message);
+    this.name = "BanSnapshotError";
+  }
+}
+
+interface ClientBase { endpointBase: string; pubkey: string; signer: NostrSigner; fetcher?: typeof fetch; signal?: AbortSignal }
+export interface RedeemSnapshotOptions extends ClientBase {
+  enforcementId: string; limit?: number; sleep?: (ms: number) => Promise<void>; maxRateLimitRetries?: number;
+  maxPages?: number; onProgress?: (progress: CursorWalkProgress) => void;
+}
+
+function clientError(code: "network-failure" | "malformed-response" | "stalled-cursor" | "page-limit", detail?: number) {
+  const message = code === "network-failure"
+    ? "The snapshot could not reach Divine. Check the connection and try again."
+    : code === "malformed-response"
+      ? "Divine did not provide the next snapshot page."
+      : code === "stalled-cursor"
+        ? "Divine stopped moving through the snapshot, so this archive ends where it stopped."
+        : `This recovery stopped after ${detail} pages. Everything read up to that point is included.`;
+  return new BanSnapshotError(code, message);
+}
+
+function buildUrl(endpointBase: string, pubkey: string, suffix: string) {
+  return new URL(`${endpointBase.replace(/\/$/, "")}/api/users/${pubkey}/export/snapshot${suffix}`);
+}
+
+function validateTimestamp(value: unknown) {
+  return typeof value === "string" && Number.isFinite(Date.parse(value));
+}
+
+function validateStatus(value: unknown): SnapshotStatus {
+  if (!value || typeof value !== "object") throw new BanSnapshotError("malformed-response", "Divine returned snapshot information this page could not read.");
+  const status = value as Partial<SnapshotStatus>;
+  const states: SnapshotLifecycleState[] = ["available", "absent", "capture_failed", "expired", "temporarily_unavailable"];
+  if (!status.state || !states.includes(status.state)) throw new BanSnapshotError("malformed-response", "Divine returned an unknown snapshot state.");
+  const timestamps = [status.enforced_at, status.created_at, status.expires_at];
+  if (timestamps.some((value) => value !== null && value !== undefined && !validateTimestamp(value))) throw new BanSnapshotError("malformed-response", "Divine returned a snapshot date this page could not read.");
+  if (status.enforcement_id !== null && status.enforcement_id !== undefined && !isHex64(status.enforcement_id)) throw new BanSnapshotError("malformed-response", "Divine returned a snapshot identifier this page could not read.");
+  if (status.days_remaining !== null && status.days_remaining !== undefined && (!Number.isInteger(status.days_remaining) || status.days_remaining < 0)) throw new BanSnapshotError("malformed-response", "Divine returned an invalid snapshot lifetime.");
+  if (status.state === "available" && (!status.enforcement_id || !status.expires_at || status.days_remaining === null || status.days_remaining === undefined)) throw new BanSnapshotError("malformed-response", "Divine returned incomplete snapshot information.");
+  return {
+    state: status.state,
+    enforcement_id: status.enforcement_id ?? null,
+    enforced_at: status.enforced_at ?? null,
+    created_at: status.created_at ?? null,
+    expires_at: status.expires_at ?? null,
+    days_remaining: status.days_remaining ?? null,
+  };
+}
+
+function commonResponseError(status: number) {
+  if (status === 401) return new BanSnapshotError("auth-required", "Sign in again, then check for a snapshot.", 401);
+  return new BanSnapshotError("server-failure", "Divine could not check the snapshot right now. Try again later.", status);
+}
+
+export async function fetchSnapshotStatus(options: ClientBase): Promise<SnapshotStatus> {
+  if (!isHex64(options.pubkey)) throw new BanSnapshotError("invalid-pubkey", "The account identifier is not valid.", 400);
+  const url = buildUrl(options.endpointBase, options.pubkey, "/status").toString();
+  const response = await signedExportGet({
+    url, signer: options.signer, fetcher: options.fetcher ?? fetch, signal: options.signal,
+    authFailure: () => new BanSnapshotError("auth-required", "This snapshot check could not be signed. Sign in again, then retry."),
+    networkFailure: () => clientError("network-failure"),
+    cancelled: () => new BanSnapshotError("cancelled", "The snapshot check was cancelled."),
+  });
+  if (response.status === 400) throw new BanSnapshotError("invalid-pubkey", "The account identifier is not valid.", 400);
+  if (response.status === 403) throw new BanSnapshotError("pubkey-mismatch", "This sign-in does not match the account being checked.", 403);
+  if (!response.ok) throw commonResponseError(response.status);
+  try { return validateStatus(await response.json()); } catch (error) {
+    if (error instanceof BanSnapshotError) throw error;
+    throw new BanSnapshotError("malformed-response", "Divine returned snapshot information this page could not read.");
+  }
+}
+
+function classifyRedeemBadRequest(body: string) {
+  const normalized = body.toLowerCase();
+  if (normalized.includes("expired") || normalized.includes("unknown cursor")) return new BanSnapshotError("expired-cursor", "The snapshot page expired. Start the recovery again.", 400);
+  if (normalized.includes("cursor")) return new BanSnapshotError("bad-cursor", "The snapshot page token was not accepted.", 400);
+  if (normalized.includes("enforcement")) return new BanSnapshotError("invalid-enforcement", "Divine did not recognize this snapshot identifier.", 400);
+  return new BanSnapshotError("invalid-pubkey", "The account identifier is not valid.", 400);
+}
+
+async function fetchSnapshotPage(input: RedeemSnapshotOptions & { url: string; retryCount: number }): Promise<ExportPage> {
+  const response = await signedExportGet({
+    url: input.url, signer: input.signer, fetcher: input.fetcher ?? fetch, signal: input.signal,
+    authFailure: () => new BanSnapshotError("auth-required", "This recovery could not be signed. Sign in again, then retry."),
+    networkFailure: () => clientError("network-failure"),
+    cancelled: () => new BanSnapshotError("cancelled", "The snapshot recovery was cancelled."),
+  });
+  const body = response.status === 400 || response.status === 403 ? await readExportErrorBody(response) : "";
+  if (response.status === 400) throw classifyRedeemBadRequest(body);
+  if (response.status === 401) throw new BanSnapshotError("auth-required", "Sign in again, then restart the recovery.", 401);
+  if (response.status === 403 && body.toLowerCase().includes("own account")) throw new BanSnapshotError("pubkey-mismatch", "This sign-in does not match the account being recovered.", 403);
+  if (response.status === 403) throw new BanSnapshotError("snapshot-unavailable", "The snapshot became unavailable, so this archive ends where recovery stopped.", 403);
+  if (response.status === 429) throw new BanSnapshotError("rate-limited", "Divine asked this recovery to slow down. Wait a moment and try again.", 429, exportRetryDelayMs(response, input.retryCount));
+  if (!response.ok) throw new BanSnapshotError("server-failure", "Divine could not finish this recovery right now. Try again later.", response.status);
+  try { return validateExportPage(await response.json(), input.pubkey, () => new BanSnapshotError("malformed-response", "Divine returned snapshot data this page could not read.")); } catch (error) {
+    if (error instanceof BanSnapshotError) throw error;
+    throw new BanSnapshotError("malformed-response", "Divine returned snapshot data this page could not read.");
+  }
+}
+
+export async function redeemSnapshotEvents(options: RedeemSnapshotOptions) {
+  if (!isHex64(options.pubkey)) throw new BanSnapshotError("invalid-pubkey", "The account identifier is not valid.", 400);
+  if (!isHex64(options.enforcementId)) throw new BanSnapshotError("invalid-enforcement", "The snapshot identifier is not valid.", 400);
+  return walkExportCursor({
+    fetchPage: (cursor, retryCount) => {
+      const url = buildUrl(options.endpointBase, options.pubkey, "");
+      url.searchParams.set("enforcement_id", options.enforcementId);
+      url.searchParams.set("limit", String(options.limit ?? 500));
+      if (cursor) url.searchParams.set("cursor", cursor);
+      return fetchSnapshotPage({ ...options, url: url.toString(), retryCount });
+    },
+    isFailure: (error): error is BanSnapshotError => error instanceof BanSnapshotError,
+    makeFailure: clientError,
+    makeCancelledFailure: () => new BanSnapshotError("cancelled", "The snapshot recovery was cancelled."),
+    cancelledCode: "cancelled", rateLimitedCode: "rate-limited", sleep: options.sleep, signal: options.signal,
+    maxRateLimitRetries: options.maxRateLimitRetries, maxPages: options.maxPages, onProgress: options.onProgress,
+  });
+}

--- a/src/lib/exit/banSnapshotClient.ts
+++ b/src/lib/exit/banSnapshotClient.ts
@@ -61,7 +61,7 @@ function validateStatus(value: unknown): SnapshotStatus {
   if (timestamps.some((value) => value !== null && value !== undefined && !validateTimestamp(value))) throw new BanSnapshotError("malformed-response", "Divine returned a snapshot date this page could not read.");
   if (status.enforcement_id !== null && status.enforcement_id !== undefined && !isHex64(status.enforcement_id)) throw new BanSnapshotError("malformed-response", "Divine returned a snapshot identifier this page could not read.");
   if (status.days_remaining !== null && status.days_remaining !== undefined && (!Number.isInteger(status.days_remaining) || status.days_remaining < 0)) throw new BanSnapshotError("malformed-response", "Divine returned an invalid snapshot lifetime.");
-  if (status.state === "available" && (!status.enforcement_id || !status.expires_at || status.days_remaining === null || status.days_remaining === undefined)) throw new BanSnapshotError("malformed-response", "Divine returned incomplete snapshot information.");
+  if (status.state === "available" && (!status.enforcement_id || !status.created_at || !status.expires_at || status.days_remaining === null || status.days_remaining === undefined)) throw new BanSnapshotError("malformed-response", "Divine returned incomplete snapshot information.");
   return {
     state: status.state,
     enforcement_id: status.enforcement_id ?? null,

--- a/src/lib/exit/cursorWalk.ts
+++ b/src/lib/exit/cursorWalk.ts
@@ -34,6 +34,8 @@ export async function walkExportCursor<TFailure extends CursorFailure>(input: {
   const usedCursors = new Set<string>();
   const sleep = input.sleep ?? ((ms: number) => new Promise((resolve) => setTimeout(resolve, ms)));
   const maxRateLimitRetries = input.maxRateLimitRetries ?? 3;
+  // This is a protocol backstop, not an account-size limit. At the default
+  // page size it permits five million events before preserving a partial walk.
   const maxPages = input.maxPages ?? 10_000;
   let cursor: string | undefined;
   let pagesFetched = 0;
@@ -60,7 +62,7 @@ export async function walkExportCursor<TFailure extends CursorFailure>(input: {
       usedCursors.add(page.pagination.next_cursor);
       cursor = page.pagination.next_cursor;
     } catch (error) {
-      if (input.isFailure(error) && error.code === input.rateLimitedCode && pageRetries < maxRateLimitRetries) {
+      if (input.isFailure(error) && (error.code === input.rateLimitedCode || error.retryAfterMs !== undefined) && pageRetries < maxRateLimitRetries) {
         pageRetries += 1;
         retryCount += 1;
         input.onProgress?.({ pagesFetched, eventsFetched: events.length, retryCount });
@@ -70,6 +72,8 @@ export async function walkExportCursor<TFailure extends CursorFailure>(input: {
       if (input.isFailure(error) && error.code === input.cancelledCode) throw error;
       const failure = input.isFailure(error) ? error : input.makeFailure("network-failure");
       failures.push(failure);
+      // A completed page is still useful. Keep it and report why the walk
+      // stopped instead of discarding data already recovered.
       if (events.length > 0) return { events, pageCount: pagesFetched, failures };
       throw failure;
     }

--- a/src/lib/exit/cursorWalk.ts
+++ b/src/lib/exit/cursorWalk.ts
@@ -1,0 +1,92 @@
+// ABOUTME: Walks cursor-paginated export endpoints while preserving successfully retrieved pages
+// ABOUTME: Handles bounded rate-limit retries, stalled cursors, cancellation, and page limits
+
+import type { NostrEvent } from "@nostrify/nostrify";
+
+import type { ExportPage } from "./exportTransport";
+
+export interface CursorFailure extends Error {
+  code: string;
+  retryAfterMs?: number;
+}
+
+export interface CursorWalkProgress {
+  pagesFetched: number;
+  eventsFetched: number;
+  retryCount: number;
+}
+
+export async function walkExportCursor<TFailure extends CursorFailure>(input: {
+  fetchPage: (cursor: string | undefined, rateLimitRetryCount: number) => Promise<ExportPage>;
+  isFailure: (error: unknown) => error is TFailure;
+  makeFailure: (code: "network-failure" | "malformed-response" | "stalled-cursor" | "page-limit", detail?: number) => TFailure;
+  makeCancelledFailure: () => TFailure;
+  cancelledCode: string;
+  rateLimitedCode: string;
+  sleep?: (ms: number) => Promise<void>;
+  signal?: AbortSignal;
+  maxRateLimitRetries?: number;
+  maxPages?: number;
+  onProgress?: (progress: CursorWalkProgress) => void;
+}): Promise<{ events: NostrEvent[]; pageCount: number; failures: TFailure[] }> {
+  const events: NostrEvent[] = [];
+  const failures: TFailure[] = [];
+  const usedCursors = new Set<string>();
+  const sleep = input.sleep ?? ((ms: number) => new Promise((resolve) => setTimeout(resolve, ms)));
+  const maxRateLimitRetries = input.maxRateLimitRetries ?? 3;
+  const maxPages = input.maxPages ?? 10_000;
+  let cursor: string | undefined;
+  let pagesFetched = 0;
+  let retryCount = 0;
+  let pageRetries = 0;
+
+  for (;;) {
+    try {
+      const page = await input.fetchPage(cursor, pageRetries);
+      pagesFetched += 1;
+      events.push(...page.data);
+      pageRetries = 0;
+      input.onProgress?.({ pagesFetched, eventsFetched: events.length, retryCount });
+      if (!page.pagination.has_more) return { events, pageCount: pagesFetched, failures };
+      if (!page.pagination.next_cursor) throw input.makeFailure("malformed-response");
+      if (usedCursors.has(page.pagination.next_cursor)) {
+        failures.push(input.makeFailure("stalled-cursor"));
+        return { events, pageCount: pagesFetched, failures };
+      }
+      if (pagesFetched >= maxPages) {
+        failures.push(input.makeFailure("page-limit", maxPages));
+        return { events, pageCount: pagesFetched, failures };
+      }
+      usedCursors.add(page.pagination.next_cursor);
+      cursor = page.pagination.next_cursor;
+    } catch (error) {
+      if (input.isFailure(error) && error.code === input.rateLimitedCode && pageRetries < maxRateLimitRetries) {
+        pageRetries += 1;
+        retryCount += 1;
+        input.onProgress?.({ pagesFetched, eventsFetched: events.length, retryCount });
+        await waitForRetry(error.retryAfterMs ?? 1000, sleep, input.signal, input.makeCancelledFailure);
+        continue;
+      }
+      if (input.isFailure(error) && error.code === input.cancelledCode) throw error;
+      const failure = input.isFailure(error) ? error : input.makeFailure("network-failure");
+      failures.push(failure);
+      if (events.length > 0) return { events, pageCount: pagesFetched, failures };
+      throw failure;
+    }
+  }
+}
+
+async function waitForRetry(ms: number, sleep: (ms: number) => Promise<void>, signal: AbortSignal | undefined, aborted: () => Error) {
+  if (!signal) return sleep(ms);
+  if (signal.aborted) throw aborted();
+  let onAbort: () => void = () => undefined;
+  const cancellation = new Promise<never>((_resolve, reject) => {
+    onAbort = () => reject(aborted());
+    signal.addEventListener("abort", onAbort, { once: true });
+  });
+  try {
+    await Promise.race([sleep(ms), cancellation]);
+  } finally {
+    signal.removeEventListener("abort", onAbort);
+  }
+}

--- a/src/lib/exit/exportTransport.ts
+++ b/src/lib/exit/exportTransport.ts
@@ -89,6 +89,8 @@ export async function readExportErrorBody(response: Response): Promise<string> {
 export function exportRetryDelayMs(response: Response, retryCount: number): number {
   const retryAfterSeconds = Number(response.headers.get("retry-after"));
   const backoffMs = Math.min(1000 * 2 ** retryCount, 8000);
+  // Bound a hostile or misconfigured Retry-After so one response cannot stall
+  // an export for hours while retaining exponential backoff as the floor.
   return Number.isFinite(retryAfterSeconds) && retryAfterSeconds >= 0
     ? Math.min(Math.max(retryAfterSeconds * 1000, backoffMs), 60_000)
     : Math.max(backoffMs, 1000);

--- a/src/lib/exit/exportTransport.ts
+++ b/src/lib/exit/exportTransport.ts
@@ -1,0 +1,95 @@
+// ABOUTME: Provides shared authenticated transport and response validation for account exports
+// ABOUTME: Leaves endpoint-specific status classification and user-facing errors to each client
+
+import type { NostrEvent, NostrSigner } from "@nostrify/nostrify";
+
+import { createNip98AuthHeader } from "@/lib/nip98Auth";
+
+import { isHex64 } from "./hex";
+
+export interface ExportPage {
+  data: NostrEvent[];
+  pagination: {
+    next_cursor: string | null;
+    has_more: boolean;
+  };
+}
+
+export async function signedExportGet(input: {
+  url: string;
+  signer: NostrSigner;
+  fetcher: typeof fetch;
+  signal?: AbortSignal;
+  authFailure: () => Error;
+  networkFailure: () => Error;
+  cancelled: () => Error;
+}): Promise<Response> {
+  if (input.signal?.aborted) throw input.cancelled();
+
+  const authHeader = await createNip98AuthHeader(input.signer, input.url, "GET");
+  if (!authHeader) throw input.authFailure();
+
+  try {
+    return await input.fetcher(input.url, {
+      method: "GET",
+      headers: { Authorization: authHeader, Accept: "application/json" },
+      signal: input.signal,
+    });
+  } catch {
+    if (input.signal?.aborted) throw input.cancelled();
+    throw input.networkFailure();
+  }
+}
+
+const SIG_HEX = /^[0-9a-f]{128}$/i;
+
+export function validateExportPage(
+  value: unknown,
+  expectedPubkey: string,
+  malformed: (detail: string) => Error,
+): ExportPage {
+  if (!value || typeof value !== "object") throw malformed("response");
+  const candidate = value as Partial<ExportPage>;
+  if (!Array.isArray(candidate.data) || !candidate.pagination || typeof candidate.pagination !== "object") {
+    throw malformed("response");
+  }
+  if (typeof candidate.pagination.has_more !== "boolean") throw malformed("pagination");
+  const nextCursor = candidate.pagination.next_cursor;
+  if (nextCursor !== null && nextCursor !== undefined && typeof nextCursor !== "string") {
+    throw malformed("pagination");
+  }
+
+  const data = candidate.data.map((value) => {
+    if (!value || typeof value !== "object") throw malformed("response");
+    const event = value as Partial<NostrEvent>;
+    if (typeof event.id !== "string" || !isHex64(event.id)) throw malformed("event identifier");
+    if (typeof event.pubkey !== "string" || !isHex64(event.pubkey)) throw malformed("account identifier");
+    if (event.pubkey !== expectedPubkey) throw malformed("event for a different account");
+    if (typeof event.sig !== "string" || !SIG_HEX.test(event.sig)) throw malformed("event signature");
+    if (typeof event.created_at !== "number" || typeof event.kind !== "number" || typeof event.content !== "string") {
+      throw malformed("response");
+    }
+    if (!Array.isArray(event.tags) || event.tags.some((tag) => !Array.isArray(tag) || tag.some((part) => typeof part !== "string"))) {
+      throw malformed("response");
+    }
+    return event as NostrEvent;
+  });
+
+  return { data, pagination: { has_more: candidate.pagination.has_more, next_cursor: nextCursor ?? null } };
+}
+
+export async function readExportErrorBody(response: Response): Promise<string> {
+  try {
+    return await response.text();
+  } catch {
+    return "";
+  }
+}
+
+export function exportRetryDelayMs(response: Response, retryCount: number): number {
+  const retryAfterSeconds = Number(response.headers.get("retry-after"));
+  const backoffMs = Math.min(1000 * 2 ** retryCount, 8000);
+  return Number.isFinite(retryAfterSeconds) && retryAfterSeconds >= 0
+    ? Math.min(Math.max(retryAfterSeconds * 1000, backoffMs), 60_000)
+    : Math.max(backoffMs, 1000);
+}

--- a/src/lib/exit/ownerExportClient.ts
+++ b/src/lib/exit/ownerExportClient.ts
@@ -1,399 +1,95 @@
 // ABOUTME: Walks Divine's owner-export endpoint with NIP-98 auth and opaque cursors
 // ABOUTME: Surfaces typed failures so the /exit/start page can explain what went wrong
 
-import type { NostrEvent, NostrSigner } from "@nostrify/nostrify";
+import type { NostrSigner } from "@nostrify/nostrify";
 
-import { createNip98AuthHeader } from "@/lib/nip98Auth";
-
+import { walkExportCursor, type CursorWalkProgress } from "./cursorWalk";
+import { exportRetryDelayMs, readExportErrorBody, signedExportGet, validateExportPage, type ExportPage } from "./exportTransport";
 import { isHex64 } from "./hex";
 
-export interface ExportPage {
-  data: NostrEvent[];
-  pagination: {
-    next_cursor: string | null;
-    has_more: boolean;
-  };
-}
+export type { ExportPage } from "./exportTransport";
+export type ExportProgress = CursorWalkProgress;
 
-export type ExportFailureCode =
-  | "invalid-pubkey"
-  | "bad-cursor"
-  | "expired-cursor"
-  | "auth-required"
-  | "pubkey-mismatch"
-  | "rate-limited"
-  | "server-failure"
-  | "malformed-response"
-  | "network-failure"
-  | "cancelled"
-  | "stalled-cursor"
-  | "page-limit";
+export type ExportFailureCode = "invalid-pubkey" | "bad-cursor" | "expired-cursor" | "auth-required" | "pubkey-mismatch" | "rate-limited" | "server-failure" | "malformed-response" | "network-failure" | "cancelled" | "stalled-cursor" | "page-limit";
 
 export class OwnerExportError extends Error {
-  constructor(
-    public readonly code: ExportFailureCode,
-    message: string,
-    public readonly status?: number,
-    public readonly retryAfterMs?: number
-  ) {
+  constructor(public readonly code: ExportFailureCode, message: string, public readonly status?: number, public readonly retryAfterMs?: number) {
     super(message);
     this.name = "OwnerExportError";
   }
 }
 
-export interface ExportProgress {
-  pagesFetched: number;
-  eventsFetched: number;
-  retryCount: number;
-}
-
-export interface OwnerExportResult {
-  events: NostrEvent[];
-  pageCount: number;
-  failures: OwnerExportError[];
-}
+export interface OwnerExportResult { events: ExportPage["data"]; pageCount: number; failures: OwnerExportError[] }
 
 export interface OwnerExportClientOptions {
-  endpointBase: string;
-  pubkey: string;
-  signer: NostrSigner;
-  limit?: number;
-  fetcher?: typeof fetch;
-  sleep?: (ms: number) => Promise<void>;
-  maxRateLimitRetries?: number;
-  maxPages?: number;
-  signal?: AbortSignal;
-  onProgress?: (progress: ExportProgress) => void;
+  endpointBase: string; pubkey: string; signer: NostrSigner; limit?: number; fetcher?: typeof fetch;
+  sleep?: (ms: number) => Promise<void>; maxRateLimitRetries?: number; maxPages?: number;
+  signal?: AbortSignal; onProgress?: (progress: ExportProgress) => void;
 }
 
-const DEFAULT_LIMIT = 500;
-const DEFAULT_MAX_RATE_LIMIT_RETRIES = 3;
+function ownerFailure(code: "network-failure" | "malformed-response" | "stalled-cursor" | "page-limit", detail?: number) {
+  const message = code === "network-failure"
+    ? "The export could not reach Divine. Check the connection and try again."
+    : code === "malformed-response"
+      ? "Divine did not provide the next export page."
+      : code === "stalled-cursor"
+        ? "Divine stopped moving through the export, so this archive ends where it stopped."
+        : `This export stopped after ${detail} pages. Everything read up to that point is included.`;
+  return new OwnerExportError(code, message);
+}
 
-// A backstop against a server that never reports `has_more: false`, not a real
-// account size. At the default page size this is five million events, so a
-// genuine export should never reach it; hitting it returns what was collected
-// rather than discarding it.
-const DEFAULT_MAX_PAGES = 10_000;
-
-function buildExportUrl(endpointBase: string, pubkey: string, limit: number, cursor?: string): string {
-  const base = endpointBase.replace(/\/$/, "");
-  const url = new URL(`${base}/api/users/${pubkey}/export/events`);
+function buildUrl(endpointBase: string, pubkey: string, limit: number, cursor?: string) {
+  const url = new URL(`${endpointBase.replace(/\/$/, "")}/api/users/${pubkey}/export/events`);
   url.searchParams.set("limit", String(limit));
-
-  if (cursor) {
-    url.searchParams.set("cursor", cursor);
-  }
-
+  if (cursor) url.searchParams.set("cursor", cursor);
   return url.toString();
 }
 
-// Cap a server-supplied Retry-After so a hostile or misconfigured header
-// (e.g. `retry-after: 86400`) cannot stall the export for hours; backoffMs
-// already floors the delay at 1000ms.
-const MAX_RETRY_AFTER_MS = 60_000;
-
-function retryDelayMs(response: Response, retryCount: number): number {
-  const retryAfter = response.headers.get("retry-after");
-  const retryAfterSeconds = retryAfter ? Number(retryAfter) : Number.NaN;
-  const backoffMs = Math.min(1000 * 2 ** retryCount, 8000);
-
-  if (Number.isFinite(retryAfterSeconds) && retryAfterSeconds >= 0) {
-    return Math.min(Math.max(retryAfterSeconds * 1000, backoffMs), MAX_RETRY_AFTER_MS);
-  }
-
-  return Math.max(backoffMs, 1000);
-}
-
-async function readErrorBody(response: Response): Promise<string> {
-  try {
-    return await response.text();
-  } catch {
-    return "";
-  }
-}
-
-async function waitBeforeRetry(ms: number, sleep: (ms: number) => Promise<void>, signal?: AbortSignal): Promise<void> {
-  if (!signal) {
-    await sleep(ms);
-    return;
-  }
-  if (signal.aborted) {
-    throw new OwnerExportError("cancelled", "The export was cancelled.");
-  }
-
-  let handleAbort: () => void = () => void 0;
-  const aborted = new Promise<never>((_resolve, reject) => {
-    handleAbort = () => reject(new OwnerExportError("cancelled", "The export was cancelled."));
-    signal.addEventListener("abort", handleAbort, { once: true });
-  });
-
-  try {
-    await Promise.race([sleep(ms), aborted]);
-  } finally {
-    signal.removeEventListener("abort", handleAbort);
-  }
-}
-
-function classifyBadRequest(body: string): OwnerExportError {
+function classifyBadRequest(body: string) {
   const normalized = body.toLowerCase();
-
-  if (normalized.includes("expired") || normalized.includes("unknown cursor")) {
-    return new OwnerExportError("expired-cursor", "The export page expired. Start the export again.", 400);
-  }
-
-  if (normalized.includes("cursor")) {
-    return new OwnerExportError("bad-cursor", "The export page token was not accepted.", 400);
-  }
-
+  if (normalized.includes("expired") || normalized.includes("unknown cursor")) return new OwnerExportError("expired-cursor", "The export page expired. Start the export again.", 400);
+  if (normalized.includes("cursor")) return new OwnerExportError("bad-cursor", "The export page token was not accepted.", 400);
   return new OwnerExportError("invalid-pubkey", "The account identifier is not valid.", 400);
 }
 
-const SIG_HEX = /^[0-9a-f]{128}$/i;
-
-function validateEvent(value: unknown, expectedPubkey: string): NostrEvent {
-  if (!value || typeof value !== "object") {
-    throw new OwnerExportError("malformed-response", "Divine returned a response this tool could not read.");
-  }
-
-  const event = value as Partial<NostrEvent>;
-
-  if (typeof event.id !== "string" || !isHex64(event.id)) {
-    throw new OwnerExportError("malformed-response", "Divine returned an event identifier this tool could not read.");
-  }
-
-  if (typeof event.pubkey !== "string" || !isHex64(event.pubkey)) {
-    throw new OwnerExportError("malformed-response", "Divine returned an account identifier this tool could not read.");
-  }
-  if (event.pubkey !== expectedPubkey) {
-    throw new OwnerExportError("malformed-response", "Divine returned an event for a different account.");
-  }
-
-  if (typeof event.sig !== "string" || !SIG_HEX.test(event.sig)) {
-    throw new OwnerExportError("malformed-response", "Divine returned an event signature this tool could not read.");
-  }
-
-  if (typeof event.created_at !== "number" || typeof event.kind !== "number" || typeof event.content !== "string") {
-    throw new OwnerExportError("malformed-response", "Divine returned a response this tool could not read.");
-  }
-
-  if (
-    !Array.isArray(event.tags) ||
-    event.tags.some((tag) => !Array.isArray(tag) || tag.some((part) => typeof part !== "string"))
-  ) {
-    throw new OwnerExportError("malformed-response", "Divine returned a response this tool could not read.");
-  }
-
-  return event as NostrEvent;
+function malformedMessage(detail: string) {
+  if (detail === "event identifier") return "Divine returned an event identifier this tool could not read.";
+  if (detail === "account identifier") return "Divine returned an account identifier this tool could not read.";
+  if (detail === "event for a different account") return "Divine returned an event for a different account.";
+  if (detail === "event signature") return "Divine returned an event signature this tool could not read.";
+  if (detail === "pagination") return "Divine returned pagination this tool could not read.";
+  return "Divine returned a response this tool could not read.";
 }
 
-function validatePage(value: unknown, expectedPubkey: string): ExportPage {
-  if (!value || typeof value !== "object") {
-    throw new OwnerExportError("malformed-response", "Divine returned a response this tool could not read.");
-  }
-
-  const candidate = value as Partial<ExportPage>;
-
-  if (!Array.isArray(candidate.data) || !candidate.pagination || typeof candidate.pagination !== "object") {
-    throw new OwnerExportError("malformed-response", "Divine returned a response this tool could not read.");
-  }
-
-  if (typeof candidate.pagination.has_more !== "boolean") {
-    throw new OwnerExportError("malformed-response", "Divine returned pagination this tool could not read.");
-  }
-
-  const nextCursor = candidate.pagination.next_cursor;
-  if (nextCursor !== null && nextCursor !== undefined && typeof nextCursor !== "string") {
-    throw new OwnerExportError("malformed-response", "Divine returned pagination this tool could not read.");
-  }
-
-  return {
-    data: candidate.data.map((event) => validateEvent(event, expectedPubkey)),
-    pagination: {
-      has_more: candidate.pagination.has_more,
-      next_cursor: nextCursor ?? null
-    }
-  };
-}
-
-async function fetchPage(
-  url: string,
-  signer: NostrSigner,
-  fetcher: typeof fetch,
-  expectedPubkey: string,
-  signal?: AbortSignal,
-  rateLimitRetryCount = 0
-): Promise<ExportPage> {
-  if (signal?.aborted) {
-    throw new OwnerExportError("cancelled", "The export was cancelled.");
-  }
-
-  const authHeader = await createNip98AuthHeader(signer, url, "GET");
-
-  if (!authHeader) {
-    throw new OwnerExportError(
-      "auth-required",
-      "This export could not be signed. If your account is restricted, appeal first. Otherwise sign in again, then restart the export."
-    );
-  }
-
-  let response: Response;
+async function fetchOwnerPage(input: { url: string; pubkey: string; signer: NostrSigner; fetcher: typeof fetch; signal?: AbortSignal; retryCount: number }) {
+  const response = await signedExportGet({
+    ...input,
+    authFailure: () => new OwnerExportError("auth-required", "This export could not be signed. If your account is restricted, appeal first. Otherwise sign in again, then restart the export."),
+    networkFailure: () => ownerFailure("network-failure"),
+    cancelled: () => new OwnerExportError("cancelled", "The export was cancelled."),
+  });
+  if (response.status === 400) throw classifyBadRequest(await readExportErrorBody(response));
+  if (response.status === 401) throw new OwnerExportError("auth-required", "Sign in again, then restart the export.", 401);
+  if (response.status === 403) throw new OwnerExportError("pubkey-mismatch", "This sign-in does not match the account being exported.", 403);
+  if (response.status === 429) throw new OwnerExportError("rate-limited", "Divine asked this export to slow down. Wait a moment and try again.", 429, exportRetryDelayMs(response, input.retryCount));
+  if (!response.ok) throw new OwnerExportError("server-failure", "Divine could not finish this export right now. Try again later.", response.status);
   try {
-    response = await fetcher(url, {
-      method: "GET",
-      headers: {
-        Authorization: authHeader,
-        Accept: "application/json"
-      },
-      signal
-    });
-  } catch {
-    if (signal?.aborted) {
-      throw new OwnerExportError("cancelled", "The export was cancelled.");
-    }
-    throw new OwnerExportError("network-failure", "The export could not reach Divine. Check the connection and try again.");
-  }
-
-  if (response.status === 400) {
-    throw classifyBadRequest(await readErrorBody(response));
-  }
-  if (response.status === 401) {
-    throw new OwnerExportError("auth-required", "Sign in again, then restart the export.", 401);
-  }
-  if (response.status === 403) {
-    throw new OwnerExportError("pubkey-mismatch", "This sign-in does not match the account being exported.", 403);
-  }
-  if (response.status === 429) {
-    throw new OwnerExportError(
-      "rate-limited",
-      "Divine asked this export to slow down. Wait a moment and try again.",
-      429,
-      retryDelayMs(response, rateLimitRetryCount)
-    );
-  }
-  if (response.status >= 500) {
-    throw new OwnerExportError("server-failure", "Divine could not finish this export right now. Try again later.", response.status);
-  }
-  if (!response.ok) {
-    throw new OwnerExportError("server-failure", "Divine could not finish this export right now. Try again later.", response.status);
-  }
-
-  try {
-    return validatePage(await response.json(), expectedPubkey);
+    return validateExportPage(await response.json(), input.pubkey, (detail) => new OwnerExportError("malformed-response", malformedMessage(detail)));
   } catch (error) {
-    if (error instanceof OwnerExportError) {
-      throw error;
-    }
-    throw new OwnerExportError("malformed-response", "Divine returned a response this tool could not read.");
+    if (error instanceof OwnerExportError) throw error;
+    throw new OwnerExportError("malformed-response", malformedMessage("response"));
   }
 }
 
 export async function exportOwnerEvents(options: OwnerExportClientOptions): Promise<OwnerExportResult> {
-  const {
-    endpointBase,
-    pubkey,
-    signer,
-    fetcher = fetch,
-    sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms)),
-    limit = DEFAULT_LIMIT,
-    maxRateLimitRetries = DEFAULT_MAX_RATE_LIMIT_RETRIES,
-    maxPages = DEFAULT_MAX_PAGES,
-    signal,
-    onProgress
-  } = options;
-
-  if (!isHex64(pubkey)) {
-    throw new OwnerExportError("invalid-pubkey", "The account identifier is not valid.", 400);
-  }
-
-  const events: NostrEvent[] = [];
-  const failures: OwnerExportError[] = [];
-  const usedCursors = new Set<string>();
-  let cursor: string | undefined;
-  let pagesFetched = 0;
-  let retryCount = 0;
-  let rateLimitRetriesForPage = 0;
-
-  for (;;) {
-    const url = buildExportUrl(endpointBase, pubkey, limit, cursor);
-
-    try {
-      const page = await fetchPage(url, signer, fetcher, pubkey, signal, rateLimitRetriesForPage);
-      pagesFetched += 1;
-      events.push(...page.data);
-      rateLimitRetriesForPage = 0;
-      onProgress?.({ pagesFetched, eventsFetched: events.length, retryCount });
-
-      if (!page.pagination.has_more) {
-        return { events, pageCount: pagesFetched, failures };
-      }
-
-      if (!page.pagination.next_cursor) {
-        throw new OwnerExportError("malformed-response", "Divine did not provide the next export page.");
-      }
-
-      const nextCursor = page.pagination.next_cursor;
-
-      // A cursor we have already requested with means the server is not
-      // advancing. That is a definite protocol violation rather than a guess,
-      // so stop here and keep everything collected so far.
-      if (usedCursors.has(nextCursor)) {
-        failures.push(
-          new OwnerExportError(
-            "stalled-cursor",
-            "Divine stopped moving through the export, so this archive ends where it stopped."
-          )
-        );
-        return { events, pageCount: pagesFetched, failures };
-      }
-
-      if (pagesFetched >= maxPages) {
-        failures.push(
-          new OwnerExportError(
-            "page-limit",
-            `This export stopped after ${maxPages} pages. Everything read up to that point is included.`
-          )
-        );
-        return { events, pageCount: pagesFetched, failures };
-      }
-
-      usedCursors.add(nextCursor);
-      cursor = nextCursor;
-    } catch (error) {
-      if (
-        error instanceof OwnerExportError &&
-        error.code === "rate-limited" &&
-        rateLimitRetriesForPage < maxRateLimitRetries
-      ) {
-        retryCount += 1;
-        rateLimitRetriesForPage += 1;
-        onProgress?.({ pagesFetched, eventsFetched: events.length, retryCount });
-        await waitBeforeRetry(error.retryAfterMs ?? 1000, sleep, signal);
-        continue;
-      }
-
-      if (error instanceof OwnerExportError && error.code === "cancelled") {
-        throw error;
-      }
-
-      const failure =
-        error instanceof OwnerExportError
-          ? error
-          : new OwnerExportError(
-              "network-failure",
-              "The export could not reach Divine. Check the connection and try again."
-            );
-
-      failures.push(failure);
-
-      // Keep a partial archive rather than discarding pages already collected.
-      // Media is content-addressed and the walk is idempotent, so an incomplete
-      // archive is still useful and re-running it costs nothing. With nothing
-      // collected there is nothing to keep, so the failure is the whole story.
-      if (events.length > 0) {
-        return { events, pageCount: pagesFetched, failures };
-      }
-
-      throw failure;
-    }
-  }
+  const { endpointBase, pubkey, signer, fetcher = fetch, limit = 500, signal } = options;
+  if (!isHex64(pubkey)) throw new OwnerExportError("invalid-pubkey", "The account identifier is not valid.", 400);
+  return walkExportCursor({
+    fetchPage: (cursor, retryCount) => fetchOwnerPage({ url: buildUrl(endpointBase, pubkey, limit, cursor), pubkey, signer, fetcher, signal, retryCount }),
+    isFailure: (error): error is OwnerExportError => error instanceof OwnerExportError,
+    makeFailure: ownerFailure,
+    makeCancelledFailure: () => new OwnerExportError("cancelled", "The export was cancelled."),
+    cancelledCode: "cancelled", rateLimitedCode: "rate-limited", sleep: options.sleep, signal,
+    maxRateLimitRetries: options.maxRateLimitRetries, maxPages: options.maxPages, onProgress: options.onProgress,
+  });
 }

--- a/src/pages/ExitStartPage.test.tsx
+++ b/src/pages/ExitStartPage.test.tsx
@@ -138,6 +138,33 @@ describe("ExitStartPage", () => {
     ).toBeInTheDocument();
   });
 
+  it("recovers an available snapshot into the existing archive flow", async () => {
+    mockUseCurrentUser.mockReturnValue(signedIn());
+    const fetcher = vi.fn<typeof fetch>()
+      .mockResolvedValueOnce(new Response(JSON.stringify({
+        state: "available",
+        enforcement_id: "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+        enforced_at: "2026-08-01T12:00:00Z",
+        created_at: "2026-08-01T12:01:00Z",
+        expires_at: "2026-08-31T12:01:00Z",
+        days_remaining: 3,
+      }), { status: 200, headers: { "content-type": "application/json" } }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({
+        data: [makeFixtureEvent()],
+        pagination: { next_cursor: null, has_more: false },
+      }), { status: 200, headers: { "content-type": "application/json" } }));
+    vi.stubGlobal("fetch", fetcher);
+
+    render(<TestApp><ExitStartPage /></TestApp>);
+    await userEvent.click(screen.getByRole("button", { name: "Check for a snapshot" }));
+    await userEvent.click(await screen.findByRole("button", { name: "Recover snapshot" }));
+
+    await waitFor(() => expect(screen.getByText("Your archive is ready.")).toBeInTheDocument());
+    expect(screen.getByText(/1 page read, 1 event and 1 media reference collected from Divine/)).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Move your media" })).toBeInTheDocument();
+    expect(String(fetcher.mock.calls[1][0])).toContain("/export/snapshot?enforcement_id=");
+  });
+
   it("validates a custom Blossom destination inline", async () => {
     mockUseCurrentUser.mockReturnValue(signedIn());
     vi.stubGlobal("fetch", createFixtureFetch("one-page"));

--- a/src/pages/ExitStartPage.tsx
+++ b/src/pages/ExitStartPage.tsx
@@ -23,6 +23,7 @@ import { DiscoveryPointerForm } from "@/components/exit/DiscoveryPointerForm";
 import { KeySafetyNotice } from "@/components/exit/KeySafetyNotice";
 import { MediaProgressList } from "@/components/exit/MediaProgressList";
 import { RelayDestinationForm } from "@/components/exit/RelayDestinationForm";
+import { SnapshotRecovery } from "@/components/exit/SnapshotRecovery";
 import { LoginArea } from "@/components/auth/LoginArea";
 import { MarketingLayout } from "@/components/MarketingLayout";
 import { SectionHero } from "@/components/static-pages";
@@ -31,10 +32,12 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { getFunnelcakeBaseUrl } from "@/config/api";
 import { useCurrentUser } from "@/hooks/useCurrentUser";
 import { useArchiveMediaExport } from "@/hooks/useArchiveMediaExport";
+import { useBanSnapshotStatus } from "@/hooks/useBanSnapshotStatus";
 import { useDestinationMirror } from "@/hooks/useDestinationMirror";
 import { useDestinationRepublish } from "@/hooks/useDestinationRepublish";
 import { buildArchiveFiles, serializeArchiveFiles, type ArchiveFiles } from "@/lib/exit/archive";
 import { oldestArchivedVideoCreatedAt } from "@/lib/exit/archiveAge";
+import { BanSnapshotError, redeemSnapshotEvents, type SnapshotStatus } from "@/lib/exit/banSnapshotClient";
 import { exportOwnerEvents, OwnerExportError, type ExportProgress } from "@/lib/exit/ownerExportClient";
 import { createZip } from "@/lib/exit/zip";
 import { getLocalNsecLogin } from "@/lib/localNsecAccount";
@@ -42,7 +45,7 @@ import { getLocalNsecLogin } from "@/lib/localNsecAccount";
 type RunState = "idle" | "running" | "complete" | "failed";
 
 function errorMessage(error: unknown): string {
-  if (error instanceof OwnerExportError) {
+  if (error instanceof OwnerExportError || error instanceof BanSnapshotError) {
     return error.message;
   }
 
@@ -90,6 +93,7 @@ export function ExitStartPage() {
   const { user, signer, hostedToken, isHostedAccount, isResolvingJwt } = useCurrentUser();
   const { logins } = useNostrLogin();
   const localNsecLogin = user ? getLocalNsecLogin(logins, user.pubkey) : null;
+  const snapshotStatus = useBanSnapshotStatus({ pubkey: user?.pubkey, signer });
 
   const [state, setState] = useState<RunState>("idle");
   const [progress, setProgress] = useState<ExportProgress>({
@@ -99,6 +103,7 @@ export function ExitStartPage() {
   });
   const [archiveFiles, setArchiveFiles] = useState<ArchiveFiles | null>(null);
   const [failure, setFailure] = useState<string | null>(null);
+  const [activeSource, setActiveSource] = useState<"owner" | "snapshot" | null>(null);
   const activeExport = useRef<AbortController | null>(null);
   const currentPubkey = useRef(user?.pubkey);
   currentPubkey.current = user?.pubkey;
@@ -115,6 +120,7 @@ export function ExitStartPage() {
     activeExport.current = null;
     setState("idle");
     setFailure(null);
+    setActiveSource(null);
     setArchiveFiles(null);
     setProgress({ pagesFetched: 0, eventsFetched: 0, retryCount: 0 });
 
@@ -144,6 +150,7 @@ export function ExitStartPage() {
     }
 
     setState("running");
+    setActiveSource("owner");
     setFailure(null);
     setArchiveFiles(null);
     setProgress({ pagesFetched: 0, eventsFetched: 0, retryCount: 0 });
@@ -185,6 +192,56 @@ export function ExitStartPage() {
     } finally {
       if (activeExport.current === controller) {
         activeExport.current = null;
+        setActiveSource(null);
+      }
+    }
+  }
+
+  async function recoverSnapshot(status: SnapshotStatus & { state: "available"; enforcement_id: string; expires_at: string }) {
+    if (!user?.pubkey || !signer) return;
+    setState("running");
+    setActiveSource("snapshot");
+    setFailure(null);
+    setArchiveFiles(null);
+    setProgress({ pagesFetched: 0, eventsFetched: 0, retryCount: 0 });
+    activeExport.current?.abort();
+    const controller = new AbortController();
+    const exportPubkey = user.pubkey;
+    const exportEndpoint = getFunnelcakeBaseUrl();
+    activeExport.current = controller;
+
+    try {
+      const result = await redeemSnapshotEvents({
+        endpointBase: exportEndpoint,
+        pubkey: exportPubkey,
+        enforcementId: status.enforcement_id,
+        signer,
+        signal: controller.signal,
+        onProgress: setProgress,
+      });
+      if (controller.signal.aborted || currentPubkey.current !== exportPubkey) return;
+      setArchiveFiles(buildArchiveFiles({
+        events: result.events,
+        pubkey: exportPubkey,
+        sourceEndpoint: exportEndpoint,
+        sourceName: "Divine pre-ban snapshot",
+        pageCount: result.pageCount,
+        failures: result.failures,
+        snapshot: {
+          enforcement_id: status.enforcement_id,
+          enforced_at: status.enforced_at,
+          expires_at: status.expires_at,
+        },
+      }));
+      setState("complete");
+    } catch (error) {
+      if (controller.signal.aborted || currentPubkey.current !== exportPubkey) return;
+      setFailure(errorMessage(error));
+      setState("failed");
+    } finally {
+      if (activeExport.current === controller) {
+        activeExport.current = null;
+        setActiveSource(null);
       }
     }
   }
@@ -423,6 +480,18 @@ export function ExitStartPage() {
             </div>
           )}
         </section>
+
+        {user && (
+          <SnapshotRecovery
+            status={snapshotStatus.data ?? null}
+            checkError={snapshotStatus.error instanceof Error ? snapshotStatus.error.message : null}
+            checking={snapshotStatus.isFetching}
+            recovering={activeSource === "snapshot"}
+            disabled={!signer || state === "running"}
+            onCheck={() => void snapshotStatus.refetch()}
+            onRecover={(status) => void recoverSnapshot(status)}
+          />
+        )}
 
         {archiveFiles && signer && (
           <section>


### PR DESCRIPTION
## Summary

- Lets a signed-in account owner check for and redeem a private pre-ban snapshot from the account portability page.
- Shows each persisted lifecycle state distinctly, including a quiet absent result and the exact creation and expiry dates for available snapshots.
- Feeds recovered events into the existing archive, media verification, mirror, and republish flow, with snapshot provenance recorded in the manifest.

## Motivation

A pubkey ban removes the rows used by the ordinary owner export, so an enforced account could not recover the 30-day snapshot preserved by Funnelcake. This adds the pull-based web redemption path without bearer links or a second archive model. Shared NIP-98 transport and cursor walking are extracted from the existing owner export, while endpoint-specific validation and overloaded HTTP error handling remain separate.

Issue #620 stays open because the backend endpoints are not deployed to production yet, and acceptance still requires exercising a real banned hosted-signer snapshot after deployment.

## Related Issue

- Refs #620
- Part of #592

## Testing

- [x] `npx vitest run` - 330 test files and 2,763 tests passed
- [x] `npx tsc -p tsconfig.app.json --noEmit`, `npx eslint src/`, and `npx vite build` passed; ESLint reported 16 pre-existing warnings and no errors
- [x] `node scripts/check-analytics-contract.mjs` passed at the pinned contract
- [x] Manual verification completed - `/exit/start` rendered with the expected heading structure and no application console errors
- [x] Focused contract tests cover lifecycle states, overloaded responses, pagination, rate limiting, partial recovery, account switching, archive provenance, mutual operation locking, page-level recovery, and creation/expiry rendering

## Visuals

- [ ] UI change with screenshots/video attached
- [ ] No visual change
- [x] Visuals and text avoid sensitive external brand or partner names unless explicitly approved

The recovery section requires an authenticated account and a deployed backend response, so no production-state screenshot is attached.

