### PR TITLE
feat(exit): explain moderation gaps in account archives

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -191,11 +191,7 @@ and drawer UI. `vite-plugin-pwa` generates the PWA service worker.
 ### Account Archive Export
 
 The `/exit/start` flow reads raw signed events through the owner-export API and
-builds archive metadata in `src/lib/exit/`. Additive moderation annotations are
-accumulated across pages, while the withheld-event acknowledgement is accepted
-only from the terminal page. The manifest records supported, incomplete, and
-unsupported metadata distinctly; `events.json` keeps the bare signed events
-unchanged. Its media option writes a store-only
+builds archive metadata in `src/lib/exit/`. Its media option writes a store-only
 Zip64 archive directly to a user-selected file, downloads one unique blob at a
 time, verifies advertised SHA-256 hashes, and records partial failures without
 changing signed events. Viewer authorization is retried only for the exact
@@ -219,6 +215,11 @@ NIP-98 `u` tag includes the enforcement id and opaque cursor. Recovered events
 enter the existing archive, media verification, mirror, and republish pipeline.
 The manifest records snapshot provenance, while partial pages remain usable if
 the snapshot expires or becomes unavailable during retrieval.
+
+Additive moderation annotations are accumulated across pages, while the
+withheld-event acknowledgement is accepted only from the terminal page. The
+manifest records supported, incomplete, and unsupported metadata distinctly;
+`events.json` keeps the bare signed events unchanged.
 
 After an archive is built, the same page can mirror its unique source blobs to a
 custom HTTPS Blossom destination with BUD-04 `PUT /mirror`. Destination URLs

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -191,7 +191,11 @@ and drawer UI. `vite-plugin-pwa` generates the PWA service worker.
 ### Account Archive Export
 
 The `/exit/start` flow reads raw signed events through the owner-export API and
-builds archive metadata in `src/lib/exit/`. Its media option writes a store-only
+builds archive metadata in `src/lib/exit/`. Additive moderation annotations are
+accumulated across pages, while the withheld-event acknowledgement is accepted
+only from the terminal page. The manifest records supported, incomplete, and
+unsupported metadata distinctly; `events.json` keeps the bare signed events
+unchanged. Its media option writes a store-only
 Zip64 archive directly to a user-selected file, downloads one unique blob at a
 time, verifies advertised SHA-256 hashes, and records partial failures without
 changing signed events. Viewer authorization is retried only for the exact

--- a/src/components/exit/DiscoveryPointerForm.test.tsx
+++ b/src/components/exit/DiscoveryPointerForm.test.tsx
@@ -4,7 +4,7 @@ import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { buildArchiveFiles } from "@/lib/exit/archive";
-import { fixturePubkey, makeFixtureEvent } from "@/lib/exit/__fixtures__/exportFixtures";
+import { fixturePubkey, makeFixtureEvent, unsupportedModeration } from "@/lib/exit/__fixtures__/exportFixtures";
 import { openDestinationRelay } from "@/lib/exit/relayConnection";
 
 import { DiscoveryPointerForm } from "./DiscoveryPointerForm";
@@ -17,6 +17,7 @@ const files = buildArchiveFiles({
   sourceEndpoint: "https://api.divine.video",
   pageCount: 1,
   failures: [],
+  moderation: unsupportedModeration,
 });
 
 const signer = {

--- a/src/components/exit/ExportSummaryCard.tsx
+++ b/src/components/exit/ExportSummaryCard.tsx
@@ -1,0 +1,67 @@
+import { CheckCircle, WarningCircle } from "@phosphor-icons/react";
+
+import { Card, CardContent } from "@/components/ui/card";
+import type { ArchiveManifest } from "@/lib/exit/archive";
+
+interface ExportSummaryCardProps {
+  manifest: ArchiveManifest;
+  mediaCount: number;
+}
+
+function withheldMessage(withheld: ArchiveManifest["moderation"]["withheld"]): string {
+  if (withheld.kind === "known") {
+    if (withheld.count === 0) {
+      return "Divine confirmed that it withheld no events from this archive.";
+    }
+    return `Divine withheld ${withheld.count} event${withheld.count === 1 ? "" : "s"} under its content rules. ${withheld.count === 1 ? "It isn't" : "They aren't"} in this archive.`;
+  }
+  if (withheld.kind === "unavailable") {
+    return "Divine couldn't confirm whether any events were withheld.";
+  }
+  return "This Divine API version didn't provide withheld-event details.";
+}
+
+export function ExportSummaryCard({ manifest, mediaCount }: ExportSummaryCardProps) {
+  const failures = manifest.failures;
+  const moderation = manifest.moderation;
+  const bannedCount = moderation.annotations.filter(({ status }) => status === "banned").length;
+  const quarantinedCount = moderation.annotations.filter(({ status }) => status === "quarantined").length;
+  const moderationUnqualified = moderation.annotations_status !== "complete" || moderation.withheld.kind !== "known";
+  const withheldPositive = moderation.withheld.kind === "known" && moderation.withheld.count > 0;
+  const warning = failures.length > 0 || moderationUnqualified || withheldPositive;
+
+  const heading = failures.length > 0
+    ? "This archive is incomplete."
+    : moderationUnqualified
+      ? "Your archive is ready, with moderation details unavailable."
+      : withheldPositive
+        ? "Your archive is ready, with some events withheld."
+        : manifest.event_count === 0
+          ? "Your archive is ready, and it is empty."
+          : "Your archive is ready.";
+
+  return (
+    <Card variant="brand" accent={warning ? "yellow" : "green"}>
+      <CardContent className="pt-6 flex items-start gap-3">
+        {warning ? (
+          <WarningCircle weight="fill" className="mt-1 h-5 w-5 flex-shrink-0 text-brand-dark-green dark:text-brand-green" />
+        ) : (
+          <CheckCircle weight="fill" className="mt-1 h-5 w-5 flex-shrink-0 text-brand-dark-green dark:text-brand-green" />
+        )}
+        <div className="space-y-2">
+          <p className="font-semibold text-foreground">{heading}</p>
+          <p className="text-base leading-relaxed text-muted-foreground">
+            {manifest.page_count} page{manifest.page_count === 1 ? "" : "s"} read, {manifest.event_count} event{manifest.event_count === 1 ? "" : "s"} and {mediaCount} media reference{mediaCount === 1 ? "" : "s"} collected from Divine. Other relays were not checked, so anything you posted elsewhere is not in this file.
+          </p>
+          {bannedCount > 0 && <p className="text-base leading-relaxed text-muted-foreground">{bannedCount} event{bannedCount === 1 ? "" : "s"} in this archive {bannedCount === 1 ? "is" : "are"} banned on Divine. {bannedCount === 1 ? "It is" : "They are"} still yours and remain in your archive.</p>}
+          {quarantinedCount > 0 && <p className="text-base leading-relaxed text-muted-foreground">{quarantinedCount} event{quarantinedCount === 1 ? "" : "s"} in this archive {quarantinedCount === 1 ? "is" : "are"} quarantined on Divine. {quarantinedCount === 1 ? "It is" : "They are"} still yours and remain in your archive.</p>}
+          {moderation.annotations_status === "incomplete" && <p className="text-base leading-relaxed text-muted-foreground">Divine returned incomplete moderation annotations, so some event labels may be missing.</p>}
+          {moderation.annotations_status === "unsupported" && <p className="text-base leading-relaxed text-muted-foreground">This Divine API version didn't provide event moderation annotations.</p>}
+          <p className="text-base leading-relaxed text-muted-foreground">{withheldMessage(moderation.withheld)}</p>
+          {failures.map((failure) => <p key={`${failure.code}-${failure.message}`} className="text-base leading-relaxed text-muted-foreground">{failure.message}</p>)}
+          {failures.length > 0 && <p className="text-base leading-relaxed text-muted-foreground">You can download what was collected and run the export again; starting over is safe and does not duplicate anything.</p>}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/exit/ExportSummaryCard.tsx
+++ b/src/components/exit/ExportSummaryCard.tsx
@@ -9,13 +9,13 @@ interface ExportSummaryCardProps {
 }
 
 function withheldMessage(withheld: ArchiveManifest["moderation"]["withheld"]): string {
-  if (withheld.kind === "known") {
+  if (withheld?.complete) {
     if (withheld.count === 0) {
       return "Divine confirmed that it withheld no events from this archive.";
     }
     return `Divine withheld ${withheld.count} event${withheld.count === 1 ? "" : "s"} under its content rules. ${withheld.count === 1 ? "It isn't" : "They aren't"} in this archive.`;
   }
-  if (withheld.kind === "unavailable") {
+  if (withheld?.complete === false) {
     return "Divine couldn't confirm whether any events were withheld.";
   }
   return "This Divine API version didn't provide withheld-event details.";
@@ -26,19 +26,19 @@ export function ExportSummaryCard({ manifest, mediaCount }: ExportSummaryCardPro
   const moderation = manifest.moderation;
   const bannedCount = moderation.annotations.filter(({ status }) => status === "banned").length;
   const quarantinedCount = moderation.annotations.filter(({ status }) => status === "quarantined").length;
-  const moderationUnqualified = moderation.annotations_status !== "complete" || moderation.withheld.kind !== "known";
-  const withheldPositive = moderation.withheld.kind === "known" && moderation.withheld.count > 0;
-  const warning = failures.length > 0 || moderationUnqualified || withheldPositive;
+  const moderationIncomplete = moderation.annotations_status === "incomplete" || moderation.withheld?.complete === false;
+  const withheldPositive = moderation.withheld?.complete === true && moderation.withheld.count > 0;
+  const warning = failures.length > 0 || moderationIncomplete || withheldPositive;
 
   const heading = failures.length > 0
     ? "This archive is incomplete."
-    : moderationUnqualified
-      ? "Your archive is ready, with moderation details unavailable."
-      : withheldPositive
+    : manifest.event_count === 0
+      ? "Your archive is ready, and it is empty."
+      : moderationIncomplete
+        ? "Your archive is ready, with moderation details unavailable."
+        : withheldPositive
         ? "Your archive is ready, with some events withheld."
-        : manifest.event_count === 0
-          ? "Your archive is ready, and it is empty."
-          : "Your archive is ready.";
+        : "Your archive is ready.";
 
   return (
     <Card variant="brand" accent={warning ? "yellow" : "green"}>

--- a/src/hooks/useDestinationMirror.test.ts
+++ b/src/hooks/useDestinationMirror.test.ts
@@ -1,7 +1,7 @@
 import { act, renderHook, waitFor } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { fixturePubkey, makeFixtureEvent, otherFixturePubkey } from "@/lib/exit/__fixtures__/exportFixtures";
+import { fixturePubkey, makeFixtureEvent, otherFixturePubkey, unsupportedModeration } from "@/lib/exit/__fixtures__/exportFixtures";
 import { FixtureSigner } from "@/lib/exit/__fixtures__/fixtureSigner";
 import { buildArchiveFiles } from "@/lib/exit/archive";
 
@@ -14,6 +14,7 @@ function files(pubkey: string) {
     sourceEndpoint: "https://api.divine.video",
     pageCount: 1,
     failures: [],
+    moderation: unsupportedModeration,
   });
 }
 

--- a/src/hooks/useDestinationRepublish.test.ts
+++ b/src/hooks/useDestinationRepublish.test.ts
@@ -1,7 +1,7 @@
 import { act, renderHook, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import { fixturePubkey, makeFixtureEvent, otherFixturePubkey } from "@/lib/exit/__fixtures__/exportFixtures";
+import { fixturePubkey, makeFixtureEvent, otherFixturePubkey, unsupportedModeration } from "@/lib/exit/__fixtures__/exportFixtures";
 import { FixtureSigner } from "@/lib/exit/__fixtures__/fixtureSigner";
 import { buildArchiveFiles } from "@/lib/exit/archive";
 import { publishArchiveEvents } from "@/lib/exit/relayPublisher";
@@ -16,7 +16,7 @@ vi.mock("@/lib/exit/relayPublisher", async (importOriginal) => {
 vi.mock("@/lib/exit/relayLimits", () => ({ fetchRelayAgeLimit: vi.fn() }));
 
 function files(pubkey: string) {
-  return buildArchiveFiles({ events: [makeFixtureEvent({ pubkey })], pubkey, sourceEndpoint: "https://api.divine.video", pageCount: 1, failures: [] });
+  return buildArchiveFiles({ events: [makeFixtureEvent({ pubkey })], pubkey, sourceEndpoint: "https://api.divine.video", pageCount: 1, failures: [], moderation: unsupportedModeration });
 }
 
 const signer = new FixtureSigner();

--- a/src/hooks/useDiscoveryPointers.test.ts
+++ b/src/hooks/useDiscoveryPointers.test.ts
@@ -3,14 +3,14 @@ import { act, renderHook } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { buildArchiveFiles } from "@/lib/exit/archive";
-import { fixturePubkey, makeFixtureEvent } from "@/lib/exit/__fixtures__/exportFixtures";
+import { fixturePubkey, makeFixtureEvent, unsupportedModeration } from "@/lib/exit/__fixtures__/exportFixtures";
 import { openDestinationRelay } from "@/lib/exit/relayConnection";
 
 import { useDiscoveryPointers } from "./useDiscoveryPointers";
 
 vi.mock("@/lib/exit/relayConnection", () => ({ openDestinationRelay: vi.fn() }));
 
-const files = buildArchiveFiles({ events: [makeFixtureEvent()], pubkey: fixturePubkey, sourceEndpoint: "https://api.divine.video", pageCount: 1, failures: [] });
+const files = buildArchiveFiles({ events: [makeFixtureEvent()], pubkey: fixturePubkey, sourceEndpoint: "https://api.divine.video", pageCount: 1, failures: [], moderation: unsupportedModeration });
 
 function signer(sign?: (template: Omit<NostrEvent, "id" | "pubkey" | "sig">) => Promise<NostrEvent>): NostrSigner {
   return {
@@ -111,6 +111,7 @@ describe("useDiscoveryPointers", () => {
       sourceEndpoint: "https://api.divine.video",
       pageCount: 1,
       failures: [],
+      moderation: unsupportedModeration,
     });
     const testSigner = signer();
     const { result } = renderHook(() => useDiscoveryPointers({ files: futureFiles, relayDestination: "wss://relay.example/", blossomDestination: "https://blossom.example", signer: testSigner }));

--- a/src/lib/exit/__fixtures__/exportFixtures.ts
+++ b/src/lib/exit/__fixtures__/exportFixtures.ts
@@ -3,8 +3,6 @@
 
 import type { NostrEvent } from "@nostrify/nostrify";
 
-import type { ExportPage } from "../ownerExportClient";
-
 export const fixturePubkey = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
 export const otherFixturePubkey = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
 export const fixtureEventIdOne = "1111111111111111111111111111111111111111111111111111111111111111";
@@ -28,7 +26,7 @@ export function makeFixtureEvent(overrides: Partial<NostrEvent> = {}): NostrEven
   };
 }
 
-export const onePageExport: ExportPage = {
+export const onePageExport = {
   data: [makeFixtureEvent()],
   pagination: {
     next_cursor: null,
@@ -36,7 +34,7 @@ export const onePageExport: ExportPage = {
   }
 };
 
-export const multiPageExport: ExportPage[] = [
+export const multiPageExport = [
   {
     data: [makeFixtureEvent()],
     pagination: {
@@ -61,7 +59,7 @@ export const multiPageExport: ExportPage[] = [
   }
 ];
 
-export const emptyExport: ExportPage = {
+export const emptyExport = {
   data: [],
   pagination: {
     next_cursor: null,

--- a/src/lib/exit/__fixtures__/exportFixtures.ts
+++ b/src/lib/exit/__fixtures__/exportFixtures.ts
@@ -3,6 +3,8 @@
 
 import type { NostrEvent } from "@nostrify/nostrify";
 
+import type { OwnerExportModeration, OwnerExportPageResponse } from "../ownerExportClient";
+
 export const fixturePubkey = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
 export const otherFixturePubkey = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
 export const fixtureEventIdOne = "1111111111111111111111111111111111111111111111111111111111111111";
@@ -26,7 +28,16 @@ export function makeFixtureEvent(overrides: Partial<NostrEvent> = {}): NostrEven
   };
 }
 
-export const onePageExport = {
+export const unsupportedModeration: OwnerExportModeration = {
+  annotations: [],
+  annotationsStatus: "unsupported",
+  invalidAnnotationCount: 0,
+  orphanAnnotationCount: 0,
+  conflictingAnnotationCount: 0,
+  withheld: { kind: "unsupported" }
+};
+
+export const onePageExport: OwnerExportPageResponse = {
   data: [makeFixtureEvent()],
   pagination: {
     next_cursor: null,
@@ -34,7 +45,7 @@ export const onePageExport = {
   }
 };
 
-export const multiPageExport = [
+export const multiPageExport: OwnerExportPageResponse[] = [
   {
     data: [makeFixtureEvent()],
     pagination: {
@@ -59,7 +70,7 @@ export const multiPageExport = [
   }
 ];
 
-export const emptyExport = {
+export const emptyExport: OwnerExportPageResponse = {
   data: [],
   pagination: {
     next_cursor: null,

--- a/src/lib/exit/archive.test.ts
+++ b/src/lib/exit/archive.test.ts
@@ -23,7 +23,47 @@ describe("archive builder", () => {
       source_name: "Divine relay",
       source_endpoint: "https://api.divine.video",
       page_count: 1,
-      failures: []
+      failures: [],
+      moderation: {
+        annotations: [],
+        annotations_status: "unsupported",
+        invalid_annotation_count: 0,
+        orphan_annotation_count: 0,
+        conflicting_annotation_count: 0,
+        withheld: { kind: "unsupported" }
+      }
+    });
+  });
+
+  it("adds moderation metadata without changing the serialized signed events", () => {
+    const event = makeFixtureEvent();
+    const withoutMetadata = buildArchiveFiles({
+      events: [event], pubkey: fixturePubkey, sourceEndpoint: "https://api.divine.video", pageCount: 1, failures: []
+    });
+    const withMetadata = buildArchiveFiles({
+      events: [event],
+      pubkey: fixturePubkey,
+      sourceEndpoint: "https://api.divine.video",
+      pageCount: 1,
+      failures: [],
+      moderation: {
+        annotations: [{ eventId: event.id, status: "banned" }],
+        annotationsStatus: "complete",
+        invalidAnnotationCount: 0,
+        orphanAnnotationCount: 0,
+        conflictingAnnotationCount: 0,
+        withheld: { kind: "known", count: 2 }
+      }
+    });
+
+    expect(serializeArchiveFiles(withMetadata)["events.json"]).toBe(serializeArchiveFiles(withoutMetadata)["events.json"]);
+    expect(withMetadata["manifest.json"].moderation).toEqual({
+      annotations: [{ event_id: event.id, status: "banned" }],
+      annotations_status: "complete",
+      invalid_annotation_count: 0,
+      orphan_annotation_count: 0,
+      conflicting_annotation_count: 0,
+      withheld: { kind: "known", count: 2 }
     });
   });
 

--- a/src/lib/exit/archive.test.ts
+++ b/src/lib/exit/archive.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { fixtureMediaHash, fixturePubkey, makeFixtureEvent } from "./__fixtures__/exportFixtures";
+import { fixtureMediaHash, fixturePubkey, makeFixtureEvent, unsupportedModeration } from "./__fixtures__/exportFixtures";
 import { buildArchiveFiles, completeArchiveMedia, discoverMediaReferences, serializeArchiveFiles } from "./archive";
 
 describe("archive builder", () => {
@@ -12,6 +12,7 @@ describe("archive builder", () => {
       sourceEndpoint: "https://api.divine.video",
       pageCount: 1,
       failures: [],
+      moderation: unsupportedModeration,
       generatedAt: new Date("2026-08-12T21:00:00Z")
     });
 
@@ -29,8 +30,7 @@ describe("archive builder", () => {
         annotations_status: "unsupported",
         invalid_annotation_count: 0,
         orphan_annotation_count: 0,
-        conflicting_annotation_count: 0,
-        withheld: { kind: "unsupported" }
+        conflicting_annotation_count: 0
       }
     });
   });
@@ -38,7 +38,8 @@ describe("archive builder", () => {
   it("adds moderation metadata without changing the serialized signed events", () => {
     const event = makeFixtureEvent();
     const withoutMetadata = buildArchiveFiles({
-      events: [event], pubkey: fixturePubkey, sourceEndpoint: "https://api.divine.video", pageCount: 1, failures: []
+      events: [event], pubkey: fixturePubkey, sourceEndpoint: "https://api.divine.video", pageCount: 1,
+      failures: [], moderation: unsupportedModeration
     });
     const withMetadata = buildArchiveFiles({
       events: [event],
@@ -63,7 +64,7 @@ describe("archive builder", () => {
       invalid_annotation_count: 0,
       orphan_annotation_count: 0,
       conflicting_annotation_count: 0,
-      withheld: { kind: "known", count: 2 }
+      withheld: { complete: true, count: 2 }
     });
   });
 
@@ -229,6 +230,7 @@ describe("archive builder", () => {
       sourceEndpoint: "https://api.divine.video",
       pageCount: 1,
       failures: [],
+      moderation: unsupportedModeration,
       generatedAt: new Date("2026-08-12T21:00:00Z")
     });
 
@@ -238,7 +240,8 @@ describe("archive builder", () => {
   it("merges per-reference results, summarizes blobs, and certifies only trusted paths", () => {
     const archive = buildArchiveFiles({
       events: [makeFixtureEvent()], pubkey: fixturePubkey, sourceEndpoint: "https://api.divine.video",
-      pageCount: 1, failures: [], generatedAt: new Date("2026-08-12T21:00:00Z"),
+      pageCount: 1, failures: [], moderation: unsupportedModeration,
+      generatedAt: new Date("2026-08-12T21:00:00Z"),
     });
     const reference = archive["media.json"][0];
     const completed = completeArchiveMedia(archive, [

--- a/src/lib/exit/archive.ts
+++ b/src/lib/exit/archive.ts
@@ -4,6 +4,7 @@
 import type { NostrEvent } from "@nostrify/nostrify";
 
 import { isHex64 } from "./hex";
+import type { ModerationAnnotation, WithheldResult } from "./moderationMetadata";
 import type { MediaDownloadResult, MediaVerification } from "./mediaDownloader";
 
 export interface ArchiveFailure extends Error {
@@ -34,6 +35,14 @@ export interface ArchiveManifest {
     enforcement_id: string;
     enforced_at: string | null;
     expires_at: string;
+  };
+  moderation: {
+    annotations: Array<{ event_id: string; status: ModerationAnnotation["status"] }>;
+    annotations_status: "complete" | "incomplete" | "unsupported";
+    invalid_annotation_count: number;
+    orphan_annotation_count: number;
+    conflicting_annotation_count: number;
+    withheld: WithheldResult;
   };
   media?: MediaSummary;
 }
@@ -174,8 +183,25 @@ export function buildArchiveFiles(input: {
   failures: ArchiveFailure[];
   sourceName?: string;
   snapshot?: ArchiveManifest["snapshot"];
+  moderation?: {
+    annotations: ModerationAnnotation[];
+    annotationsStatus: "complete" | "incomplete" | "unsupported";
+    invalidAnnotationCount: number;
+    orphanAnnotationCount: number;
+    conflictingAnnotationCount: number;
+    withheld: WithheldResult;
+  };
   generatedAt?: Date;
 }): ArchiveFiles {
+  const moderation = input.moderation ?? {
+    annotations: [],
+    annotationsStatus: "unsupported" as const,
+    invalidAnnotationCount: 0,
+    orphanAnnotationCount: 0,
+    conflictingAnnotationCount: 0,
+    withheld: { kind: "unsupported" as const }
+  };
+
   return {
     "events.json": input.events,
     "manifest.json": {
@@ -191,6 +217,14 @@ export function buildArchiveFiles(input: {
         status: failure.status
       })),
       ...(input.snapshot ? { snapshot: input.snapshot } : {}),
+      moderation: {
+        annotations: moderation.annotations.map(({ eventId, status }) => ({ event_id: eventId, status })),
+        annotations_status: moderation.annotationsStatus,
+        invalid_annotation_count: moderation.invalidAnnotationCount,
+        orphan_annotation_count: moderation.orphanAnnotationCount,
+        conflicting_annotation_count: moderation.conflictingAnnotationCount,
+        withheld: moderation.withheld
+      }
     },
     "media.json": discoverMediaReferences(input.events)
   };

--- a/src/lib/exit/archive.ts
+++ b/src/lib/exit/archive.ts
@@ -4,7 +4,8 @@
 import type { NostrEvent } from "@nostrify/nostrify";
 
 import { isHex64 } from "./hex";
-import type { ModerationAnnotation, WithheldResult } from "./moderationMetadata";
+import type { OwnerExportModeration } from "./ownerExportClient";
+import type { ModerationAnnotation } from "./moderationMetadata";
 import type { MediaDownloadResult, MediaVerification } from "./mediaDownloader";
 
 export interface ArchiveFailure extends Error {
@@ -18,6 +19,8 @@ export interface MediaReference {
   url: string;
   sha256: string | null;
 }
+
+export type ArchiveWithheld = { complete: false } | { complete: true; count: number };
 
 export interface ArchiveManifest {
   pubkey: string;
@@ -42,7 +45,7 @@ export interface ArchiveManifest {
     invalid_annotation_count: number;
     orphan_annotation_count: number;
     conflicting_annotation_count: number;
-    withheld: WithheldResult;
+    withheld?: ArchiveWithheld;
   };
   media?: MediaSummary;
 }
@@ -183,14 +186,7 @@ export function buildArchiveFiles(input: {
   failures: ArchiveFailure[];
   sourceName?: string;
   snapshot?: ArchiveManifest["snapshot"];
-  moderation?: {
-    annotations: ModerationAnnotation[];
-    annotationsStatus: "complete" | "incomplete" | "unsupported";
-    invalidAnnotationCount: number;
-    orphanAnnotationCount: number;
-    conflictingAnnotationCount: number;
-    withheld: WithheldResult;
-  };
+  moderation?: OwnerExportModeration;
   generatedAt?: Date;
 }): ArchiveFiles {
   const moderation = input.moderation ?? {
@@ -199,8 +195,13 @@ export function buildArchiveFiles(input: {
     invalidAnnotationCount: 0,
     orphanAnnotationCount: 0,
     conflictingAnnotationCount: 0,
-    withheld: { kind: "unsupported" as const }
+    withheld: { kind: "unsupported" as const },
   };
+  const withheld = moderation.withheld.kind === "known"
+    ? { complete: true as const, count: moderation.withheld.count }
+    : moderation.withheld.kind === "unavailable"
+      ? { complete: false as const }
+      : undefined;
 
   return {
     "events.json": input.events,
@@ -223,7 +224,7 @@ export function buildArchiveFiles(input: {
         invalid_annotation_count: moderation.invalidAnnotationCount,
         orphan_annotation_count: moderation.orphanAnnotationCount,
         conflicting_annotation_count: moderation.conflictingAnnotationCount,
-        withheld: moderation.withheld
+        ...(withheld ? { withheld } : {})
       }
     },
     "media.json": discoverMediaReferences(input.events)

--- a/src/lib/exit/banSnapshotClient.test.ts
+++ b/src/lib/exit/banSnapshotClient.test.ts
@@ -49,6 +49,31 @@ describe("fetchSnapshotStatus", () => {
 });
 
 describe("redeemSnapshotEvents", () => {
+  it("preserves moderation annotations and terminal withheld metadata", async () => {
+    const event = makeFixtureEvent();
+    const result = await redeemSnapshotEvents({
+      endpointBase: "https://api.divine.video",
+      pubkey: fixturePubkey,
+      enforcementId,
+      signer: new FixtureSigner(),
+      fetcher: async () => json({
+        data: [event],
+        moderation_annotations: { [event.id]: { status: "banned" } },
+        withheld: { complete: true, count: 2 },
+        pagination: { has_more: false, next_cursor: null },
+      }),
+    });
+
+    expect(result.moderation).toEqual({
+      annotations: [{ eventId: event.id, status: "banned" }],
+      annotationsStatus: "complete",
+      invalidAnnotationCount: 0,
+      orphanAnnotationCount: 0,
+      conflictingAnnotationCount: 0,
+      withheld: { kind: "known", count: 2 },
+    });
+  });
+
   it("signs every full page URL including enforcement id and cursor", async () => {
     const signer = new FixtureSigner();
     let page = 0;

--- a/src/lib/exit/cursorWalk.ts
+++ b/src/lib/exit/cursorWalk.ts
@@ -4,6 +4,7 @@
 import type { NostrEvent } from "@nostrify/nostrify";
 
 import type { ExportPage } from "./exportTransport";
+import { dropOrphanAnnotations, type AnnotationStatus, type ExportModeration, type WithheldResult } from "./moderationMetadata";
 
 export interface CursorFailure extends Error {
   code: string;
@@ -28,7 +29,7 @@ export async function walkExportCursor<TFailure extends CursorFailure>(input: {
   maxRateLimitRetries?: number;
   maxPages?: number;
   onProgress?: (progress: CursorWalkProgress) => void;
-}): Promise<{ events: NostrEvent[]; pageCount: number; failures: TFailure[] }> {
+}): Promise<{ events: NostrEvent[]; pageCount: number; failures: TFailure[]; moderation: ExportModeration }> {
   const events: NostrEvent[] = [];
   const failures: TFailure[] = [];
   const usedCursors = new Set<string>();
@@ -41,23 +42,66 @@ export async function walkExportCursor<TFailure extends CursorFailure>(input: {
   let pagesFetched = 0;
   let retryCount = 0;
   let pageRetries = 0;
+  const annotations = new Map<string, AnnotationStatus>();
+  let annotationPagesAvailable = 0;
+  let annotationPagesUnsupported = 0;
+  let invalidAnnotationCount = 0;
+  let conflictingAnnotationCount = 0;
+
+  function buildResult(withheld: WithheldResult) {
+    const filtered = dropOrphanAnnotations(annotations, new Set(events.map((event) => event.id)));
+    const annotationsStatus = annotationPagesAvailable === 0
+      ? "unsupported" as const
+      : annotationPagesUnsupported > 0 || invalidAnnotationCount > 0 || filtered.orphanCount > 0 || conflictingAnnotationCount > 0
+        ? "incomplete" as const
+        : "complete" as const;
+
+    return {
+      events,
+      pageCount: pagesFetched,
+      failures,
+      moderation: {
+        annotations: Array.from(filtered.annotations, ([eventId, status]) => ({ eventId, status })),
+        annotationsStatus,
+        invalidAnnotationCount,
+        orphanAnnotationCount: filtered.orphanCount,
+        conflictingAnnotationCount,
+        withheld,
+      },
+    };
+  }
 
   for (;;) {
     try {
       const page = await input.fetchPage(cursor, pageRetries);
       pagesFetched += 1;
       events.push(...page.data);
+      if (page.moderationAnnotations.kind === "unsupported") {
+        annotationPagesUnsupported += 1;
+      } else {
+        annotationPagesAvailable += 1;
+        invalidAnnotationCount += page.moderationAnnotations.invalidCount;
+        conflictingAnnotationCount += page.moderationAnnotations.conflictingCount;
+        for (const [eventId, status] of page.moderationAnnotations.annotations) {
+          const previous = annotations.get(eventId);
+          if (previous && previous !== status) {
+            conflictingAnnotationCount += 1;
+            continue;
+          }
+          annotations.set(eventId, status);
+        }
+      }
       pageRetries = 0;
       input.onProgress?.({ pagesFetched, eventsFetched: events.length, retryCount });
-      if (!page.pagination.has_more) return { events, pageCount: pagesFetched, failures };
+      if (!page.pagination.has_more) return buildResult(page.withheld);
       if (!page.pagination.next_cursor) throw input.makeFailure("malformed-response");
       if (usedCursors.has(page.pagination.next_cursor)) {
         failures.push(input.makeFailure("stalled-cursor"));
-        return { events, pageCount: pagesFetched, failures };
+        return buildResult({ kind: "unavailable" });
       }
       if (pagesFetched >= maxPages) {
         failures.push(input.makeFailure("page-limit", maxPages));
-        return { events, pageCount: pagesFetched, failures };
+        return buildResult({ kind: "unavailable" });
       }
       usedCursors.add(page.pagination.next_cursor);
       cursor = page.pagination.next_cursor;
@@ -74,7 +118,7 @@ export async function walkExportCursor<TFailure extends CursorFailure>(input: {
       failures.push(failure);
       // A completed page is still useful. Keep it and report why the walk
       // stopped instead of discarding data already recovered.
-      if (events.length > 0) return { events, pageCount: pagesFetched, failures };
+      if (events.length > 0) return buildResult({ kind: "unavailable" });
       throw failure;
     }
   }

--- a/src/lib/exit/exportTransport.ts
+++ b/src/lib/exit/exportTransport.ts
@@ -6,9 +6,12 @@ import type { NostrEvent, NostrSigner } from "@nostrify/nostrify";
 import { createNip98AuthHeader } from "@/lib/nip98Auth";
 
 import { isHex64 } from "./hex";
+import { parseAnnotations, parseWithheld, type AnnotationMetadata, type WithheldResult } from "./moderationMetadata";
 
 export interface ExportPage {
   data: NostrEvent[];
+  moderationAnnotations: AnnotationMetadata;
+  withheld: WithheldResult;
   pagination: {
     next_cursor: string | null;
     has_more: boolean;
@@ -75,7 +78,13 @@ export function validateExportPage(
     return event as NostrEvent;
   });
 
-  return { data, pagination: { has_more: candidate.pagination.has_more, next_cursor: nextCursor ?? null } };
+  const metadata = value as { moderation_annotations?: unknown; withheld?: unknown };
+  return {
+    data,
+    moderationAnnotations: parseAnnotations(metadata.moderation_annotations),
+    withheld: parseWithheld(metadata.withheld),
+    pagination: { has_more: candidate.pagination.has_more, next_cursor: nextCursor ?? null },
+  };
 }
 
 export async function readExportErrorBody(response: Response): Promise<string> {

--- a/src/lib/exit/moderationMetadata.test.ts
+++ b/src/lib/exit/moderationMetadata.test.ts
@@ -10,7 +10,7 @@ describe("moderation metadata", () => {
       [fixtureEventIdTwo]: { status: "quarantined" }
     });
 
-    expect(result).toMatchObject({ kind: "available", complete: true, invalidCount: 0 });
+    expect(result).toMatchObject({ kind: "available", invalidCount: 0 });
     expect(result.kind === "available" && Array.from(result.annotations)).toEqual([
       [fixtureEventIdOne, "banned"],
       [fixtureEventIdTwo, "quarantined"]
@@ -24,12 +24,12 @@ describe("moderation metadata", () => {
     [[], 1],
     ["bad", 1]
   ])("keeps malformed annotations from invalidating the event page", (raw, invalidCount) => {
-    expect(parseAnnotations(raw)).toMatchObject({ kind: "available", complete: false, invalidCount });
+    expect(parseAnnotations(raw)).toMatchObject({ kind: "available", invalidCount });
   });
 
   it("distinguishes an absent annotation field from an empty supported field", () => {
     expect(parseAnnotations(undefined)).toEqual({ kind: "unsupported" });
-    expect(parseAnnotations({})).toMatchObject({ kind: "available", complete: true, invalidCount: 0 });
+    expect(parseAnnotations({})).toMatchObject({ kind: "available", invalidCount: 0 });
   });
 
   it.each([

--- a/src/lib/exit/moderationMetadata.test.ts
+++ b/src/lib/exit/moderationMetadata.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+
+import { fixtureEventIdOne, fixtureEventIdTwo } from "./__fixtures__/exportFixtures";
+import { dropOrphanAnnotations, parseAnnotations, parseWithheld } from "./moderationMetadata";
+
+describe("moderation metadata", () => {
+  it("parses banned and quarantined annotations with full event IDs", () => {
+    const result = parseAnnotations({
+      [fixtureEventIdOne]: { status: "banned" },
+      [fixtureEventIdTwo]: { status: "quarantined" }
+    });
+
+    expect(result).toMatchObject({ kind: "available", complete: true, invalidCount: 0 });
+    expect(result.kind === "available" && Array.from(result.annotations)).toEqual([
+      [fixtureEventIdOne, "banned"],
+      [fixtureEventIdTwo, "quarantined"]
+    ]);
+  });
+
+  it.each([
+    [{ [fixtureEventIdOne]: { status: "reviewed" } }, 1],
+    [{ short: { status: "banned" } }, 1],
+    [{ [fixtureEventIdOne]: null }, 1],
+    [[], 1],
+    ["bad", 1]
+  ])("keeps malformed annotations from invalidating the event page", (raw, invalidCount) => {
+    expect(parseAnnotations(raw)).toMatchObject({ kind: "available", complete: false, invalidCount });
+  });
+
+  it("distinguishes an absent annotation field from an empty supported field", () => {
+    expect(parseAnnotations(undefined)).toEqual({ kind: "unsupported" });
+    expect(parseAnnotations({})).toMatchObject({ kind: "available", complete: true, invalidCount: 0 });
+  });
+
+  it.each([
+    [{ complete: true, count: 2 }, { kind: "known", count: 2 }],
+    [{ complete: true, count: 0 }, { kind: "known", count: 0 }],
+    [{ complete: false }, { kind: "unavailable" }],
+    [undefined, { kind: "unsupported" }],
+    [{ complete: true, count: -1 }, { kind: "unavailable" }],
+    [{ complete: true, count: 1.5 }, { kind: "unavailable" }],
+    [null, { kind: "unavailable" }]
+  ])("parses withheld state %#", (raw, expected) => {
+    expect(parseWithheld(raw)).toEqual(expected);
+  });
+
+  it("drops annotations that do not belong to returned events", () => {
+    const result = dropOrphanAnnotations(
+      new Map([[fixtureEventIdOne, "banned"], [fixtureEventIdTwo, "quarantined"]]),
+      new Set([fixtureEventIdOne])
+    );
+
+    expect(Array.from(result.annotations)).toEqual([[fixtureEventIdOne, "banned"]]);
+    expect(result.orphanCount).toBe(1);
+  });
+});

--- a/src/lib/exit/moderationMetadata.test.ts
+++ b/src/lib/exit/moderationMetadata.test.ts
@@ -35,6 +35,19 @@ describe("moderation metadata", () => {
     ]);
   });
 
+  it("reports conflicting statuses whose event IDs differ only by case", () => {
+    const eventId = "ab".repeat(32);
+    const result = parseAnnotations({
+      [eventId]: { status: "banned" },
+      [eventId.toUpperCase()]: { status: "quarantined" }
+    });
+
+    expect(result).toMatchObject({ kind: "available", conflictingCount: 1 });
+    expect(result.kind === "available" && Array.from(result.annotations)).toEqual([
+      [eventId, "banned"]
+    ]);
+  });
+
   it("distinguishes an absent annotation field from an empty supported field", () => {
     expect(parseAnnotations(undefined)).toEqual({ kind: "unsupported" });
     expect(parseAnnotations({})).toMatchObject({ kind: "available", invalidCount: 0 });

--- a/src/lib/exit/moderationMetadata.test.ts
+++ b/src/lib/exit/moderationMetadata.test.ts
@@ -27,6 +27,14 @@ describe("moderation metadata", () => {
     expect(parseAnnotations(raw)).toMatchObject({ kind: "available", invalidCount });
   });
 
+  it("canonicalises upper-case event IDs so they can match returned events", () => {
+    const result = parseAnnotations({ [fixtureEventIdOne.toUpperCase()]: { status: "banned" } });
+
+    expect(result.kind === "available" && Array.from(result.annotations)).toEqual([
+      [fixtureEventIdOne, "banned"]
+    ]);
+  });
+
   it("distinguishes an absent annotation field from an empty supported field", () => {
     expect(parseAnnotations(undefined)).toEqual({ kind: "unsupported" });
     expect(parseAnnotations({})).toMatchObject({ kind: "available", invalidCount: 0 });

--- a/src/lib/exit/moderationMetadata.ts
+++ b/src/lib/exit/moderationMetadata.ts
@@ -13,6 +13,7 @@ export type AnnotationMetadata =
       kind: "available";
       annotations: Map<string, AnnotationStatus>;
       invalidCount: number;
+      conflictingCount: number;
     };
 
 export type WithheldResult =
@@ -30,11 +31,12 @@ export function parseAnnotations(raw: unknown): AnnotationMetadata {
     return { kind: "unsupported" };
   }
   if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
-    return { kind: "available", annotations: new Map(), invalidCount: 1 };
+    return { kind: "available", annotations: new Map(), invalidCount: 1, conflictingCount: 0 };
   }
 
   const annotations = new Map<string, AnnotationStatus>();
   let invalidCount = 0;
+  let conflictingCount = 0;
 
   for (const [eventId, value] of Object.entries(raw)) {
     if (!isHex64(eventId) || !value || typeof value !== "object" || Array.isArray(value)) {
@@ -47,12 +49,16 @@ export function parseAnnotations(raw: unknown): AnnotationMetadata {
       invalidCount += 1;
       continue;
     }
-    // `isHex64` accepts either case, so canonicalise before the key is compared
-    // against event IDs, the way the media hashes in `archive.ts` are.
-    annotations.set(eventId.toLowerCase(), status);
+    const normalizedEventId = eventId.toLowerCase();
+    const previous = annotations.get(normalizedEventId);
+    if (previous && previous !== status) {
+      conflictingCount += 1;
+      continue;
+    }
+    annotations.set(normalizedEventId, status);
   }
 
-  return { kind: "available", annotations, invalidCount };
+  return { kind: "available", annotations, invalidCount, conflictingCount };
 }
 
 export function parseWithheld(raw: unknown): WithheldResult {

--- a/src/lib/exit/moderationMetadata.ts
+++ b/src/lib/exit/moderationMetadata.ts
@@ -1,0 +1,96 @@
+import { isHex64 } from "./hex";
+
+export type AnnotationStatus = "banned" | "quarantined";
+
+export interface ModerationAnnotation {
+  eventId: string;
+  status: AnnotationStatus;
+}
+
+export type AnnotationMetadata =
+  | { kind: "unsupported" }
+  | {
+      kind: "available";
+      annotations: Map<string, AnnotationStatus>;
+      complete: boolean;
+      invalidCount: number;
+    };
+
+export type WithheldResult =
+  | { kind: "unsupported" }
+  | { kind: "unavailable" }
+  | { kind: "known"; count: number };
+
+export interface FilteredAnnotations {
+  annotations: Map<string, AnnotationStatus>;
+  orphanCount: number;
+}
+
+export function parseAnnotations(raw: unknown): AnnotationMetadata {
+  if (raw === undefined) {
+    return { kind: "unsupported" };
+  }
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
+    return { kind: "available", annotations: new Map(), complete: false, invalidCount: 1 };
+  }
+
+  const annotations = new Map<string, AnnotationStatus>();
+  let invalidCount = 0;
+
+  for (const [eventId, value] of Object.entries(raw)) {
+    if (!isHex64(eventId) || !value || typeof value !== "object" || Array.isArray(value)) {
+      invalidCount += 1;
+      continue;
+    }
+
+    const status = (value as { status?: unknown }).status;
+    if (status !== "banned" && status !== "quarantined") {
+      invalidCount += 1;
+      continue;
+    }
+    annotations.set(eventId, status);
+  }
+
+  return { kind: "available", annotations, complete: invalidCount === 0, invalidCount };
+}
+
+export function parseWithheld(raw: unknown): WithheldResult {
+  if (raw === undefined) {
+    return { kind: "unsupported" };
+  }
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
+    return { kind: "unavailable" };
+  }
+
+  const candidate = raw as { complete?: unknown; count?: unknown };
+  if (candidate.complete === false) {
+    return { kind: "unavailable" };
+  }
+  if (
+    candidate.complete === true &&
+    typeof candidate.count === "number" &&
+    Number.isSafeInteger(candidate.count) &&
+    candidate.count >= 0
+  ) {
+    return { kind: "known", count: candidate.count };
+  }
+  return { kind: "unavailable" };
+}
+
+export function dropOrphanAnnotations(
+  annotations: Map<string, AnnotationStatus>,
+  eventIds: ReadonlySet<string>
+): FilteredAnnotations {
+  const filtered = new Map<string, AnnotationStatus>();
+  let orphanCount = 0;
+
+  for (const [eventId, status] of annotations) {
+    if (eventIds.has(eventId)) {
+      filtered.set(eventId, status);
+    } else {
+      orphanCount += 1;
+    }
+  }
+
+  return { annotations: filtered, orphanCount };
+}

--- a/src/lib/exit/moderationMetadata.ts
+++ b/src/lib/exit/moderationMetadata.ts
@@ -78,19 +78,28 @@ export function parseWithheld(raw: unknown): WithheldResult {
   return { kind: "unavailable" };
 }
 
+// Annotations arrive canonicalised to lower case, but the archive must key them
+// by the event ID exactly as it appears in `events.json`, so the manifest always
+// cross-references the signed events byte for byte.
 export function dropOrphanAnnotations(
   annotations: Map<string, AnnotationStatus>,
   eventIds: ReadonlySet<string>
 ): FilteredAnnotations {
+  const canonicalById = new Map<string, string>();
+  for (const eventId of eventIds) {
+    canonicalById.set(eventId.toLowerCase(), eventId);
+  }
+
   const filtered = new Map<string, AnnotationStatus>();
   let orphanCount = 0;
 
   for (const [eventId, status] of annotations) {
-    if (eventIds.has(eventId)) {
-      filtered.set(eventId, status);
-    } else {
+    const canonical = canonicalById.get(eventId);
+    if (canonical === undefined) {
       orphanCount += 1;
+      continue;
     }
+    filtered.set(canonical, status);
   }
 
   return { annotations: filtered, orphanCount };

--- a/src/lib/exit/moderationMetadata.ts
+++ b/src/lib/exit/moderationMetadata.ts
@@ -47,7 +47,9 @@ export function parseAnnotations(raw: unknown): AnnotationMetadata {
       invalidCount += 1;
       continue;
     }
-    annotations.set(eventId, status);
+    // `isHex64` accepts either case, so canonicalise before the key is compared
+    // against event IDs, the way the media hashes in `archive.ts` are.
+    annotations.set(eventId.toLowerCase(), status);
   }
 
   return { kind: "available", annotations, invalidCount };

--- a/src/lib/exit/moderationMetadata.ts
+++ b/src/lib/exit/moderationMetadata.ts
@@ -12,7 +12,6 @@ export type AnnotationMetadata =
   | {
       kind: "available";
       annotations: Map<string, AnnotationStatus>;
-      complete: boolean;
       invalidCount: number;
     };
 
@@ -31,7 +30,7 @@ export function parseAnnotations(raw: unknown): AnnotationMetadata {
     return { kind: "unsupported" };
   }
   if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
-    return { kind: "available", annotations: new Map(), complete: false, invalidCount: 1 };
+    return { kind: "available", annotations: new Map(), invalidCount: 1 };
   }
 
   const annotations = new Map<string, AnnotationStatus>();
@@ -51,7 +50,7 @@ export function parseAnnotations(raw: unknown): AnnotationMetadata {
     annotations.set(eventId, status);
   }
 
-  return { kind: "available", annotations, complete: invalidCount === 0, invalidCount };
+  return { kind: "available", annotations, invalidCount };
 }
 
 export function parseWithheld(raw: unknown): WithheldResult {

--- a/src/lib/exit/moderationMetadata.ts
+++ b/src/lib/exit/moderationMetadata.ts
@@ -7,6 +7,15 @@ export interface ModerationAnnotation {
   status: AnnotationStatus;
 }
 
+export interface ExportModeration {
+  annotations: ModerationAnnotation[];
+  annotationsStatus: "complete" | "incomplete" | "unsupported";
+  invalidAnnotationCount: number;
+  orphanAnnotationCount: number;
+  conflictingAnnotationCount: number;
+  withheld: WithheldResult;
+}
+
 export type AnnotationMetadata =
   | { kind: "unsupported" }
   | {

--- a/src/lib/exit/ownerExportClient.test.ts
+++ b/src/lib/exit/ownerExportClient.test.ts
@@ -456,6 +456,24 @@ describe("exportOwnerEvents", () => {
     expect(result.moderation.withheld).toEqual({ kind: "known", count: 2 });
   });
 
+  it("matches an upper-case annotation key to the event it belongs to", async () => {
+    const eventId = "ab".repeat(32);
+    const result = await exportOwnerEvents({
+      endpointBase: "https://api.divine.video",
+      pubkey: fixturePubkey,
+      signer: new FixtureSigner(),
+      fetcher: async () => new Response(JSON.stringify({
+        data: [makeFixtureEvent({ id: eventId })],
+        moderation_annotations: { [eventId.toUpperCase()]: { status: "banned" } },
+        pagination: { next_cursor: null, has_more: false },
+        withheld: { complete: true, count: 0 }
+      }), { status: 200 })
+    });
+
+    expect(result.moderation.annotations).toEqual([{ eventId, status: "banned" }]);
+    expect(result.moderation).toMatchObject({ annotationsStatus: "complete", orphanAnnotationCount: 0 });
+  });
+
   it("keeps valid annotations while qualifying malformed, orphan, and conflicting entries", async () => {
     let requests = 0;
     const result = await exportOwnerEvents({

--- a/src/lib/exit/ownerExportClient.test.ts
+++ b/src/lib/exit/ownerExportClient.test.ts
@@ -364,6 +364,7 @@ describe("exportOwnerEvents", () => {
     expect(result.events).toHaveLength(1);
     expect(result.pageCount).toBe(1);
     expect(result.failures.map((failure) => failure.code)).toEqual(["server-failure"]);
+    expect(result.moderation.withheld).toEqual({ kind: "unavailable" });
   });
 
   it("still rejects when the export fails before anything was collected", async () => {
@@ -399,6 +400,7 @@ describe("exportOwnerEvents", () => {
     expect(requests).toBe(2);
     expect(result.events).toHaveLength(2);
     expect(result.failures.map((failure) => failure.code)).toEqual(["stalled-cursor"]);
+    expect(result.moderation.withheld).toEqual({ kind: "unavailable" });
   });
 
   it("stops at the page ceiling and reports the archive as incomplete", async () => {
@@ -425,6 +427,66 @@ describe("exportOwnerEvents", () => {
     expect(result.pageCount).toBe(2);
     expect(result.events).toHaveLength(2);
     expect(result.failures.map((failure) => failure.code)).toEqual(["page-limit"]);
+    expect(result.moderation.withheld).toEqual({ kind: "unavailable" });
+  });
+
+  it("accumulates annotations and retains only the terminal withheld acknowledgement", async () => {
+    let requests = 0;
+    const result = await exportOwnerEvents({
+      endpointBase: "https://api.divine.video",
+      pubkey: fixturePubkey,
+      signer: new FixtureSigner(),
+      fetcher: async () => {
+        requests += 1;
+        const event = makeFixtureEvent({ id: requests === 1 ? "1".repeat(64) : "2".repeat(64) });
+        return new Response(JSON.stringify({
+          data: [event],
+          moderation_annotations: { [event.id]: { status: requests === 1 ? "banned" : "quarantined" } },
+          pagination: { next_cursor: requests === 1 ? "next" : null, has_more: requests === 1 },
+          withheld: requests === 1 ? { complete: true, count: 99 } : { complete: true, count: 2 }
+        }), { status: 200 });
+      }
+    });
+
+    expect(result.moderation.annotations).toEqual([
+      { eventId: "1".repeat(64), status: "banned" },
+      { eventId: "2".repeat(64), status: "quarantined" }
+    ]);
+    expect(result.moderation.annotationsStatus).toBe("complete");
+    expect(result.moderation.withheld).toEqual({ kind: "known", count: 2 });
+  });
+
+  it("keeps valid annotations while qualifying malformed, orphan, and conflicting entries", async () => {
+    let requests = 0;
+    const result = await exportOwnerEvents({
+      endpointBase: "https://api.divine.video",
+      pubkey: fixturePubkey,
+      signer: new FixtureSigner(),
+      fetcher: async () => {
+        requests += 1;
+        return new Response(JSON.stringify({
+          data: requests === 1 ? [makeFixtureEvent()] : [],
+          moderation_annotations: requests === 1
+            ? {
+                [makeFixtureEvent().id]: { status: "banned" },
+                ["f".repeat(64)]: { status: "quarantined" },
+                short: { status: "banned" }
+              }
+            : { [makeFixtureEvent().id]: { status: "quarantined" } },
+          pagination: { next_cursor: requests === 1 ? "next" : null, has_more: requests === 1 },
+          ...(requests === 2 ? { withheld: { complete: true, count: 0 } } : {})
+        }), { status: 200 });
+      }
+    });
+
+    expect(result.moderation.annotations).toEqual([{ eventId: makeFixtureEvent().id, status: "banned" }]);
+    expect(result.moderation).toMatchObject({
+      annotationsStatus: "incomplete",
+      invalidAnnotationCount: 1,
+      orphanAnnotationCount: 1,
+      conflictingAnnotationCount: 1,
+      withheld: { kind: "known", count: 0 }
+    });
   });
 
   it("rejects invalid pubkeys before making a request", async () => {

--- a/src/lib/exit/ownerExportClient.test.ts
+++ b/src/lib/exit/ownerExportClient.test.ts
@@ -526,6 +526,30 @@ describe("exportOwnerEvents", () => {
     });
   });
 
+  it("qualifies conflicting same-page annotation keys that differ only by case", async () => {
+    const eventId = "ab".repeat(32);
+    const result = await exportOwnerEvents({
+      endpointBase: "https://api.divine.video",
+      pubkey: fixturePubkey,
+      signer: new FixtureSigner(),
+      fetcher: async () => new Response(JSON.stringify({
+        data: [makeFixtureEvent({ id: eventId })],
+        moderation_annotations: {
+          [eventId]: { status: "banned" },
+          [eventId.toUpperCase()]: { status: "quarantined" }
+        },
+        pagination: { next_cursor: null, has_more: false },
+        withheld: { complete: true, count: 0 }
+      }), { status: 200 })
+    });
+
+    expect(result.moderation.annotations).toEqual([{ eventId, status: "banned" }]);
+    expect(result.moderation).toMatchObject({
+      annotationsStatus: "incomplete",
+      conflictingAnnotationCount: 1
+    });
+  });
+
   it("rejects invalid pubkeys before making a request", async () => {
     await expect(
       exportOwnerEvents({

--- a/src/lib/exit/ownerExportClient.test.ts
+++ b/src/lib/exit/ownerExportClient.test.ts
@@ -474,6 +474,25 @@ describe("exportOwnerEvents", () => {
     expect(result.moderation).toMatchObject({ annotationsStatus: "complete", orphanAnnotationCount: 0 });
   });
 
+  it("keys annotations by the event ID exactly as the archive stores it", async () => {
+    const eventId = "AB".repeat(32);
+    const result = await exportOwnerEvents({
+      endpointBase: "https://api.divine.video",
+      pubkey: fixturePubkey,
+      signer: new FixtureSigner(),
+      fetcher: async () => new Response(JSON.stringify({
+        data: [makeFixtureEvent({ id: eventId })],
+        moderation_annotations: { [eventId]: { status: "quarantined" } },
+        pagination: { next_cursor: null, has_more: false },
+        withheld: { complete: true, count: 0 }
+      }), { status: 200 })
+    });
+
+    expect(result.events[0].id).toBe(eventId);
+    expect(result.moderation.annotations).toEqual([{ eventId, status: "quarantined" }]);
+    expect(result.moderation).toMatchObject({ annotationsStatus: "complete", orphanAnnotationCount: 0 });
+  });
+
   it("keeps valid annotations while qualifying malformed, orphan, and conflicting entries", async () => {
     let requests = 0;
     const result = await exportOwnerEvents({

--- a/src/lib/exit/ownerExportClient.ts
+++ b/src/lib/exit/ownerExportClient.ts
@@ -6,23 +6,10 @@ import type { NostrSigner } from "@nostrify/nostrify";
 import { walkExportCursor, type CursorWalkProgress } from "./cursorWalk";
 import { exportRetryDelayMs, readExportErrorBody, signedExportGet, validateExportPage, type ExportPage } from "./exportTransport";
 import { isHex64 } from "./hex";
-import {
-  dropOrphanAnnotations,
-  parseAnnotations,
-  parseWithheld,
-  type AnnotationMetadata,
-  type AnnotationStatus,
-  type ModerationAnnotation,
-  type WithheldResult
-} from "./moderationMetadata";
+import type { AnnotationStatus, ExportModeration } from "./moderationMetadata";
 
 export type { ExportPage } from "./exportTransport";
 export type ExportProgress = CursorWalkProgress;
-
-interface OwnerExportPage extends ExportPage {
-  moderationAnnotations: AnnotationMetadata;
-  withheld: WithheldResult;
-}
 
 export type ExportFailureCode = "invalid-pubkey" | "bad-cursor" | "expired-cursor" | "auth-required" | "pubkey-mismatch" | "rate-limited" | "server-failure" | "malformed-response" | "network-failure" | "cancelled" | "stalled-cursor" | "page-limit";
 
@@ -43,14 +30,7 @@ export class OwnerExportError extends Error {
   }
 }
 
-export interface OwnerExportModeration {
-  annotations: ModerationAnnotation[];
-  annotationsStatus: "complete" | "incomplete" | "unsupported";
-  invalidAnnotationCount: number;
-  orphanAnnotationCount: number;
-  conflictingAnnotationCount: number;
-  withheld: WithheldResult;
-}
+export type OwnerExportModeration = ExportModeration;
 
 export interface OwnerExportResult {
   events: ExportPage["data"];
@@ -99,7 +79,7 @@ function malformedMessage(detail: string) {
   return "Divine returned a response this tool could not read.";
 }
 
-async function fetchOwnerPage(input: { url: string; pubkey: string; signer: NostrSigner; fetcher: typeof fetch; signal?: AbortSignal; retryCount: number }): Promise<OwnerExportPage> {
+async function fetchOwnerPage(input: { url: string; pubkey: string; signer: NostrSigner; fetcher: typeof fetch; signal?: AbortSignal; retryCount: number }): Promise<ExportPage> {
   const response = await signedExportGet({
     ...input,
     authFailure: () => new OwnerExportError("auth-required", "This export could not be signed. If your account is restricted, appeal first. Otherwise sign in again, then restart the export."),
@@ -112,14 +92,7 @@ async function fetchOwnerPage(input: { url: string; pubkey: string; signer: Nost
   if (response.status === 429) throw new OwnerExportError("rate-limited", "Divine asked this export to slow down. Wait a moment and try again.", 429, exportRetryDelayMs(response, input.retryCount));
   if (!response.ok) throw new OwnerExportError("server-failure", "Divine could not finish this export right now. Try again later.", response.status);
   try {
-    const raw = await response.json();
-    const page = validateExportPage(raw, input.pubkey, (detail) => new OwnerExportError("malformed-response", malformedMessage(detail)));
-    const metadata = raw as { moderation_annotations?: unknown; withheld?: unknown };
-    return {
-      ...page,
-      moderationAnnotations: parseAnnotations(metadata.moderation_annotations),
-      withheld: parseWithheld(metadata.withheld),
-    };
+    return validateExportPage(await response.json(), input.pubkey, (detail) => new OwnerExportError("malformed-response", malformedMessage(detail)));
   } catch (error) {
     if (error instanceof OwnerExportError) throw error;
     throw new OwnerExportError("malformed-response", malformedMessage("response"));
@@ -129,57 +102,12 @@ async function fetchOwnerPage(input: { url: string; pubkey: string; signer: Nost
 export async function exportOwnerEvents(options: OwnerExportClientOptions): Promise<OwnerExportResult> {
   const { endpointBase, pubkey, signer, fetcher = fetch, limit = 500, signal } = options;
   if (!isHex64(pubkey)) throw new OwnerExportError("invalid-pubkey", "The account identifier is not valid.", 400);
-  const annotations = new Map<string, AnnotationStatus>();
-  let annotationPagesAvailable = 0;
-  let annotationPagesUnsupported = 0;
-  let invalidAnnotationCount = 0;
-  let conflictingAnnotationCount = 0;
-  let lastWithheld: WithheldResult = { kind: "unsupported" };
-
-  const result = await walkExportCursor({
-    fetchPage: async (cursor, retryCount) => {
-      const page = await fetchOwnerPage({ url: buildUrl(endpointBase, pubkey, limit, cursor), pubkey, signer, fetcher, signal, retryCount });
-      lastWithheld = page.withheld;
-      if (page.moderationAnnotations.kind === "unsupported") {
-        annotationPagesUnsupported += 1;
-      } else {
-        annotationPagesAvailable += 1;
-        invalidAnnotationCount += page.moderationAnnotations.invalidCount;
-        conflictingAnnotationCount += page.moderationAnnotations.conflictingCount;
-        for (const [eventId, status] of page.moderationAnnotations.annotations) {
-          const previous = annotations.get(eventId);
-          if (previous && previous !== status) {
-            conflictingAnnotationCount += 1;
-            continue;
-          }
-          annotations.set(eventId, status);
-        }
-      }
-      return page;
-    },
+  return walkExportCursor({
+    fetchPage: (cursor, retryCount) => fetchOwnerPage({ url: buildUrl(endpointBase, pubkey, limit, cursor), pubkey, signer, fetcher, signal, retryCount }),
     isFailure: (error): error is OwnerExportError => error instanceof OwnerExportError,
     makeFailure: ownerFailure,
     makeCancelledFailure: () => new OwnerExportError("cancelled", "The export was cancelled."),
     cancelledCode: "cancelled", rateLimitedCode: "rate-limited", sleep: options.sleep, signal,
     maxRateLimitRetries: options.maxRateLimitRetries, maxPages: options.maxPages, onProgress: options.onProgress,
   });
-
-  const filtered = dropOrphanAnnotations(annotations, new Set(result.events.map((event) => event.id)));
-  const annotationsStatus = annotationPagesAvailable === 0
-    ? "unsupported"
-    : annotationPagesUnsupported > 0 || invalidAnnotationCount > 0 || filtered.orphanCount > 0 || conflictingAnnotationCount > 0
-      ? "incomplete"
-      : "complete";
-
-  return {
-    ...result,
-    moderation: {
-      annotations: Array.from(filtered.annotations, ([eventId, status]) => ({ eventId, status })),
-      annotationsStatus,
-      invalidAnnotationCount,
-      orphanAnnotationCount: filtered.orphanCount,
-      conflictingAnnotationCount,
-      withheld: result.failures.length > 0 ? { kind: "unavailable" } : lastWithheld,
-    },
-  };
 }

--- a/src/lib/exit/ownerExportClient.ts
+++ b/src/lib/exit/ownerExportClient.ts
@@ -154,7 +154,7 @@ export async function exportOwnerEvents(options: OwnerExportClientOptions): Prom
     maxRateLimitRetries: options.maxRateLimitRetries, maxPages: options.maxPages, onProgress: options.onProgress,
   });
 
-  const filtered = dropOrphanAnnotations(annotations, new Set(result.events.map((event) => event.id)));
+  const filtered = dropOrphanAnnotations(annotations, new Set(result.events.map((event) => event.id.toLowerCase())));
   const annotationsStatus = annotationPagesAvailable === 0
     ? "unsupported"
     : annotationPagesUnsupported > 0 || invalidAnnotationCount > 0 || filtered.orphanCount > 0 || conflictingAnnotationCount > 0

--- a/src/lib/exit/ownerExportClient.ts
+++ b/src/lib/exit/ownerExportClient.ts
@@ -145,6 +145,7 @@ export async function exportOwnerEvents(options: OwnerExportClientOptions): Prom
       } else {
         annotationPagesAvailable += 1;
         invalidAnnotationCount += page.moderationAnnotations.invalidCount;
+        conflictingAnnotationCount += page.moderationAnnotations.conflictingCount;
         for (const [eventId, status] of page.moderationAnnotations.annotations) {
           const previous = annotations.get(eventId);
           if (previous && previous !== status) {

--- a/src/lib/exit/ownerExportClient.ts
+++ b/src/lib/exit/ownerExportClient.ts
@@ -26,6 +26,16 @@ interface OwnerExportPage extends ExportPage {
 
 export type ExportFailureCode = "invalid-pubkey" | "bad-cursor" | "expired-cursor" | "auth-required" | "pubkey-mismatch" | "rate-limited" | "server-failure" | "malformed-response" | "network-failure" | "cancelled" | "stalled-cursor" | "page-limit";
 
+export interface OwnerExportPageResponse {
+  data: ExportPage["data"];
+  moderation_annotations?: Record<string, { status: AnnotationStatus }>;
+  withheld?: { complete: false } | { complete: true; count: number };
+  pagination: {
+    next_cursor: string | null;
+    has_more: boolean;
+  };
+}
+
 export class OwnerExportError extends Error {
   constructor(public readonly code: ExportFailureCode, message: string, public readonly status?: number, public readonly retryAfterMs?: number) {
     super(message);
@@ -33,18 +43,20 @@ export class OwnerExportError extends Error {
   }
 }
 
+export interface OwnerExportModeration {
+  annotations: ModerationAnnotation[];
+  annotationsStatus: "complete" | "incomplete" | "unsupported";
+  invalidAnnotationCount: number;
+  orphanAnnotationCount: number;
+  conflictingAnnotationCount: number;
+  withheld: WithheldResult;
+}
+
 export interface OwnerExportResult {
   events: ExportPage["data"];
   pageCount: number;
   failures: OwnerExportError[];
-  moderation: {
-    annotations: ModerationAnnotation[];
-    annotationsStatus: "complete" | "incomplete" | "unsupported";
-    invalidAnnotationCount: number;
-    orphanAnnotationCount: number;
-    conflictingAnnotationCount: number;
-    withheld: WithheldResult;
-  };
+  moderation: OwnerExportModeration;
 }
 
 export interface OwnerExportClientOptions {
@@ -133,9 +145,6 @@ export async function exportOwnerEvents(options: OwnerExportClientOptions): Prom
       } else {
         annotationPagesAvailable += 1;
         invalidAnnotationCount += page.moderationAnnotations.invalidCount;
-        conflictingAnnotationCount += "conflictingCount" in page.moderationAnnotations
-          ? page.moderationAnnotations.conflictingCount
-          : 0;
         for (const [eventId, status] of page.moderationAnnotations.annotations) {
           const previous = annotations.get(eventId);
           if (previous && previous !== status) {

--- a/src/lib/exit/ownerExportClient.ts
+++ b/src/lib/exit/ownerExportClient.ts
@@ -6,9 +6,23 @@ import type { NostrSigner } from "@nostrify/nostrify";
 import { walkExportCursor, type CursorWalkProgress } from "./cursorWalk";
 import { exportRetryDelayMs, readExportErrorBody, signedExportGet, validateExportPage, type ExportPage } from "./exportTransport";
 import { isHex64 } from "./hex";
+import {
+  dropOrphanAnnotations,
+  parseAnnotations,
+  parseWithheld,
+  type AnnotationMetadata,
+  type AnnotationStatus,
+  type ModerationAnnotation,
+  type WithheldResult
+} from "./moderationMetadata";
 
 export type { ExportPage } from "./exportTransport";
 export type ExportProgress = CursorWalkProgress;
+
+interface OwnerExportPage extends ExportPage {
+  moderationAnnotations: AnnotationMetadata;
+  withheld: WithheldResult;
+}
 
 export type ExportFailureCode = "invalid-pubkey" | "bad-cursor" | "expired-cursor" | "auth-required" | "pubkey-mismatch" | "rate-limited" | "server-failure" | "malformed-response" | "network-failure" | "cancelled" | "stalled-cursor" | "page-limit";
 
@@ -19,7 +33,19 @@ export class OwnerExportError extends Error {
   }
 }
 
-export interface OwnerExportResult { events: ExportPage["data"]; pageCount: number; failures: OwnerExportError[] }
+export interface OwnerExportResult {
+  events: ExportPage["data"];
+  pageCount: number;
+  failures: OwnerExportError[];
+  moderation: {
+    annotations: ModerationAnnotation[];
+    annotationsStatus: "complete" | "incomplete" | "unsupported";
+    invalidAnnotationCount: number;
+    orphanAnnotationCount: number;
+    conflictingAnnotationCount: number;
+    withheld: WithheldResult;
+  };
+}
 
 export interface OwnerExportClientOptions {
   endpointBase: string; pubkey: string; signer: NostrSigner; limit?: number; fetcher?: typeof fetch;
@@ -61,7 +87,7 @@ function malformedMessage(detail: string) {
   return "Divine returned a response this tool could not read.";
 }
 
-async function fetchOwnerPage(input: { url: string; pubkey: string; signer: NostrSigner; fetcher: typeof fetch; signal?: AbortSignal; retryCount: number }) {
+async function fetchOwnerPage(input: { url: string; pubkey: string; signer: NostrSigner; fetcher: typeof fetch; signal?: AbortSignal; retryCount: number }): Promise<OwnerExportPage> {
   const response = await signedExportGet({
     ...input,
     authFailure: () => new OwnerExportError("auth-required", "This export could not be signed. If your account is restricted, appeal first. Otherwise sign in again, then restart the export."),
@@ -74,7 +100,14 @@ async function fetchOwnerPage(input: { url: string; pubkey: string; signer: Nost
   if (response.status === 429) throw new OwnerExportError("rate-limited", "Divine asked this export to slow down. Wait a moment and try again.", 429, exportRetryDelayMs(response, input.retryCount));
   if (!response.ok) throw new OwnerExportError("server-failure", "Divine could not finish this export right now. Try again later.", response.status);
   try {
-    return validateExportPage(await response.json(), input.pubkey, (detail) => new OwnerExportError("malformed-response", malformedMessage(detail)));
+    const raw = await response.json();
+    const page = validateExportPage(raw, input.pubkey, (detail) => new OwnerExportError("malformed-response", malformedMessage(detail)));
+    const metadata = raw as { moderation_annotations?: unknown; withheld?: unknown };
+    return {
+      ...page,
+      moderationAnnotations: parseAnnotations(metadata.moderation_annotations),
+      withheld: parseWithheld(metadata.withheld),
+    };
   } catch (error) {
     if (error instanceof OwnerExportError) throw error;
     throw new OwnerExportError("malformed-response", malformedMessage("response"));
@@ -84,12 +117,59 @@ async function fetchOwnerPage(input: { url: string; pubkey: string; signer: Nost
 export async function exportOwnerEvents(options: OwnerExportClientOptions): Promise<OwnerExportResult> {
   const { endpointBase, pubkey, signer, fetcher = fetch, limit = 500, signal } = options;
   if (!isHex64(pubkey)) throw new OwnerExportError("invalid-pubkey", "The account identifier is not valid.", 400);
-  return walkExportCursor({
-    fetchPage: (cursor, retryCount) => fetchOwnerPage({ url: buildUrl(endpointBase, pubkey, limit, cursor), pubkey, signer, fetcher, signal, retryCount }),
+  const annotations = new Map<string, AnnotationStatus>();
+  let annotationPagesAvailable = 0;
+  let annotationPagesUnsupported = 0;
+  let invalidAnnotationCount = 0;
+  let conflictingAnnotationCount = 0;
+  let lastWithheld: WithheldResult = { kind: "unsupported" };
+
+  const result = await walkExportCursor({
+    fetchPage: async (cursor, retryCount) => {
+      const page = await fetchOwnerPage({ url: buildUrl(endpointBase, pubkey, limit, cursor), pubkey, signer, fetcher, signal, retryCount });
+      lastWithheld = page.withheld;
+      if (page.moderationAnnotations.kind === "unsupported") {
+        annotationPagesUnsupported += 1;
+      } else {
+        annotationPagesAvailable += 1;
+        invalidAnnotationCount += page.moderationAnnotations.invalidCount;
+        conflictingAnnotationCount += "conflictingCount" in page.moderationAnnotations
+          ? page.moderationAnnotations.conflictingCount
+          : 0;
+        for (const [eventId, status] of page.moderationAnnotations.annotations) {
+          const previous = annotations.get(eventId);
+          if (previous && previous !== status) {
+            conflictingAnnotationCount += 1;
+            continue;
+          }
+          annotations.set(eventId, status);
+        }
+      }
+      return page;
+    },
     isFailure: (error): error is OwnerExportError => error instanceof OwnerExportError,
     makeFailure: ownerFailure,
     makeCancelledFailure: () => new OwnerExportError("cancelled", "The export was cancelled."),
     cancelledCode: "cancelled", rateLimitedCode: "rate-limited", sleep: options.sleep, signal,
     maxRateLimitRetries: options.maxRateLimitRetries, maxPages: options.maxPages, onProgress: options.onProgress,
   });
+
+  const filtered = dropOrphanAnnotations(annotations, new Set(result.events.map((event) => event.id)));
+  const annotationsStatus = annotationPagesAvailable === 0
+    ? "unsupported"
+    : annotationPagesUnsupported > 0 || invalidAnnotationCount > 0 || filtered.orphanCount > 0 || conflictingAnnotationCount > 0
+      ? "incomplete"
+      : "complete";
+
+  return {
+    ...result,
+    moderation: {
+      annotations: Array.from(filtered.annotations, ([eventId, status]) => ({ eventId, status })),
+      annotationsStatus,
+      invalidAnnotationCount,
+      orphanAnnotationCount: filtered.orphanCount,
+      conflictingAnnotationCount,
+      withheld: result.failures.length > 0 ? { kind: "unavailable" } : lastWithheld,
+    },
+  };
 }

--- a/src/lib/exit/ownerExportClient.ts
+++ b/src/lib/exit/ownerExportClient.ts
@@ -163,7 +163,7 @@ export async function exportOwnerEvents(options: OwnerExportClientOptions): Prom
     maxRateLimitRetries: options.maxRateLimitRetries, maxPages: options.maxPages, onProgress: options.onProgress,
   });
 
-  const filtered = dropOrphanAnnotations(annotations, new Set(result.events.map((event) => event.id.toLowerCase())));
+  const filtered = dropOrphanAnnotations(annotations, new Set(result.events.map((event) => event.id)));
   const annotationsStatus = annotationPagesAvailable === 0
     ? "unsupported"
     : annotationPagesUnsupported > 0 || invalidAnnotationCount > 0 || filtered.orphanCount > 0 || conflictingAnnotationCount > 0

--- a/src/pages/ExitStartPage.test.tsx
+++ b/src/pages/ExitStartPage.test.tsx
@@ -192,8 +192,20 @@ describe("ExitStartPage", () => {
     await userEvent.click(screen.getByRole("button", { name: /Create my archive/ }));
 
     await waitFor(() => expect(screen.getByText("This Divine API version didn't provide withheld-event details.")).toBeInTheDocument());
+    expect(screen.getByText("Your archive is ready.")).toBeInTheDocument();
     expect(screen.getByText("This Divine API version didn't provide event moderation annotations.")).toBeInTheDocument();
     expect(screen.queryByText(/withheld no events/)).not.toBeInTheDocument();
+  });
+
+  it("preserves the empty archive heading when moderation metadata is unsupported", async () => {
+    mockUseCurrentUser.mockReturnValue(signedIn());
+    vi.stubGlobal("fetch", createFixtureFetch("empty"));
+
+    render(<TestApp><ExitStartPage /></TestApp>);
+    await userEvent.click(screen.getByRole("button", { name: /Create my archive/ }));
+
+    await waitFor(() => expect(screen.getByText("Your archive is ready, and it is empty.")).toBeInTheDocument());
+    expect(screen.queryByText("Your archive is ready, with moderation details unavailable.")).not.toBeInTheDocument();
   });
 
   it("reports banned and quarantined returned events separately", async () => {

--- a/src/pages/ExitStartPage.test.tsx
+++ b/src/pages/ExitStartPage.test.tsx
@@ -151,6 +151,8 @@ describe("ExitStartPage", () => {
       }), { status: 200, headers: { "content-type": "application/json" } }))
       .mockResolvedValueOnce(new Response(JSON.stringify({
         data: [makeFixtureEvent()],
+        moderation_annotations: { [makeFixtureEvent().id]: { status: "banned" } },
+        withheld: { complete: true, count: 1 },
         pagination: { next_cursor: null, has_more: false },
       }), { status: 200, headers: { "content-type": "application/json" } }));
     vi.stubGlobal("fetch", fetcher);
@@ -159,8 +161,10 @@ describe("ExitStartPage", () => {
     await userEvent.click(screen.getByRole("button", { name: "Check for a snapshot" }));
     await userEvent.click(await screen.findByRole("button", { name: "Recover snapshot" }));
 
-    await waitFor(() => expect(screen.getByText("Your archive is ready.")).toBeInTheDocument());
+    await waitFor(() => expect(screen.getByText("Your archive is ready, with some events withheld.")).toBeInTheDocument());
     expect(screen.getByText(/1 page read, 1 event and 1 media reference collected from Divine/)).toBeInTheDocument();
+    expect(screen.getByText(/1 event in this archive is banned on Divine/)).toBeInTheDocument();
+    expect(screen.getByText(/Divine withheld 1 event under its content rules/)).toBeInTheDocument();
     expect(screen.getByRole("heading", { name: "Move your media" })).toBeInTheDocument();
     expect(String(fetcher.mock.calls[1][0])).toContain("/export/snapshot?enforcement_id=");
   });

--- a/src/pages/ExitStartPage.test.tsx
+++ b/src/pages/ExitStartPage.test.tsx
@@ -165,6 +165,56 @@ describe("ExitStartPage", () => {
     expect(String(fetcher.mock.calls[1][0])).toContain("/export/snapshot?enforcement_id=");
   });
 
+  it.each([
+    [{ complete: true, count: 2 }, "Divine withheld 2 events under its content rules. They aren't in this archive."],
+    [{ complete: true, count: 0 }, "Divine confirmed that it withheld no events from this archive."],
+    [{ complete: false }, "Divine couldn't confirm whether any events were withheld."]
+  ])("renders a distinct withheld result for %#", async (withheld, message) => {
+    mockUseCurrentUser.mockReturnValue(signedIn());
+    vi.stubGlobal("fetch", async () => new Response(JSON.stringify({
+      data: [makeFixtureEvent()],
+      moderation_annotations: {},
+      pagination: { next_cursor: null, has_more: false },
+      withheld
+    }), { status: 200 }));
+
+    render(<TestApp><ExitStartPage /></TestApp>);
+    await userEvent.click(screen.getByRole("button", { name: /Create my archive/ }));
+
+    await waitFor(() => expect(screen.getByText(message)).toBeInTheDocument());
+  });
+
+  it("reports unsupported moderation metadata instead of implying a verified zero", async () => {
+    mockUseCurrentUser.mockReturnValue(signedIn());
+    vi.stubGlobal("fetch", createFixtureFetch("one-page"));
+
+    render(<TestApp><ExitStartPage /></TestApp>);
+    await userEvent.click(screen.getByRole("button", { name: /Create my archive/ }));
+
+    await waitFor(() => expect(screen.getByText("This Divine API version didn't provide withheld-event details.")).toBeInTheDocument());
+    expect(screen.getByText("This Divine API version didn't provide event moderation annotations.")).toBeInTheDocument();
+    expect(screen.queryByText(/withheld no events/)).not.toBeInTheDocument();
+  });
+
+  it("reports banned and quarantined returned events separately", async () => {
+    mockUseCurrentUser.mockReturnValue(signedIn());
+    vi.stubGlobal("fetch", async () => new Response(JSON.stringify({
+      data: [makeFixtureEvent(), makeFixtureEvent({ id: "2".repeat(64) })],
+      moderation_annotations: {
+        [makeFixtureEvent().id]: { status: "banned" },
+        ["2".repeat(64)]: { status: "quarantined" }
+      },
+      pagination: { next_cursor: null, has_more: false },
+      withheld: { complete: true, count: 0 }
+    }), { status: 200 }));
+
+    render(<TestApp><ExitStartPage /></TestApp>);
+    await userEvent.click(screen.getByRole("button", { name: /Create my archive/ }));
+
+    await waitFor(() => expect(screen.getByText(/1 event in this archive is banned on Divine/)).toBeInTheDocument());
+    expect(screen.getByText(/1 event in this archive is quarantined on Divine/)).toBeInTheDocument();
+  });
+
   it("validates a custom Blossom destination inline", async () => {
     mockUseCurrentUser.mockReturnValue(signedIn());
     vi.stubGlobal("fetch", createFixtureFetch("one-page"));

--- a/src/pages/ExitStartPage.tsx
+++ b/src/pages/ExitStartPage.tsx
@@ -5,7 +5,6 @@ import {
   Archive,
   ArrowClockwise,
   Broadcast,
-  CheckCircle,
   Copy,
   DownloadSimple,
   Key,
@@ -19,6 +18,7 @@ import { Link } from "react-router-dom";
 
 import { AccountKeySection } from "@/components/exit/AccountKeySection";
 import { DestinationForm } from "@/components/exit/DestinationForm";
+import { ExportSummaryCard } from "@/components/exit/ExportSummaryCard";
 import { DiscoveryPointerForm } from "@/components/exit/DiscoveryPointerForm";
 import { KeySafetyNotice } from "@/components/exit/KeySafetyNotice";
 import { MediaProgressList } from "@/components/exit/MediaProgressList";
@@ -133,10 +133,8 @@ export function ExitStartPage() {
     }
 
     return {
-      events: archiveFiles["manifest.json"].event_count,
-      pages: archiveFiles["manifest.json"].page_count,
       media: archiveFiles["media.json"].length,
-      failures: archiveFiles["manifest.json"].failures,
+      manifest: archiveFiles["manifest.json"],
     };
   }, [archiveFiles]);
   const oldestVideoCreatedAt = useMemo(
@@ -180,6 +178,7 @@ export function ExitStartPage() {
           sourceEndpoint: exportEndpoint,
           pageCount: result.pageCount,
           failures: result.failures,
+          moderation: result.moderation,
         })
       );
       setState("complete");
@@ -416,51 +415,7 @@ export function ExitStartPage() {
               )}
 
               {state === "complete" && summary && (
-                <Card variant="brand" accent={summary.failures.length > 0 ? "yellow" : "green"}>
-                  <CardContent className="pt-6 flex items-start gap-3">
-                    {summary.failures.length > 0 ? (
-                      <WarningCircle
-                        weight="fill"
-                        className="mt-1 h-5 w-5 flex-shrink-0 text-brand-dark-green dark:text-brand-green"
-                      />
-                    ) : (
-                      <CheckCircle
-                        weight="fill"
-                        className="mt-1 h-5 w-5 flex-shrink-0 text-brand-dark-green dark:text-brand-green"
-                      />
-                    )}
-                    <div className="space-y-2">
-                      <p className="font-semibold text-foreground">
-                        {summary.failures.length > 0
-                          ? "This archive is incomplete."
-                          : summary.events === 0
-                            ? "Your archive is ready, and it is empty."
-                            : "Your archive is ready."}
-                      </p>
-                      <p className="text-base leading-relaxed text-muted-foreground">
-                        {summary.pages} page{summary.pages === 1 ? "" : "s"} read,{" "}
-                        {summary.events} event{summary.events === 1 ? "" : "s"} and{" "}
-                        {summary.media} media reference{summary.media === 1 ? "" : "s"}{" "}
-                        collected from Divine. Other relays were not checked, so anything
-                        you posted elsewhere is not in this file.
-                      </p>
-                      {summary.failures.map((failure) => (
-                        <p
-                          key={`${failure.code}-${failure.message}`}
-                          className="text-base leading-relaxed text-muted-foreground"
-                        >
-                          {failure.message}
-                        </p>
-                      ))}
-                      {summary.failures.length > 0 && (
-                        <p className="text-base leading-relaxed text-muted-foreground">
-                          You can download what was collected and run the export again;
-                          starting over is safe and does not duplicate anything.
-                        </p>
-                      )}
-                    </div>
-                  </CardContent>
-                </Card>
+                <ExportSummaryCard manifest={summary.manifest} mediaCount={summary.media} />
               )}
 
               {state === "failed" && failure && (

--- a/src/pages/ExitStartPage.tsx
+++ b/src/pages/ExitStartPage.tsx
@@ -226,6 +226,7 @@ export function ExitStartPage() {
         sourceName: "Divine pre-ban snapshot",
         pageCount: result.pageCount,
         failures: result.failures,
+        moderation: result.moderation,
         snapshot: {
           enforcement_id: status.enforcement_id,
           enforced_at: status.enforced_at,


### PR DESCRIPTION
## Summary

- Explain when returned account-export events are banned or quarantined on Divine.
- Distinguish verified withheld counts, verified zero, unavailable counts, and older API responses without moderation metadata.
- Record moderation qualification in `manifest.json` while preserving every raw signed event in `events.json`.

## Motivation

Owner archives could previously look fully qualified even when moderation policy changed public visibility or withheld events entirely. The export now parses the additive response metadata without letting malformed optional fields discard otherwise valid event pages, and it keeps terminal-only acknowledgements distinct from truncated page walks.

This deliberately does not alter, wrap, re-sign, or gate republishing of signed events. Live backend acceptance remains dependent on the corresponding Funnelcake deployment, so this PR references rather than closes the issue.

## Related Issue

- Refs #619

## Testing

- [x] `npm test`: TypeScript, ESLint with 0 errors and 16 existing warnings, 333 Vitest files and 2,842 tests, and production Vite build
- [x] Focused parser, pagination, archive-integrity, snapshot-recovery, and UI-state tests
- [x] `npm run test:visual`: 29 Chromium visual and WCAG checks, including `/exit/start` in light and dark mode

## Visuals

- [x] UI change verified by the visual and accessibility suite; no account-data screenshot attached
- [x] Visuals and text avoid sensitive external brand or partner names unless explicitly approved
