### PR TITLE
fix(exit): stop claiming failed media archives are complete

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -194,8 +194,12 @@ The `/exit/start` flow reads raw signed events through the owner-export API and
 builds archive metadata in `src/lib/exit/`. Its media option writes a store-only
 Zip64 archive directly to a user-selected file, downloads one unique blob at a
 time, verifies advertised SHA-256 hashes, and records partial failures without
-changing signed events. Viewer authorization is retried only for the exact
-`https://media.divine.video` origin; third-party media requests remain bare.
+changing signed events. Bare media requests follow content-delivery redirects,
+while requests carrying viewer authorization refuse redirects and are retried
+only for the exact `https://media.divine.video` origin; third-party media
+requests remain bare. The completed archive omits an empty checksum file, adds
+a readable failure report for downloads and quarantined hash mismatches, and
+keeps the final on-screen result aligned with the media actually saved.
 
 The same page shows the signed-in account's full npub and separates hosted,
 local-nsec, and external-signer key ownership. Hosted accounts may export their

--- a/src/components/exit/MediaExportSummary.tsx
+++ b/src/components/exit/MediaExportSummary.tsx
@@ -1,0 +1,61 @@
+// ABOUTME: Summarizes the final contents and integrity of a streamed media archive
+// ABOUTME: Keeps failed downloads and quarantined hash mismatches visible after progress ends
+
+import type { MediaExportState } from "@/hooks/useArchiveMediaExport";
+import type { MediaSummary } from "@/lib/exit/archive";
+import type { MediaDownloadResult } from "@/lib/exit/mediaDownloader";
+import { Card, CardContent } from "@/components/ui/card";
+
+interface MediaExportSummaryProps {
+  state: MediaExportState;
+  summary: MediaSummary | null;
+  results: MediaDownloadResult[];
+}
+
+export function MediaExportSummary({ state, summary, results }: MediaExportSummaryProps) {
+  if (!summary || !["complete", "partial", "no-media", "empty"].includes(state)) return null;
+
+  const saved = summary.media_verified + summary.media_unverified;
+  const issues = results.filter((result) => result.verification === "failed" || result.verification === "hash-mismatch");
+  const accent = state === "complete" ? "green" : state === "no-media" ? "pink" : "yellow";
+  const heading = state === "complete"
+    ? `Your media archive is saved — ${saved} of ${summary.media_total} files saved.`
+    : state === "partial"
+      ? `${saved} of ${summary.media_total} files were saved as usable media.`
+      : state === "no-media"
+        ? `No media was saved. The archive has your events, but none of your ${summary.media_total} media files could be downloaded.`
+        : "Your archive has no media files to save.";
+
+  return (
+    <Card variant="brand" accent={accent} role={state === "no-media" ? "alert" : "status"}>
+      <CardContent className="space-y-3 pt-6">
+        <p className="text-base font-semibold text-foreground">{heading}</p>
+        {summary.media_unverified > 0 && (
+          <p className="text-sm text-muted-foreground">
+            {summary.media_unverified} saved without an advertised hash.
+          </p>
+        )}
+        {summary.media_mismatched > 0 && (
+          <p className="text-sm text-muted-foreground">
+            {summary.media_mismatched} saved separately because the advertised hash did not match.
+          </p>
+        )}
+        {issues.length > 0 && (
+          <ul className="space-y-2 text-sm text-muted-foreground">
+            {issues.map((result) => (
+              <li key={`${result.verification}:${result.expected_sha256}:${result.source_url}`} className="break-all">
+                <span className="font-semibold text-foreground">{result.source_url}</span>
+                {result.verification === "failed"
+                  ? ` — ${result.failure_reason ?? "Download failed"}`
+                  : ` — Hash mismatch; expected ${result.expected_sha256 ?? "unknown"}, computed ${result.computed_sha256 ?? "unknown"}.`}
+              </li>
+            ))}
+          </ul>
+        )}
+        {issues.length > 0 && (
+          <p className="text-sm text-muted-foreground">The details are also in media-failures.txt inside the archive.</p>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/hooks/useArchiveMediaExport.test.ts
+++ b/src/hooks/useArchiveMediaExport.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+
+import type { MediaSummary } from "@/lib/exit/archive";
+
+import { classifyMediaExport } from "./useArchiveMediaExport";
+
+function summary(overrides: Partial<MediaSummary> = {}): MediaSummary {
+  return {
+    media_total: 4,
+    media_verified: 4,
+    media_unverified: 0,
+    media_mismatched: 0,
+    media_failed: 0,
+    ...overrides,
+  };
+}
+
+describe("classifyMediaExport", () => {
+  it("distinguishes clean, degraded, all-failed, and empty exports", () => {
+    expect(classifyMediaExport(summary())).toBe("complete");
+    expect(classifyMediaExport(summary({ media_verified: 3, media_failed: 1 }))).toBe("partial");
+    expect(classifyMediaExport(summary({ media_verified: 3, media_mismatched: 1 }))).toBe("partial");
+    expect(classifyMediaExport(summary({ media_verified: 0, media_failed: 4 }))).toBe("no-media");
+    expect(classifyMediaExport(summary({ media_total: 0, media_verified: 0 }))).toBe("empty");
+  });
+});

--- a/src/hooks/useArchiveMediaExport.ts
+++ b/src/hooks/useArchiveMediaExport.ts
@@ -4,17 +4,26 @@
 import type { NostrSigner } from "@nostrify/nostrify";
 import { useEffect, useRef, useState } from "react";
 
-import { completeArchiveMedia, serializeArchiveFiles, type ArchiveFiles } from "@/lib/exit/archive";
+import { completeArchiveMedia, serializeArchiveFiles, summarizeMedia, type ArchiveFiles, type MediaSummary } from "@/lib/exit/archive";
 import { pickArchiveSink, supportsStreamingArchive } from "@/lib/exit/archiveSink";
-import { downloadArchiveMedia, type MediaProgress } from "@/lib/exit/mediaDownloader";
+import { downloadArchiveMedia, type MediaDownloadResult, type MediaProgress } from "@/lib/exit/mediaDownloader";
 import { createZipWriter } from "@/lib/exit/zip";
 
-type MediaExportState = "idle" | "running" | "complete" | "failed";
+export type MediaExportState = "idle" | "running" | "complete" | "partial" | "no-media" | "empty" | "failed";
+
+export function classifyMediaExport(summary: MediaSummary): Extract<MediaExportState, "complete" | "partial" | "no-media" | "empty"> {
+  if (summary.media_total === 0) return "empty";
+  if (summary.media_failed === summary.media_total) return "no-media";
+  if (summary.media_failed > 0 || summary.media_mismatched > 0) return "partial";
+  return "complete";
+}
 
 export function useArchiveMediaExport(input: { files: ArchiveFiles | null; signer: NostrSigner | null | undefined }) {
   const [state, setState] = useState<MediaExportState>("idle");
   const [progress, setProgress] = useState<MediaProgress | null>(null);
   const [failure, setFailure] = useState<string | null>(null);
+  const [summary, setSummary] = useState<MediaSummary | null>(null);
+  const [results, setResults] = useState<MediaDownloadResult[]>([]);
   const activeController = useRef<AbortController | null>(null);
   const archivePubkey = input.files?.["manifest.json"].pubkey;
 
@@ -23,6 +32,8 @@ export function useArchiveMediaExport(input: { files: ArchiveFiles | null; signe
     setState("idle");
     setProgress(null);
     setFailure(null);
+    setSummary(null);
+    setResults([]);
     return () => activeController.current?.abort();
   }, [archivePubkey]);
 
@@ -31,7 +42,7 @@ export function useArchiveMediaExport(input: { files: ArchiveFiles | null; signe
     const pubkey = input.files["manifest.json"].pubkey;
     let sink;
     try {
-      sink = await pickArchiveSink(`divine-export-${pubkey}-with-media.zip`);
+      sink = await pickArchiveSink(`divine-export-${pubkey}-media.zip`);
     } catch (error) {
       if (error instanceof DOMException && error.name === "AbortError") return;
       setFailure(error instanceof Error ? error.message : "The media archive could not be created.");
@@ -45,6 +56,8 @@ export function useArchiveMediaExport(input: { files: ArchiveFiles | null; signe
     setState("running");
     setFailure(null);
     setProgress(null);
+    setSummary(null);
+    setResults([]);
     try {
       const initial = serializeArchiveFiles(input.files);
       await writer.addFile("events.json", initial["events.json"]);
@@ -59,9 +72,13 @@ export function useArchiveMediaExport(input: { files: ArchiveFiles | null; signe
       const completed = serializeArchiveFiles(completeArchiveMedia(input.files, results));
       await writer.addFile("manifest.json", completed["manifest.json"]);
       await writer.addFile("media.json", completed["media.json"]);
-      await writer.addFile("media-checksums.txt", completed["media-checksums.txt"]);
+      if (completed["media-checksums.txt"]) await writer.addFile("media-checksums.txt", completed["media-checksums.txt"]);
+      if (completed["media-failures.txt"]) await writer.addFile("media-failures.txt", completed["media-failures.txt"]);
       await writer.close();
-      setState("complete");
+      const mediaSummary = summarizeMedia(results);
+      setSummary(mediaSummary);
+      setResults(results);
+      setState(classifyMediaExport(mediaSummary));
     } catch (error) {
       await writer.abort(error);
       setFailure(error instanceof Error ? error.message : "The media archive could not be created.");
@@ -71,5 +88,5 @@ export function useArchiveMediaExport(input: { files: ArchiveFiles | null; signe
     }
   }
 
-  return { state, progress, failure, supported: supportsStreamingArchive(), start };
+  return { state, progress, failure, summary, results, supported: supportsStreamingArchive(), start };
 }

--- a/src/lib/exit/archive.test.ts
+++ b/src/lib/exit/archive.test.ts
@@ -192,5 +192,23 @@ describe("archive builder", () => {
     });
     expect(completed["media.json"]).toHaveLength(2);
     expect(completed["media-checksums.txt"]).toBe(`${fixtureMediaHash}  media/${fixtureMediaHash}.mp4\n`);
+    expect(completed["media-failures.txt"]).toContain("hash-mismatch\thttps://example.com/wrong");
+  });
+
+  it("omits empty checksums and records failed downloads in a readable report", () => {
+    const archive = buildArchiveFiles({
+      events: [makeFixtureEvent()], pubkey: fixturePubkey, sourceEndpoint: "https://api.divine.video",
+      pageCount: 1, failures: [], generatedAt: new Date("2026-08-12T21:00:00Z"),
+    });
+    const reference = archive["media.json"][0];
+    const completed = completeArchiveMedia(archive, [{
+      references: [reference], source_url: reference.url, expected_sha256: fixtureMediaHash,
+      computed_sha256: null, byte_size: null, content_type: null, archive_path: null,
+      verification: "failed", failure_reason: `${reference.url}: HTTP 503`,
+    }]);
+    const serialized = serializeArchiveFiles(completed);
+
+    expect(serialized).not.toHaveProperty("media-checksums.txt");
+    expect(serialized["media-failures.txt"]).toBe(`failed\t${reference.url}\t${reference.url}: HTTP 503\n`);
   });
 });

--- a/src/lib/exit/archive.ts
+++ b/src/lib/exit/archive.ts
@@ -53,6 +53,7 @@ export interface ArchiveFiles {
   "manifest.json": ArchiveManifest;
   "media.json": MediaReference[] | ArchivedMediaReference[];
   "media-checksums.txt"?: string;
+  "media-failures.txt"?: string;
 }
 
 const URL_TAGS = new Set(["url", "image", "thumb", "thumbnail"]);
@@ -208,19 +209,35 @@ export function summarizeMedia(results: MediaDownloadResult[]): MediaSummary {
   };
 }
 
-export function createMediaChecksums(results: MediaDownloadResult[]): string {
+export function createMediaChecksums(results: MediaDownloadResult[]): string | null {
   const lines = results
     .filter((result) => result.archive_path && (result.verification === "verified" || result.verification === "unverified"))
     .map((result) => `${result.computed_sha256}  ${result.archive_path}`);
-  return lines.length ? `${lines.join("\n")}\n` : "";
+  return lines.length ? `${lines.join("\n")}\n` : null;
+}
+
+export function createMediaFailureReport(results: MediaDownloadResult[]): string | null {
+  const lines = results.flatMap((result) => {
+    if (result.verification === "failed") {
+      return [`failed\t${result.source_url}\t${result.failure_reason ?? "Download failed"}`];
+    }
+    if (result.verification === "hash-mismatch") {
+      return [`hash-mismatch\t${result.source_url}\texpected ${result.expected_sha256 ?? "unknown"}; computed ${result.computed_sha256 ?? "unknown"}`];
+    }
+    return [];
+  });
+  return lines.length ? `${lines.join("\n")}\n` : null;
 }
 
 export function completeArchiveMedia(files: ArchiveFiles, results: MediaDownloadResult[]): ArchiveFiles {
+  const checksums = createMediaChecksums(results);
+  const failures = createMediaFailureReport(results);
   return {
-    ...files,
+    "events.json": files["events.json"],
     "manifest.json": { ...files["manifest.json"], media: summarizeMedia(results) },
     "media.json": mergeMediaResults(results),
-    "media-checksums.txt": createMediaChecksums(results),
+    ...(checksums ? { "media-checksums.txt": checksums } : {}),
+    ...(failures ? { "media-failures.txt": failures } : {}),
   };
 }
 
@@ -231,5 +248,6 @@ export function serializeArchiveFiles(files: ArchiveFiles): Record<string, strin
     "media.json": `${JSON.stringify(files["media.json"], null, 2)}\n`
   };
   if (files["media-checksums.txt"] !== undefined) serialized["media-checksums.txt"] = files["media-checksums.txt"];
+  if (files["media-failures.txt"] !== undefined) serialized["media-failures.txt"] = files["media-failures.txt"];
   return serialized;
 }

--- a/src/lib/exit/mediaDownloader.test.ts
+++ b/src/lib/exit/mediaDownloader.test.ts
@@ -70,13 +70,25 @@ describe("downloadArchiveMedia", () => {
     for (const [result] of cases) expect(result.verification).toBe("failed");
   });
 
-  it("rejects truncated responses and disables automatic redirects", async () => {
+  it("rejects truncated responses and follows redirects for bare requests", async () => {
     const fetcher = vi.fn<typeof fetch>(async () => new Response("short", { headers: { "content-length": "99" } }));
     const [result] = await downloadArchiveMedia({
       references: [reference("https://example.com/truncated")], fetcher, onFile: async () => undefined,
     });
     expect(result).toMatchObject({ verification: "failed" });
-    expect(fetcher.mock.calls[0][1]).toMatchObject({ redirect: "error" });
+    expect(fetcher.mock.calls[0][1]).toMatchObject({ redirect: "follow" });
+  });
+
+  it("accepts a redirected bare candidate when the final bytes match", async () => {
+    const fetcher = vi.fn<typeof fetch>(async (_input, init) => {
+      expect(init).toMatchObject({ redirect: "follow" });
+      return new Response("hello", { headers: { "content-type": "video/mp4" } });
+    });
+    const [result] = await downloadArchiveMedia({
+      references: [reference("https://blossom.example/redirecting-blob")], fetcher, onFile: async () => undefined,
+    });
+
+    expect(result.verification).toBe("verified");
   });
 
   it("retries an auth challenge only for the exact Divine media origin", async () => {
@@ -86,11 +98,29 @@ describe("downloadArchiveMedia", () => {
     const signer = { getPublicKey: vi.fn(), signEvent: vi.fn(async (event) => ({ ...event, id: "a".repeat(64), pubkey: "b".repeat(64), sig: "c".repeat(128) })) };
     await downloadArchiveMedia({ references: [reference("https://media.divine.video/blob")], signer, fetcher: divineFetch, onFile: async () => undefined });
     expect(divineFetch).toHaveBeenCalledTimes(2);
+    expect(divineFetch.mock.calls[0][1]).toMatchObject({ redirect: "follow" });
+    expect(divineFetch.mock.calls[1][1]).toMatchObject({ redirect: "error" });
     expect((divineFetch.mock.calls[1][1]?.headers as Record<string, string>).Authorization).toMatch(/^Nostr /);
 
     const thirdPartyFetch = vi.fn(async () => new Response(null, { status: 401 }));
     await downloadArchiveMedia({ references: [reference("https://media.divine.video.evil.example/blob")], signer, fetcher: thirdPartyFetch, onFile: async () => undefined });
     expect(thirdPartyFetch).toHaveBeenCalledOnce();
+  });
+
+  it("rejects an authorized response that resolves off the Divine media origin", async () => {
+    const redirectedResponse = new Response("hello");
+    Object.defineProperty(redirectedResponse, "url", { value: "https://cdn.example/blob" });
+    const fetcher = vi.fn()
+      .mockResolvedValueOnce(new Response(null, { status: 401 }))
+      .mockResolvedValueOnce(redirectedResponse);
+    const signer = { getPublicKey: vi.fn(), signEvent: vi.fn(async (event) => ({ ...event, id: "a".repeat(64), pubkey: "b".repeat(64), sig: "c".repeat(128) })) };
+
+    const [result] = await downloadArchiveMedia({
+      references: [reference("https://media.divine.video/blob")], signer, fetcher, onFile: async () => undefined,
+    });
+
+    expect(result).toMatchObject({ verification: "failed" });
+    expect(result.failure_reason).toContain("redirected to an untrusted origin");
   });
 });
 

--- a/src/lib/exit/mediaDownloader.ts
+++ b/src/lib/exit/mediaDownloader.ts
@@ -60,16 +60,20 @@ function hex(bytes: ArrayBuffer): string {
 async function fetchCandidate(url: string, expectedHash: string | null, options: Pick<DownloadOptions, "fetcher" | "signer" | "signal">) {
   const fetcher = options.fetcher ?? fetch;
   const request = async (authorization?: string | null) => fetcher(url, {
-    method: "GET", signal: options.signal, redirect: "error",
+    method: "GET", signal: options.signal, redirect: authorization ? "error" : "follow",
     headers: authorization ? { Authorization: authorization } : undefined,
   });
   let response = await request();
+  let usedAuthorization = false;
   if ((response.status === 401 || response.status === 403) && isDivineMediaOrigin(url)) {
     const auth = await createMediaViewerAuthHeader({ signer: options.signer, url, sha256: expectedHash ?? undefined });
-    if (auth) response = await request(auth);
+    if (auth) {
+      response = await request(auth);
+      usedAuthorization = true;
+    }
   }
   if (!response.ok) throw new Error(`HTTP ${response.status}`);
-  if (!isDivineMediaOrigin(response.url || url) && isDivineMediaOrigin(url)) throw new Error("Divine media redirected to an untrusted origin");
+  if (usedAuthorization && !isDivineMediaOrigin(response.url || url)) throw new Error("Divine media redirected to an untrusted origin");
   const bytes = new Uint8Array(await response.arrayBuffer());
   const advertisedSize = response.headers.get("content-length");
   if (advertisedSize && Number(advertisedSize) !== bytes.length) throw new Error("Response byte count did not match Content-Length");

--- a/src/pages/ExitStartPage.test.tsx
+++ b/src/pages/ExitStartPage.test.tsx
@@ -198,25 +198,51 @@ describe("ExitStartPage", () => {
     expect(screen.getByText(/cannot safely assemble one large media archive/)).toBeInTheDocument();
   });
 
-  it("streams media to a selected file and reports a quarantined mismatch", async () => {
+  it("streams media to a selected file and reports a quarantined mismatch as degraded", async () => {
     mockUseCurrentUser.mockReturnValue(signedIn());
     vi.stubGlobal("fetch", createFixtureFetch("one-page"));
     const write = vi.fn(async () => undefined);
     const close = vi.fn(async () => undefined);
     const abort = vi.fn(async () => undefined);
-    vi.stubGlobal("showSaveFilePicker", vi.fn(async () => ({
+    const showSaveFilePicker = vi.fn(async () => ({
       createWritable: async () => ({ write, close, abort }),
-    })));
+    }));
+    vi.stubGlobal("showSaveFilePicker", showSaveFilePicker);
     render(<TestApp><ExitStartPage /></TestApp>);
     await userEvent.click(screen.getByRole("button", { name: /Create my archive/ }));
     await waitFor(() => expect(screen.getByText(/Your archive is ready/)).toBeInTheDocument());
     vi.stubGlobal("fetch", vi.fn(async () => new Response("hello", { headers: { "content-type": "video/mp4" } })));
     await userEvent.click(screen.getByRole("button", { name: /Save media archive/ }));
-    await waitFor(() => expect(screen.getByText("Your media archive is saved.")).toBeInTheDocument());
+    await waitFor(() => expect(screen.getByText("0 of 1 files were saved as usable media.")).toBeInTheDocument());
     expect(screen.getByText(/Saved separately because the hash did not match/)).toBeInTheDocument();
+    expect(screen.queryByText("Your media archive is saved.")).not.toBeInTheDocument();
+    expect(showSaveFilePicker).toHaveBeenCalledWith(expect.objectContaining({
+      suggestedName: `divine-export-${fixturePubkey}-media.zip`,
+    }));
     expect(write).toHaveBeenCalled();
     expect(close).toHaveBeenCalledOnce();
     expect(abort).not.toHaveBeenCalled();
+  });
+
+  it("reports when the archive saves no media and omits the success message", async () => {
+    mockUseCurrentUser.mockReturnValue(signedIn());
+    vi.stubGlobal("fetch", createFixtureFetch("one-page"));
+    const write = vi.fn(async () => undefined);
+    const close = vi.fn(async () => undefined);
+    vi.stubGlobal("showSaveFilePicker", vi.fn(async () => ({
+      createWritable: async () => ({ write, close, abort: vi.fn(async () => undefined) }),
+    })));
+    render(<TestApp><ExitStartPage /></TestApp>);
+    await userEvent.click(screen.getByRole("button", { name: /Create my archive/ }));
+    await waitFor(() => expect(screen.getByText(/Your archive is ready/)).toBeInTheDocument());
+    vi.stubGlobal("fetch", vi.fn(async () => { throw new TypeError("offline"); }));
+
+    await userEvent.click(screen.getByRole("button", { name: /Save media archive/ }));
+
+    await waitFor(() => expect(screen.getByText(/No media was saved/)).toBeInTheDocument());
+    expect(screen.queryByText("Your media archive is saved.")).not.toBeInTheDocument();
+    expect(screen.getByText(/offline/)).toBeInTheDocument();
+    expect(close).toHaveBeenCalledOnce();
   });
 
   it("uses the active Funnelcake environment", async () => {

--- a/src/pages/ExitStartPage.tsx
+++ b/src/pages/ExitStartPage.tsx
@@ -22,6 +22,7 @@ import { DestinationForm } from "@/components/exit/DestinationForm";
 import { DiscoveryPointerForm } from "@/components/exit/DiscoveryPointerForm";
 import { KeySafetyNotice } from "@/components/exit/KeySafetyNotice";
 import { MediaProgressList } from "@/components/exit/MediaProgressList";
+import { MediaExportSummary } from "@/components/exit/MediaExportSummary";
 import { RelayDestinationForm } from "@/components/exit/RelayDestinationForm";
 import { LoginArea } from "@/components/auth/LoginArea";
 import { MarketingLayout } from "@/components/MarketingLayout";
@@ -309,9 +310,7 @@ export function ExitStartPage() {
 
               <MediaProgressList progress={mediaExport.progress} />
 
-              {mediaExport.state === "complete" && (
-                <p className="text-base font-semibold text-foreground" role="status">Your media archive is saved.</p>
-              )}
+              <MediaExportSummary state={mediaExport.state} summary={mediaExport.summary} results={mediaExport.results} />
 
               {mediaExport.state === "failed" && mediaExport.failure && (
                 <p className="text-base text-destructive" role="alert">{mediaExport.failure}</p>


### PR DESCRIPTION
## Summary

- Reports whether a media archive is complete, degraded, empty, or contains no downloaded media instead of treating every finalized ZIP as successful.
- Includes readable download and hash-mismatch details in the UI and in media-failures.txt, while omitting empty checksum files and using a neutral -media.zip filename.
- Follows redirects for bare media requests while continuing to refuse redirects whenever viewer authorization is attached.

> Avoid naming corporate partners, customers, or other sensitive external brands in this PR title or body. Use generic descriptors unless a maintainer explicitly approves the public reference.

## Motivation

- Users could receive a ZIP containing only account events after every media request failed, while the page still said the media archive was saved. The downloader already tracked honest per-file results, but the completion UI ignored them.
- This keeps the streamed archive design and authorization boundary intact. It deliberately does not add a first-party fallback URL or change which media URLs exported events contain; source-selection policy remains separate from this reporting and redirect fix.

## Related Issue

- Closes #693

## Testing

- [x] npm run test
- [x] Focused Vitest coverage for archive reports, redirects, outcome classification, and exit-page summaries
- [ ] Manual verification completed

## Visuals

- [ ] UI change with screenshots/video attached
- [ ] No visual change
- [x] Visuals and text avoid sensitive external brand or partner names unless explicitly approved

The final status card is a UI change; automated page tests cover the complete, quarantined-mismatch, and all-downloads-failed copy.