### PR TITLE
fix(exit): include profile media in account archives

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -199,7 +199,9 @@ while requests carrying viewer authorization refuse redirects and are retried
 only for the exact `https://media.divine.video` origin; third-party media
 requests remain bare. The completed archive omits an empty checksum file, adds
 a readable failure report for downloads and quarantined hash mismatches, and
-keeps the final on-screen result aligned with the media actually saved.
+keeps the final on-screen result aligned with the media actually saved. Media
+discovery reads URL-bearing event tags plus the `picture` and `banner` fields in
+kind-0 profile metadata.
 
 The same page shows the signed-in account's full npub and separates hosted,
 local-nsec, and external-signer key ownership. Hosted accounts may export their

--- a/src/lib/exit/archive.test.ts
+++ b/src/lib/exit/archive.test.ts
@@ -170,6 +170,26 @@ describe("archive builder", () => {
     ]);
   });
 
+  it("ignores a non-URL banner such as a theme color", () => {
+    const profile = makeFixtureEvent({
+      kind: 0,
+      tags: [],
+      content: JSON.stringify({
+        picture: "https://cdn.divine.video/avatar/current.jpg",
+        banner: "0x27c58b",
+      }),
+    });
+
+    expect(discoverMediaReferences([profile])).toEqual([
+      {
+        event_id: profile.id,
+        tag: "picture",
+        url: "https://cdn.divine.video/avatar/current.jpg",
+        sha256: null,
+      },
+    ]);
+  });
+
   it("uses a sibling x tag when the URL does not carry a hash", () => {
     const hash = "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff";
     const references = discoverMediaReferences([

--- a/src/lib/exit/archive.test.ts
+++ b/src/lib/exit/archive.test.ts
@@ -121,6 +121,55 @@ describe("archive builder", () => {
     ]);
   });
 
+  it("discovers picture and banner URLs from profile metadata", () => {
+    const pictureHash = "e".repeat(64);
+    const bannerHash = "f".repeat(64);
+    const profile = makeFixtureEvent({
+      kind: 0,
+      tags: [],
+      content: JSON.stringify({
+        picture: `https://cdn.divine.video/${pictureHash}.jpg`,
+        banner: `https://media.divine.video/${bannerHash}`,
+      }),
+    });
+
+    expect(discoverMediaReferences([profile])).toEqual([
+      {
+        event_id: profile.id,
+        tag: "picture",
+        url: `https://cdn.divine.video/${pictureHash}.jpg`,
+        sha256: pictureHash,
+      },
+      {
+        event_id: profile.id,
+        tag: "banner",
+        url: `https://media.divine.video/${bannerHash}`,
+        sha256: bannerHash,
+      },
+    ]);
+  });
+
+  it("keeps hashless profile media and ignores invalid metadata values", () => {
+    const profile = makeFixtureEvent({
+      kind: 0,
+      tags: [],
+      content: JSON.stringify({
+        picture: "https://cdn.divine.video/avatar/current.jpg",
+        banner: 42,
+      }),
+    });
+    const malformed = makeFixtureEvent({ kind: 0, tags: [], content: "{" });
+
+    expect(discoverMediaReferences([profile, malformed])).toEqual([
+      {
+        event_id: profile.id,
+        tag: "picture",
+        url: "https://cdn.divine.video/avatar/current.jpg",
+        sha256: null,
+      },
+    ]);
+  });
+
   it("uses a sibling x tag when the URL does not carry a hash", () => {
     const hash = "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff";
     const references = discoverMediaReferences([

--- a/src/lib/exit/archive.ts
+++ b/src/lib/exit/archive.ts
@@ -4,6 +4,7 @@
 import type { NostrEvent } from "@nostrify/nostrify";
 
 import { isHex64 } from "./hex";
+import { IMETA_URL_KEYS, profileMediaUrls, URL_TAGS } from "./mediaReferences";
 import type { OwnerExportModeration } from "./ownerExportClient";
 import type { ModerationAnnotation } from "./moderationMetadata";
 import type { MediaDownloadResult, MediaVerification } from "./mediaDownloader";
@@ -76,9 +77,6 @@ export interface ArchiveFiles {
   "media-checksums.txt"?: string;
   "media-failures.txt"?: string;
 }
-
-const URL_TAGS = new Set(["url", "image", "thumb", "thumbnail"]);
-const IMETA_URL_KEYS = new Set(["url", "image", "thumb", "thumbnail", "fallback"]);
 
 function basenameHash(url: string): string | null {
   try {
@@ -173,6 +171,15 @@ export function discoverMediaReferences(events: NostrEvent[]): MediaReference[] 
           });
         }
       }
+    }
+
+    for (const profileMedia of profileMediaUrls(event)) {
+      references.push({
+        event_id: event.id,
+        tag: profileMedia.key,
+        url: profileMedia.url,
+        sha256: basenameHash(profileMedia.url),
+      });
     }
   }
 

--- a/src/lib/exit/eventRewrite.test.ts
+++ b/src/lib/exit/eventRewrite.test.ts
@@ -104,6 +104,30 @@ describe("rewriteEventMedia", () => {
     expect(result.changed).toBe(false);
     expect(result.remainingMediaUrls).toBe(0);
   });
+
+  it("rewrites mapped profile media and reports unmapped profile media", () => {
+    const banner = `https://media.divine.video/${"e".repeat(64)}.jpg`;
+    const original = event({
+      kind: 0,
+      content: JSON.stringify({ picture: SOURCE, banner }),
+      tags: [],
+    });
+
+    const result = rewriteEventMedia(original, new Map([[SOURCE, DESTINATION]]));
+
+    expect(result.changed).toBe(true);
+    expect(JSON.parse(result.template.content)).toEqual({ picture: DESTINATION, banner });
+    expect(result.remainingMediaUrls).toBe(1);
+  });
+
+  it("ignores malformed and non-string profile media while reporting", () => {
+    expect(rewriteEventMedia(event({ kind: 0, content: "{", tags: [] }), new Map()).remainingMediaUrls).toBe(0);
+    expect(rewriteEventMedia(event({
+      kind: 0,
+      content: JSON.stringify({ picture: 42, banner: "" }),
+      tags: [],
+    }), new Map()).remainingMediaUrls).toBe(0);
+  });
 });
 
 describe("event references", () => {

--- a/src/lib/exit/eventRewrite.test.ts
+++ b/src/lib/exit/eventRewrite.test.ts
@@ -128,6 +128,16 @@ describe("rewriteEventMedia", () => {
       tags: [],
     }), new Map()).remainingMediaUrls).toBe(0);
   });
+
+  it("does not count a non-URL banner such as a theme color as remaining media", () => {
+    const result = rewriteEventMedia(event({
+      kind: 0,
+      content: JSON.stringify({ picture: SOURCE, banner: "0x27c58b" }),
+      tags: [],
+    }), new Map());
+
+    expect(result.remainingMediaUrls).toBe(1);
+  });
 });
 
 describe("event references", () => {

--- a/src/lib/exit/eventRewrite.ts
+++ b/src/lib/exit/eventRewrite.ts
@@ -3,6 +3,7 @@
 
 import { NKinds, type NostrEvent } from "@nostrify/nostrify";
 
+import { IMETA_URL_KEYS, profileMediaUrls, URL_TAGS } from "./mediaReferences";
 import type { MirrorResult } from "./mirrorClient";
 
 export type EventTemplate = Omit<NostrEvent, "id" | "pubkey" | "sig">;
@@ -13,8 +14,6 @@ export interface EventRewrite {
   remainingMediaUrls: number;
 }
 
-const URL_TAGS = new Set(["url", "image", "thumb", "thumbnail"]);
-const IMETA_URL_KEYS = new Set(["url", "image", "thumb", "thumbnail", "fallback"]);
 // 4 is a NIP-04 direct message; 13 is the NIP-59 seal, which carries the
 // sender's real pubkey and so is the one of these an owner export can return;
 // 14 and 15 are NIP-17 chat and file messages; 1059 is the NIP-59 gift wrap.
@@ -71,9 +70,9 @@ function rewriteImeta(tag: string[], urls: ReadonlyMap<string, string>): string[
   });
 }
 
-function countRemainingMediaUrls(tags: string[][], urls: ReadonlyMap<string, string>): number {
+function countRemainingMediaUrls(event: NostrEvent, urls: ReadonlyMap<string, string>): number {
   let count = 0;
-  for (const tag of tags) {
+  for (const tag of event.tags) {
     if (URL_TAGS.has(tag[0]) && tag[1] && !urls.has(tag[1])) count += 1;
     if (tag[0] !== "imeta") continue;
     if (tag[1]?.includes(" ")) {
@@ -87,6 +86,7 @@ function countRemainingMediaUrls(tags: string[][], urls: ReadonlyMap<string, str
       }
     }
   }
+  count += profileMediaUrls(event).filter(({ url }) => !urls.has(url)).length;
   return count;
 }
 
@@ -109,7 +109,7 @@ export function rewriteEventMedia(event: NostrEvent, urls: ReadonlyMap<string, s
   return {
     template: { kind: event.kind, created_at: event.created_at, content, tags },
     changed,
-    remainingMediaUrls: countRemainingMediaUrls(event.tags, urls),
+    remainingMediaUrls: countRemainingMediaUrls(event, urls),
   };
 }
 

--- a/src/lib/exit/mediaDownloader.test.ts
+++ b/src/lib/exit/mediaDownloader.test.ts
@@ -37,6 +37,22 @@ describe("downloadArchiveMedia", () => {
     expect(results[0].references).toHaveLength(2);
   });
 
+  it("downloads one blob for duplicate profile and tag references", async () => {
+    const url = `https://media.divine.video/${helloHash}.jpg`;
+    const fetcher = vi.fn(async () => new Response("hello", { headers: { "content-type": "image/jpeg" } }));
+    const onFile = vi.fn(async () => undefined);
+
+    const results = await downloadArchiveMedia({
+      references: [reference(url), { ...reference(url), tag: "picture" }],
+      fetcher,
+      onFile,
+    });
+
+    expect(fetcher).toHaveBeenCalledOnce();
+    expect(onFile).toHaveBeenCalledOnce();
+    expect(results[0].references).toHaveLength(2);
+  });
+
   it("quarantines the last mismatch when every mirror is invalid", async () => {
     const onFile = vi.fn(async () => undefined);
     const results = await downloadArchiveMedia({

--- a/src/lib/exit/mediaReferences.ts
+++ b/src/lib/exit/mediaReferences.ts
@@ -1,0 +1,31 @@
+// ABOUTME: Identifies portable media references shared by archive discovery and event rewriting
+// ABOUTME: Safely reads profile picture and banner URLs from kind-0 metadata
+
+import type { NostrEvent } from "@nostrify/nostrify";
+
+export const URL_TAGS = new Set(["url", "image", "thumb", "thumbnail"]);
+export const IMETA_URL_KEYS = new Set(["url", "image", "thumb", "thumbnail", "fallback"]);
+
+const PROFILE_MEDIA_KEYS = ["picture", "banner"] as const;
+
+export interface ProfileMediaUrl {
+  key: (typeof PROFILE_MEDIA_KEYS)[number];
+  url: string;
+}
+
+export function profileMediaUrls(event: Pick<NostrEvent, "kind" | "content">): ProfileMediaUrl[] {
+  if (event.kind !== 0) return [];
+
+  try {
+    const metadata: unknown = JSON.parse(event.content);
+    if (!metadata || typeof metadata !== "object" || Array.isArray(metadata)) return [];
+
+    const values = metadata as Record<string, unknown>;
+    return PROFILE_MEDIA_KEYS.flatMap((key) => {
+      const value = values[key];
+      return typeof value === "string" && value.trim() ? [{ key, url: value }] : [];
+    });
+  } catch {
+    return [];
+  }
+}

--- a/src/lib/exit/mediaReferences.ts
+++ b/src/lib/exit/mediaReferences.ts
@@ -13,6 +13,15 @@ export interface ProfileMediaUrl {
   url: string;
 }
 
+function isHttpUrl(value: string): boolean {
+  try {
+    const { protocol } = new URL(value);
+    return protocol === "https:" || protocol === "http:";
+  } catch {
+    return false;
+  }
+}
+
 export function profileMediaUrls(event: Pick<NostrEvent, "kind" | "content">): ProfileMediaUrl[] {
   if (event.kind !== 0) return [];
 
@@ -23,7 +32,11 @@ export function profileMediaUrls(event: Pick<NostrEvent, "kind" | "content">): P
     const values = metadata as Record<string, unknown>;
     return PROFILE_MEDIA_KEYS.flatMap((key) => {
       const value = values[key];
-      return typeof value === "string" && value.trim() ? [{ key, url: value }] : [];
+      // Profile fields are free-form strings. `banner` in particular commonly
+      // holds a theme color such as "0x27c58b" rather than an image; only treat
+      // values that parse as http(s) URLs as portable media, so a color is not
+      // reported as a failed download or an unmirrored reference.
+      return typeof value === "string" && isHttpUrl(value) ? [{ key, url: value }] : [];
     });
   } catch {
     return [];

--- a/src/lib/exit/relayPublisher.test.ts
+++ b/src/lib/exit/relayPublisher.test.ts
@@ -108,6 +108,29 @@ describe("publishArchiveEvents", () => {
     expect(results.every((result) => result.status === "published")).toBe(true);
   });
 
+  it("republishes a profile with its mirrored picture URL", async () => {
+    const signer = makeSigner();
+    const relay = fakeRelay();
+    const profile = makeEvent("1", {
+      kind: 0,
+      content: JSON.stringify({ name: "Fixture profile", picture: SOURCE }),
+    });
+
+    const results = await publishArchiveEvents({
+      destination: RELAY,
+      events: [profile],
+      mirrorResults: [mirrorResult()],
+      signer,
+      relayFactory: () => relay,
+    });
+
+    expect(JSON.parse(relay.published[0].content)).toEqual({
+      name: "Fixture profile",
+      picture: DESTINATION_MEDIA,
+    });
+    expect(results[0]).toMatchObject({ status: "published", remaining_media_urls: 0 });
+  });
+
   it("produces the same replacement templates on repeated runs", async () => {
     const signer = makeSigner();
     const video = makeEvent("1", { kind: 34236, content: SOURCE, tags: [["url", SOURCE]] });


### PR DESCRIPTION
## Summary

- discover kind-0 profile pictures and banners alongside tag-based media
- reuse the same profile parsing for accurate remaining-media reporting
- preserve existing one-blob deduplication and republish mapped profile URLs

## Motivation

Account archives previously ignored profile media because kind-0 events store picture and banner URLs in JSON content rather than tags. That omission kept those assets out of downloads and destination mirror mappings, while migration reporting could incorrectly say no media references remained.

This change deliberately leaves hashless Blossom upload fallback and Divine media-origin authorization policy unchanged. Hashless profile assets are now included in the archive as unverified references, but the existing secure mirror flow still skips sources without an advertised or URL-derived SHA-256.

## Related Issue

- Refs #692

## Testing

- [x] `npm run test`
- [ ] Manual verification completed

## Visuals

- [ ] UI change with screenshots/video attached
- [x] No visual change
- [x] Visuals and text avoid sensitive external brand or partner names unless explicitly approved