### PR TITLE
fix(exit): report media already at the destination honestly

### DIFF
--- a/src/components/exit/DestinationForm.test.tsx
+++ b/src/components/exit/DestinationForm.test.tsx
@@ -1,0 +1,48 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { DestinationForm } from "./DestinationForm";
+
+describe("DestinationForm", () => {
+  it("describes already-present progress and hides zero summary categories", () => {
+    render(
+      <DestinationForm
+        state="complete"
+        progress={{
+          completed: 1,
+          total: 1,
+          result: {
+            references: [],
+            source_url: "https://blossom.example/file.jpg",
+            destination_url: "https://blossom.example/file.jpg",
+            expected_sha256: "a".repeat(64),
+            destination_sha256: "a".repeat(64),
+            byte_size: null,
+            verification: "already-present",
+          },
+        }}
+        summary={{ mirrored: 0, alreadyPresent: 1, failed: 0, skipped: 0, unverified: 0 }}
+        failure={null}
+        onStart={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText(/Already at the destination:/)).toBeInTheDocument();
+    expect(screen.getByRole("status")).toHaveTextContent("1 already there.");
+    expect(screen.getByRole("status")).not.toHaveTextContent("0 failed");
+  });
+
+  it("has an explicit empty summary", () => {
+    render(
+      <DestinationForm
+        state="complete"
+        progress={null}
+        summary={{ mirrored: 0, alreadyPresent: 0, failed: 0, skipped: 0, unverified: 0 }}
+        failure={null}
+        onStart={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByRole("status")).toHaveTextContent("No media needed copying.");
+  });
+});

--- a/src/components/exit/DestinationForm.tsx
+++ b/src/components/exit/DestinationForm.tsx
@@ -22,11 +22,29 @@ interface DestinationFormProps {
 function progressLabel(progress: MirrorProgress): string {
   switch (progress.result.verification) {
     case "descriptor-verified": return "Mirrored and confirmed by the destination";
+    case "already-present": return "Already at the destination";
     case "unverified": return "Mirrored without confirmed readback";
     case "hash-mismatch": return "Destination reported a different hash";
     case "skipped": return progress.result.reason ?? "Skipped this source";
     default: return "Could not mirror";
   }
+}
+
+function summaryLabel(summary: MirrorSummary): string {
+  const counts = [
+    [summary.mirrored, "mirrored"],
+    [summary.alreadyPresent, "already there"],
+    [summary.failed, "failed"],
+    [summary.skipped, "skipped"],
+    [summary.unverified, "unverified"],
+  ] as const;
+  const visible = counts
+    .filter(([count]) => count > 0)
+    .map(([count, label]) => `${count} ${label}`);
+  if (visible.length === 0) return "No media needed copying.";
+  if (visible.length === 1) return `${visible[0]}.`;
+  if (visible.length === 2) return `${visible[0]} and ${visible[1]}.`;
+  return `${visible.slice(0, -1).join(", ")}, and ${visible.at(-1)}.`;
 }
 
 export function DestinationForm({ state, progress, summary, failure, onStart }: DestinationFormProps) {
@@ -85,7 +103,7 @@ export function DestinationForm({ state, progress, summary, failure, onStart }: 
             <div>
               <p className="font-semibold text-foreground">Destination copy finished.</p>
               <p className="text-base leading-relaxed text-muted-foreground">
-                {summary.mirrored} mirrored, {summary.failed} failed, {summary.skipped} skipped, and {summary.unverified} unverified.
+                {summaryLabel(summary)}
               </p>
             </div>
           </div>

--- a/src/lib/exit/eventRewrite.test.ts
+++ b/src/lib/exit/eventRewrite.test.ts
@@ -42,13 +42,18 @@ function mirror(verification: MirrorResult["verification"] = "descriptor-verifie
 }
 
 describe("buildDestinationUrlMap", () => {
-  it("uses only descriptor-verified results and maps every grouped source", () => {
+  it("uses confirmed destination results and maps every grouped source", () => {
     const verified = mirror();
     verified.references.push({ event_id: "e".repeat(64), tag: "thumb", url: `${SOURCE}?thumb=1`, sha256: "c".repeat(64) });
-    const map = buildDestinationUrlMap([verified, mirror("unverified"), mirror("hash-mismatch")]);
+    const alreadyPresent = mirror("already-present");
+    alreadyPresent.references = [{ event_id: ID, tag: "image", url: DESTINATION, sha256: "c".repeat(64) }];
+    alreadyPresent.source_url = DESTINATION;
+    alreadyPresent.destination_url = DESTINATION;
+    const map = buildDestinationUrlMap([verified, alreadyPresent, mirror("unverified"), mirror("hash-mismatch")]);
     expect([...map.entries()]).toEqual([
       [SOURCE, DESTINATION],
       [`${SOURCE}?thumb=1`, DESTINATION],
+      [DESTINATION, DESTINATION],
     ]);
   });
 });
@@ -90,6 +95,14 @@ describe("rewriteEventMedia", () => {
     const result = rewriteEventMedia(event({ content: "unchanged" }), new Map());
     expect(result.changed).toBe(false);
     expect(result.remainingMediaUrls).toBe(1);
+  });
+
+  it("treats an identity mapping as unchanged with no remaining media", () => {
+    const original = event({ content: DESTINATION, tags: [["url", DESTINATION]] });
+    const result = rewriteEventMedia(original, new Map([[DESTINATION, DESTINATION]]));
+
+    expect(result.changed).toBe(false);
+    expect(result.remainingMediaUrls).toBe(0);
   });
 });
 

--- a/src/lib/exit/eventRewrite.ts
+++ b/src/lib/exit/eventRewrite.ts
@@ -24,7 +24,10 @@ const DESTRUCTIVE_KINDS = new Set([5, 62]);
 export function buildDestinationUrlMap(results: MirrorResult[]): Map<string, string> {
   const urls = new Map<string, string>();
   for (const result of results) {
-    if (result.verification !== "descriptor-verified" || !result.destination_url) continue;
+    if (
+      (result.verification !== "descriptor-verified" && result.verification !== "already-present")
+      || !result.destination_url
+    ) continue;
     for (const reference of result.references) {
       urls.set(reference.url, result.destination_url);
     }

--- a/src/lib/exit/mirrorClient.test.ts
+++ b/src/lib/exit/mirrorClient.test.ts
@@ -4,7 +4,7 @@ import type { NostrSigner } from "@nostrify/nostrify";
 
 import type { MediaReference } from "./archive";
 import { DestinationError } from "./destination";
-import { mirrorArchiveMedia } from "./mirrorClient";
+import { mirrorArchiveMedia, summarizeMirrorResults } from "./mirrorClient";
 
 const hash = "a".repeat(64);
 const otherHash = "b".repeat(64);
@@ -64,7 +64,7 @@ describe("mirrorArchiveMedia", () => {
       signer,
       fetcher,
     })).rejects.toMatchObject({ code });
-    expect(fetcher).toHaveBeenCalledOnce();
+    expect(fetcher).toHaveBeenCalledTimes(2);
   });
 
   it("describes a canary CORS or network failure honestly", async () => {
@@ -205,13 +205,95 @@ describe("mirrorArchiveMedia", () => {
   });
 
   it("records malformed destination JSON as a file failure", async () => {
+    const fetcher = vi.fn<typeof fetch>()
+      .mockResolvedValueOnce(new Response("not json", { status: 200 }))
+      .mockResolvedValueOnce(new Response(null, { status: 404 }));
     const results = await mirrorArchiveMedia({
       destination: "https://blossom.example",
       references: [reference("https://source.example/one")],
       signer,
-      fetcher: vi.fn(async () => new Response("not json", { status: 200 })),
+      fetcher,
     });
     expect(results[0]).toMatchObject({ verification: "failed", reason: "The destination returned an invalid blob descriptor." });
+  });
+
+  it("reports a refused mirror as already present when the destination serves the blob", async () => {
+    const source = `https://blossom.example/${hash}.jpg`;
+    const fetcher = vi.fn<typeof fetch>()
+      .mockResolvedValueOnce(new Response(null, { status: 409 }))
+      .mockResolvedValueOnce(new Response(null, { status: 200 }));
+
+    const results = await mirrorArchiveMedia({
+      destination: "https://blossom.example", references: [reference(source)], signer, fetcher,
+    });
+
+    expect(results[0]).toMatchObject({
+      verification: "already-present",
+      source_url: source,
+      destination_url: source,
+      destination_sha256: hash,
+    });
+    expect(fetcher.mock.calls[1]).toEqual([
+      `https://blossom.example/${hash}`,
+      expect.objectContaining({ method: "HEAD", redirect: "follow" }),
+    ]);
+  });
+
+  it("uses the canonical destination URL when an existing blob came from another origin", async () => {
+    const fetcher = vi.fn<typeof fetch>()
+      .mockResolvedValueOnce(new Response(null, { status: 409 }))
+      .mockResolvedValueOnce(new Response(null, { status: 200 }));
+
+    const results = await mirrorArchiveMedia({
+      destination: "https://blossom.example", references: [reference("https://source.example/one.jpg")], signer, fetcher,
+    });
+
+    expect(results[0]).toMatchObject({
+      verification: "already-present",
+      destination_url: `https://blossom.example/${hash}`,
+    });
+  });
+
+  it("keeps a refused mirror failed when the destination does not serve the blob", async () => {
+    const fetcher = vi.fn<typeof fetch>()
+      .mockResolvedValueOnce(new Response(null, { status: 409 }))
+      .mockResolvedValueOnce(new Response(null, { status: 404 }));
+
+    const results = await mirrorArchiveMedia({
+      destination: "https://blossom.example", references: [reference("https://source.example/one")], signer, fetcher,
+    });
+
+    expect(results[0].verification).toBe("failed");
+  });
+
+  it("does not fail the canary when a refused blob is already present", async () => {
+    const fetcher = vi.fn<typeof fetch>()
+      .mockResolvedValueOnce(new Response(null, { status: 403 }))
+      .mockResolvedValueOnce(new Response(null, { status: 200 }));
+
+    await expect(mirrorArchiveMedia({
+      destination: "https://blossom.example", references: [reference("https://source.example/one")], signer, fetcher,
+    })).resolves.toMatchObject([{ verification: "already-present" }]);
+  });
+
+  it("does not probe after a hash mismatch", async () => {
+    const fetcher = vi.fn<typeof fetch>()
+      .mockResolvedValueOnce(new Response(JSON.stringify(descriptor(otherHash)), { status: 200 }));
+
+    const results = await mirrorArchiveMedia({
+      destination: "https://blossom.example", references: [reference("https://source.example/one")], signer, fetcher,
+    });
+
+    expect(results[0].verification).toBe("hash-mismatch");
+    expect(fetcher).toHaveBeenCalledOnce();
+  });
+
+  it("summarizes already-present blobs separately from mirrored and failed blobs", () => {
+    expect(summarizeMirrorResults([
+      { references: [], source_url: "one", destination_url: "one", expected_sha256: hash, destination_sha256: hash, byte_size: null, verification: "already-present" },
+      { references: [], source_url: "two", destination_url: "two", expected_sha256: hash, destination_sha256: hash, byte_size: 5, verification: "descriptor-verified" },
+      { references: [], source_url: "three", destination_url: null, expected_sha256: hash, destination_sha256: null, byte_size: null, verification: "failed" },
+    ])).toEqual({ mirrored: 1, alreadyPresent: 1, failed: 1, skipped: 0, unverified: 0 });
   });
 
   it("throws a typed destination error after exhausted canary rate limits", async () => {

--- a/src/lib/exit/mirrorClient.test.ts
+++ b/src/lib/exit/mirrorClient.test.ts
@@ -254,6 +254,24 @@ describe("mirrorArchiveMedia", () => {
     });
   });
 
+  it("uses the canonical destination URL when a same-origin source names another blob", async () => {
+    const fetcher = vi.fn<typeof fetch>()
+      .mockResolvedValueOnce(new Response(null, { status: 409 }))
+      .mockResolvedValueOnce(new Response(null, { status: 200 }));
+
+    const results = await mirrorArchiveMedia({
+      destination: "https://blossom.example",
+      references: [reference(`https://blossom.example/${otherHash}.jpg`)],
+      signer,
+      fetcher,
+    });
+
+    expect(results[0]).toMatchObject({
+      verification: "already-present",
+      destination_url: `https://blossom.example/${hash}`,
+    });
+  });
+
   it("keeps a refused mirror failed when the destination does not serve the blob", async () => {
     const fetcher = vi.fn<typeof fetch>()
       .mockResolvedValueOnce(new Response(null, { status: 409 }))
@@ -274,6 +292,21 @@ describe("mirrorArchiveMedia", () => {
     await expect(mirrorArchiveMedia({
       destination: "https://blossom.example", references: [reference("https://source.example/one")], signer, fetcher,
     })).resolves.toMatchObject([{ verification: "already-present" }]);
+  });
+
+  it("keeps the canary for the first blob that is not already present", async () => {
+    const fetcher = vi.fn<typeof fetch>()
+      .mockResolvedValueOnce(new Response(null, { status: 403 }))
+      .mockResolvedValueOnce(new Response(null, { status: 200 }))
+      .mockResolvedValueOnce(new Response(null, { status: 403 }))
+      .mockResolvedValueOnce(new Response(null, { status: 404 }));
+
+    await expect(mirrorArchiveMedia({
+      destination: "https://blossom.example",
+      references: [reference("https://source.example/one"), reference("https://source.example/two", otherHash)],
+      signer,
+      fetcher,
+    })).rejects.toMatchObject({ code: "auth-required" });
   });
 
   it("does not probe after a hash mismatch", async () => {

--- a/src/lib/exit/mirrorClient.test.ts
+++ b/src/lib/exit/mirrorClient.test.ts
@@ -21,6 +21,10 @@ function descriptor(sha256 = hash, size = 5) {
   return { url: `https://blossom.example/${sha256}`, sha256, size, type: "video/mp4" };
 }
 
+function blobHead(size = 5, contentType = "video/mp4") {
+  return new Response(null, { status: 200, headers: { "content-length": String(size), "content-type": contentType } });
+}
+
 function decodeAuthorization(value: string): { tags: string[][] } {
   const token = value.slice("Nostr ".length);
   const padded = token.replace(/-/g, "+").replace(/_/g, "/").padEnd(Math.ceil(token.length / 4) * 4, "=");
@@ -221,7 +225,7 @@ describe("mirrorArchiveMedia", () => {
     const source = `https://blossom.example/${hash}.jpg`;
     const fetcher = vi.fn<typeof fetch>()
       .mockResolvedValueOnce(new Response(null, { status: 409 }))
-      .mockResolvedValueOnce(new Response(null, { status: 200 }));
+      .mockResolvedValueOnce(blobHead());
 
     const results = await mirrorArchiveMedia({
       destination: "https://blossom.example", references: [reference(source)], signer, fetcher,
@@ -242,7 +246,7 @@ describe("mirrorArchiveMedia", () => {
   it("uses the canonical destination URL when an existing blob came from another origin", async () => {
     const fetcher = vi.fn<typeof fetch>()
       .mockResolvedValueOnce(new Response(null, { status: 409 }))
-      .mockResolvedValueOnce(new Response(null, { status: 200 }));
+      .mockResolvedValueOnce(blobHead());
 
     const results = await mirrorArchiveMedia({
       destination: "https://blossom.example", references: [reference("https://source.example/one.jpg")], signer, fetcher,
@@ -257,7 +261,7 @@ describe("mirrorArchiveMedia", () => {
   it("uses the canonical destination URL when a same-origin source names another blob", async () => {
     const fetcher = vi.fn<typeof fetch>()
       .mockResolvedValueOnce(new Response(null, { status: 409 }))
-      .mockResolvedValueOnce(new Response(null, { status: 200 }));
+      .mockResolvedValueOnce(blobHead());
 
     const results = await mirrorArchiveMedia({
       destination: "https://blossom.example",
@@ -270,6 +274,53 @@ describe("mirrorArchiveMedia", () => {
       verification: "already-present",
       destination_url: `https://blossom.example/${hash}`,
     });
+  });
+
+  it("preserves a matching destination URL from anywhere in a hash group", async () => {
+    const destinationSource = `https://blossom.example/${hash}.jpg`;
+    const fetcher = vi.fn<typeof fetch>()
+      .mockResolvedValueOnce(new Response(null, { status: 409 }))
+      .mockResolvedValueOnce(blobHead());
+
+    const results = await mirrorArchiveMedia({
+      destination: "https://blossom.example",
+      references: [reference("https://source.example/one.jpg"), reference(destinationSource)],
+      signer,
+      fetcher,
+    });
+
+    expect(results[0]).toMatchObject({
+      verification: "already-present",
+      destination_url: destinationSource,
+    });
+  });
+
+  it("rejects a generic HTML catch-all as proof that the blob exists", async () => {
+    const fetcher = vi.fn<typeof fetch>()
+      .mockResolvedValueOnce(new Response(null, { status: 405 }))
+      .mockResolvedValueOnce(blobHead(100, "text/html"));
+
+    await expect(mirrorArchiveMedia({
+      destination: "https://website.example",
+      references: [reference("https://source.example/one")],
+      signer,
+      fetcher,
+    })).rejects.toMatchObject({ code: "no-mirror-support" });
+  });
+
+  it("requires BUD-01 metadata before reporting a blob as already present", async () => {
+    const fetcher = vi.fn<typeof fetch>()
+      .mockResolvedValueOnce(new Response(null, { status: 409 }))
+      .mockResolvedValueOnce(new Response(null, { status: 200 }));
+
+    const results = await mirrorArchiveMedia({
+      destination: "https://blossom.example",
+      references: [reference("https://source.example/one")],
+      signer,
+      fetcher,
+    });
+
+    expect(results[0].verification).toBe("failed");
   });
 
   it("keeps a refused mirror failed when the destination does not serve the blob", async () => {
@@ -287,7 +338,7 @@ describe("mirrorArchiveMedia", () => {
   it("does not fail the canary when a refused blob is already present", async () => {
     const fetcher = vi.fn<typeof fetch>()
       .mockResolvedValueOnce(new Response(null, { status: 403 }))
-      .mockResolvedValueOnce(new Response(null, { status: 200 }));
+      .mockResolvedValueOnce(blobHead());
 
     await expect(mirrorArchiveMedia({
       destination: "https://blossom.example", references: [reference("https://source.example/one")], signer, fetcher,
@@ -297,7 +348,7 @@ describe("mirrorArchiveMedia", () => {
   it("keeps the canary for the first blob that is not already present", async () => {
     const fetcher = vi.fn<typeof fetch>()
       .mockResolvedValueOnce(new Response(null, { status: 403 }))
-      .mockResolvedValueOnce(new Response(null, { status: 200 }))
+      .mockResolvedValueOnce(blobHead())
       .mockResolvedValueOnce(new Response(null, { status: 403 }))
       .mockResolvedValueOnce(new Response(null, { status: 404 }));
 

--- a/src/lib/exit/mirrorClient.ts
+++ b/src/lib/exit/mirrorClient.ts
@@ -205,6 +205,16 @@ async function verifyReadback(
       : "The source did not advertise a hash, so the destination copy could not be compared." };
 }
 
+function isDestinationBlobUrl(sourceUrl: string, destination: string, sha256: string): boolean {
+  try {
+    const source = new URL(sourceUrl);
+    const pathHash = source.pathname.match(/^\/([a-f0-9]{64})(?:\.[^/]+)?$/i)?.[1];
+    return source.origin === new URL(destination).origin && pathHash?.toLowerCase() === sha256.toLowerCase();
+  } catch {
+    return false;
+  }
+}
+
 async function probeExistingBlob(
   references: MediaReference[],
   sha256: string,
@@ -219,7 +229,7 @@ async function probeExistingBlob(
     });
     if (!response.ok) return null;
     const sourceUrl = references[0].url;
-    const destinationUrl = new URL(sourceUrl).origin === new URL(options.destination).origin
+    const destinationUrl = isDestinationBlobUrl(sourceUrl, options.destination, sha256)
       ? sourceUrl
       : canonicalUrl;
     const size = response.headers.get("content-length");
@@ -281,7 +291,7 @@ async function mirrorOne(
 export async function mirrorArchiveMedia(options: MirrorOptions): Promise<MirrorResult[]> {
   const groups = groupReferences(options.references);
   const results: MirrorResult[] = [];
-  let mirrorAttempts = 0;
+  let copyAttempts = 0;
   for (const references of groups) {
     if (options.signal?.aborted) throw new DOMException("Mirror cancelled", "AbortError");
     const reference = references[0];
@@ -300,8 +310,10 @@ export async function mirrorArchiveMedia(options: MirrorOptions): Promise<Mirror
       };
     } else {
       const outcome = await mirrorOne(references, reference.sha256, options);
-      if (mirrorAttempts === 0 && outcome.destinationError) throw outcome.destinationError;
-      mirrorAttempts += 1;
+      if (outcome.result.verification !== "already-present") {
+        if (copyAttempts === 0 && outcome.destinationError) throw outcome.destinationError;
+        copyAttempts += 1;
+      }
       result = outcome.result;
     }
     results.push(result);

--- a/src/lib/exit/mirrorClient.ts
+++ b/src/lib/exit/mirrorClient.ts
@@ -215,6 +215,16 @@ function isDestinationBlobUrl(sourceUrl: string, destination: string, sha256: st
   }
 }
 
+function readBlobHeadSize(response: Response): number | null {
+  if (!response.ok) return null;
+  const contentType = response.headers.get("content-type")?.split(";", 1)[0].trim().toLowerCase();
+  if (!contentType || contentType === "text/html" || contentType === "application/xhtml+xml") return null;
+  const contentLength = response.headers.get("content-length");
+  if (contentLength === null || contentLength.trim() === "") return null;
+  const byteSize = Number(contentLength);
+  return Number.isSafeInteger(byteSize) && byteSize >= 0 ? byteSize : null;
+}
+
 async function probeExistingBlob(
   references: MediaReference[],
   sha256: string,
@@ -227,20 +237,19 @@ async function probeExistingBlob(
       signal: options.signal,
       redirect: "follow",
     });
-    if (!response.ok) return null;
+    const byteSize = readBlobHeadSize(response);
+    if (byteSize === null) return null;
     const sourceUrl = references[0].url;
-    const destinationUrl = isDestinationBlobUrl(sourceUrl, options.destination, sha256)
-      ? sourceUrl
-      : canonicalUrl;
-    const size = response.headers.get("content-length");
-    const byteSize = size === null ? null : Number(size);
+    const destinationUrl = references.find((reference) =>
+      isDestinationBlobUrl(reference.url, options.destination, sha256)
+    )?.url ?? canonicalUrl;
     return {
       references,
       source_url: sourceUrl,
       destination_url: destinationUrl,
       expected_sha256: sha256,
       destination_sha256: sha256.toLowerCase(),
-      byte_size: byteSize !== null && Number.isFinite(byteSize) ? byteSize : null,
+      byte_size: byteSize,
       verification: "already-present",
     };
   } catch {

--- a/src/lib/exit/mirrorClient.ts
+++ b/src/lib/exit/mirrorClient.ts
@@ -8,7 +8,7 @@ import { createBlossomUploadAuthHeader } from "@/lib/blossomAuth";
 import type { MediaReference } from "./archive";
 import { DestinationError } from "./destination";
 
-export type MirrorVerification = "descriptor-verified" | "unverified" | "hash-mismatch" | "failed" | "skipped";
+export type MirrorVerification = "descriptor-verified" | "already-present" | "unverified" | "hash-mismatch" | "failed" | "skipped";
 
 export interface MirrorResult {
   references: MediaReference[];
@@ -29,6 +29,7 @@ export interface MirrorProgress {
 
 export interface MirrorSummary {
   mirrored: number;
+  alreadyPresent: number;
   failed: number;
   skipped: number;
   unverified: number;
@@ -204,6 +205,40 @@ async function verifyReadback(
       : "The source did not advertise a hash, so the destination copy could not be compared." };
 }
 
+async function probeExistingBlob(
+  references: MediaReference[],
+  sha256: string,
+  options: MirrorOptions,
+): Promise<MirrorResult | null> {
+  const canonicalUrl = `${options.destination}/${sha256.toLowerCase()}`;
+  try {
+    const response = await (options.fetcher ?? fetch)(canonicalUrl, {
+      method: "HEAD",
+      signal: options.signal,
+      redirect: "follow",
+    });
+    if (!response.ok) return null;
+    const sourceUrl = references[0].url;
+    const destinationUrl = new URL(sourceUrl).origin === new URL(options.destination).origin
+      ? sourceUrl
+      : canonicalUrl;
+    const size = response.headers.get("content-length");
+    const byteSize = size === null ? null : Number(size);
+    return {
+      references,
+      source_url: sourceUrl,
+      destination_url: destinationUrl,
+      expected_sha256: sha256,
+      destination_sha256: sha256.toLowerCase(),
+      byte_size: byteSize !== null && Number.isFinite(byteSize) ? byteSize : null,
+      verification: "already-present",
+    };
+  } catch {
+    if (options.signal?.aborted) throw new DOMException("Mirror cancelled", "AbortError");
+    return null;
+  }
+}
+
 async function mirrorOne(
   references: MediaReference[],
   expectedHash: string,
@@ -211,15 +246,21 @@ async function mirrorOne(
 ): Promise<{ result: MirrorResult; destinationError: DestinationError | null }> {
   const response = await requestMirror(references, expectedHash, options);
   if (response instanceof DestinationError) {
+    const existing = await probeExistingBlob(references, expectedHash, options);
+    if (existing) return { result: existing, destinationError: null };
     return { result: failedResult(references, "failed", response.message), destinationError: response };
   }
   const destinationError = response.status === 429
     ? new DestinationError("rate-limited", `${options.destination} is rate limiting media copies. Try again later.`, 429)
     : destinationFailure(response.status, options.destination);
   if (destinationError) {
+    const existing = await probeExistingBlob(references, expectedHash, options);
+    if (existing) return { result: existing, destinationError: null };
     return { result: failedResult(references, "failed", destinationError.message), destinationError };
   }
   if (!response.ok) {
+    const existing = await probeExistingBlob(references, expectedHash, options);
+    if (existing) return { result: existing, destinationError: null };
     return {
       result: failedResult(references, "failed", `The destination refused this file (HTTP ${response.status}).${serverReason(response)}`),
       destinationError: null,
@@ -227,6 +268,8 @@ async function mirrorOne(
   }
   const descriptor = await readDescriptor(response);
   if (!descriptor) {
+    const existing = await probeExistingBlob(references, expectedHash, options);
+    if (existing) return { result: existing, destinationError: null };
     return { result: failedResult(references, "failed", "The destination returned an invalid blob descriptor."), destinationError: null };
   }
   if (expectedHash && descriptor.sha256 !== expectedHash.toLowerCase()) {
@@ -270,6 +313,7 @@ export async function mirrorArchiveMedia(options: MirrorOptions): Promise<Mirror
 export function summarizeMirrorResults(results: MirrorResult[]): MirrorSummary {
   return {
     mirrored: results.filter((result) => result.verification === "descriptor-verified").length,
+    alreadyPresent: results.filter((result) => result.verification === "already-present").length,
     failed: results.filter((result) => result.verification === "failed" || result.verification === "hash-mismatch").length,
     skipped: results.filter((result) => result.verification === "skipped").length,
     unverified: results.filter((result) => result.verification === "unverified").length,

--- a/src/lib/exit/relayPublisher.test.ts
+++ b/src/lib/exit/relayPublisher.test.ts
@@ -125,6 +125,27 @@ describe("publishArchiveEvents", () => {
     });
   });
 
+  it("publishes destination-hosted media unchanged on a repeat run", async () => {
+    const signer = makeSigner();
+    const relay = fakeRelay();
+    const video = makeEvent("1", { kind: 34236, content: DESTINATION_MEDIA, tags: [["url", DESTINATION_MEDIA]] });
+    const alreadyPresent = mirrorResult(DESTINATION_MEDIA, DESTINATION_MEDIA);
+    alreadyPresent.verification = "already-present";
+
+    const results = await publishArchiveEvents({
+      destination: RELAY,
+      events: [video],
+      mirrorResults: [alreadyPresent],
+      signer,
+      relayFactory: () => relay,
+    });
+
+    expect(results).toMatchObject([{ status: "unchanged", remaining_media_urls: 0 }]);
+    expect(relay.published).toEqual([video]);
+    expect(signer.signEvent).not.toHaveBeenCalled();
+    expect(summarizePublishResults(results).remainingMediaUrls).toBe(0);
+  });
+
   it("advances an addressable event changed only by reference rewriting", async () => {
     const signer = makeSigner();
     const relay = fakeRelay();

--- a/src/pages/ExitStartPage.test.tsx
+++ b/src/pages/ExitStartPage.test.tsx
@@ -183,7 +183,7 @@ describe("ExitStartPage", () => {
     await userEvent.click(screen.getByRole("button", { name: "Copy my media" }));
 
     await waitFor(() => expect(screen.getByText("Destination copy finished.")).toBeInTheDocument());
-    expect(screen.getByRole("status")).toHaveTextContent("1 mirrored, 0 failed, 0 skipped, and 0 unverified.");
+    expect(screen.getByRole("status")).toHaveTextContent("1 mirrored.");
     expect(screen.getByRole("heading", { name: "Move your posts" })).toBeInTheDocument();
     expect(screen.getByLabelText("Relay URL")).toBeInTheDocument();
   });


### PR DESCRIPTION
## Summary

- Report destination-hosted media as already there when a repeat copy request is refused but the content-addressed blob is readable.
- Carry that confirmed state into republishing so destination URLs remain unchanged and are not reported as still pointing to their original location.
- Keep completion summaries concise by omitting zero-valued categories.

> Avoid naming corporate partners, customers, or other sensitive external brands in this PR title or body. Use generic descriptors unless a maintainer explicitly approves the public reference.

## Motivation

- A repeated account migration could report every media copy as failed even though every blob was already intact at the selected destination. The same run then claimed those destination-hosted links still pointed to their original location.
- A content-addressed `HEAD` probe after a refused mirror request distinguishes an existing blob from a real copy failure without adding requests to successful first runs. Same-origin URLs retain their extensions, so unchanged events do not need to be re-signed.
- This deliberately does not change the broader inference used for media URLs that have no mirror result; #698 tracks that structural hardening separately.

## Related Issue

- Closes #694
- Follow-up: #698

## Testing

- [x] `npm run test`
- [ ] Manual verification completed

## Visuals

- [ ] UI change with screenshots/video attached
- [x] No visual layout change; user-facing status copy is covered by component tests
- [x] Visuals and text avoid sensitive external brand or partner names unless explicitly approved