### PR TITLE
fix(exit): report destination-hosted media accurately

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -237,13 +237,20 @@ copies. Hashless profile images are read through a five-megabyte streaming cap,
 hashed in the browser, and sent through BUD-02 `PUT /upload`; other hashless
 media and generated HLS manifests are skipped. Source-advertised hashes,
 browser-computed upload hashes, descriptor hashes, and redirect-aware `HEAD`
-readback results remain distinct.
+readback results remain distinct. Confirmed copy results also establish
+the delivery origins used by republish summaries. Those origins come from the
+destination-provided copy descriptor because Blossom servers may deliver through
+a separate CDN; HTTPS and readback are validated, but ownership by the typed
+destination is not independently established. The summary therefore trusts the
+chosen destination's reported delivery origin. An unconfirmed result for a
+specific URL remains conservative even when another copy confirms that origin.
 
 After mirroring finishes, the page can republish durable public events to one
 custom `wss://` relay. Migration writes use a standalone authenticated relay
 session instead of the app's `NPool`; the same session primitive also publishes
-the discovery pointers described below. Only media with
-descriptor-and-readback verification is rewritten.
+the discovery pointers described below. Only media with a confirmed destination
+result is rewritten, while already-hosted destination URLs affect reporting
+without changing or re-signing the exported event.
 Changed replaceable and addressable events are re-signed with the move run's
 timestamp, falling back to one second past the original when that original is
 already newer. The migrated copy therefore supersedes the old media references

--- a/src/lib/exit/eventRewrite.test.ts
+++ b/src/lib/exit/eventRewrite.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from "vitest";
 
 import type { MirrorResult } from "./mirrorClient";
 import {
-  buildDestinationUrlMap,
+  buildDestinationRewrite,
   referencedEventIds,
   republishCreatedAt,
   republishSkipReason,
@@ -41,20 +41,34 @@ function mirror(verification: MirrorResult["verification"] = "descriptor-verifie
   };
 }
 
-describe("buildDestinationUrlMap", () => {
-  it("uses confirmed destination results and maps every grouped source", () => {
+describe("buildDestinationRewrite", () => {
+  it("classifies confirmed mappings, origins, and unconfirmed source URLs", () => {
     const verified = mirror();
     verified.references.push({ event_id: "e".repeat(64), tag: "thumb", url: `${SOURCE}?thumb=1`, sha256: "c".repeat(64) });
     const alreadyPresent = mirror("already-present");
     alreadyPresent.references = [{ event_id: ID, tag: "image", url: DESTINATION, sha256: "c".repeat(64) }];
     alreadyPresent.source_url = DESTINATION;
     alreadyPresent.destination_url = DESTINATION;
-    const map = buildDestinationUrlMap([verified, alreadyPresent, mirror("unverified"), mirror("hash-mismatch")]);
-    expect([...map.entries()]).toEqual([
+    const unverified = mirror("unverified");
+    unverified.references = [{ event_id: ID, tag: "url", url: `${SOURCE}?unverified=1`, sha256: "c".repeat(64) }];
+    const mismatch = mirror("hash-mismatch");
+    mismatch.references = [{ event_id: ID, tag: "url", url: `${SOURCE}?mismatch=1`, sha256: "c".repeat(64) }];
+    const rewrite = buildDestinationRewrite([verified, alreadyPresent, unverified, mismatch]);
+
+    expect([...rewrite.urls.entries()]).toEqual([
       [SOURCE, DESTINATION],
       [`${SOURCE}?thumb=1`, DESTINATION],
       [DESTINATION, DESTINATION],
     ]);
+    expect([...rewrite.confirmedOrigins]).toEqual(["https://blossom.example"]);
+    expect([...rewrite.unconfirmedUrls]).toEqual([`${SOURCE}?unverified=1`, `${SOURCE}?mismatch=1`]);
+  });
+
+  it("skips malformed confirmed destination origins", () => {
+    const verified = mirror();
+    verified.destination_url = "not a URL";
+
+    expect(buildDestinationRewrite([verified]).confirmedOrigins).toEqual(new Set());
   });
 
   it("uses verified browser uploads", () => {
@@ -68,14 +82,26 @@ describe("buildDestinationUrlMap", () => {
       expected_sha256: null,
     };
 
-    expect(buildDestinationUrlMap([uploaded])).toEqual(new Map([[source, destination]]));
+    expect(buildDestinationRewrite([uploaded]).urls).toEqual(new Map([[source, destination]]));
   });
+
+  it.each<MirrorResult["verification"]>(["failed", "skipped", "hash-mismatch", "unverified"])(
+    "keeps %s references unconfirmed",
+    (verification) => {
+      const result = mirror(verification);
+      const rewrite = buildDestinationRewrite([result]);
+
+      expect(rewrite.urls).toEqual(new Map());
+      expect(rewrite.confirmedOrigins).toEqual(new Set());
+      expect(rewrite.unconfirmedUrls).toEqual(new Set([SOURCE]));
+    },
+  );
 });
 
 describe("rewriteEventMedia", () => {
   it("rewrites direct tags and exact content occurrences while preserving event fields", () => {
     const original = event();
-    const result = rewriteEventMedia(original, new Map([[SOURCE, DESTINATION]]));
+    const result = rewriteEventMedia(original, buildDestinationRewrite([mirror()]));
     expect(result).toEqual({
       changed: true,
       remainingMediaUrls: 0,
@@ -98,7 +124,10 @@ describe("rewriteEventMedia", () => {
         ["imeta", "url", pairSource, "m", "video/mp4", "fallback", SOURCE],
       ],
     });
-    const result = rewriteEventMedia(original, new Map([[SOURCE, DESTINATION], [pairSource, `${DESTINATION}?pair=1`]]));
+    const second = mirror();
+    second.references = [{ event_id: ID, tag: "image", url: pairSource, sha256: "c".repeat(64) }];
+    second.destination_url = `${DESTINATION}?pair=1`;
+    const result = rewriteEventMedia(original, buildDestinationRewrite([mirror(), second]));
     expect(result.template.tags).toEqual([
       ["imeta", `url ${DESTINATION}`, "m video/mp4", `image ${DESTINATION}?pair=1`, `x ${"c".repeat(64)}`],
       ["imeta", "url", `${DESTINATION}?pair=1`, "m", "video/mp4", "fallback", DESTINATION],
@@ -106,17 +135,90 @@ describe("rewriteEventMedia", () => {
   });
 
   it("leaves unmapped URLs unchanged and reports them", () => {
-    const result = rewriteEventMedia(event({ content: "unchanged" }), new Map());
+    const result = rewriteEventMedia(event({ content: "unchanged" }), buildDestinationRewrite([]));
     expect(result.changed).toBe(false);
     expect(result.remainingMediaUrls).toBe(1);
   });
 
   it("treats an identity mapping as unchanged with no remaining media", () => {
     const original = event({ content: DESTINATION, tags: [["url", DESTINATION]] });
-    const result = rewriteEventMedia(original, new Map([[DESTINATION, DESTINATION]]));
+    const alreadyPresent = mirror("already-present");
+    alreadyPresent.references = [{ event_id: ID, tag: "url", url: DESTINATION, sha256: "c".repeat(64) }];
+    alreadyPresent.source_url = DESTINATION;
+    alreadyPresent.destination_url = DESTINATION;
+    const result = rewriteEventMedia(original, buildDestinationRewrite([alreadyPresent]));
 
     expect(result.changed).toBe(false);
     expect(result.remainingMediaUrls).toBe(0);
+  });
+
+  it("leaves destination-origin media with no mirror reference unchanged and confirmed", () => {
+    const original = event({ content: DESTINATION, tags: [["url", DESTINATION]] });
+    const result = rewriteEventMedia(original, buildDestinationRewrite([mirror()]));
+
+    expect(result.changed).toBe(false);
+    expect(result.remainingMediaUrls).toBe(0);
+    expect(result.template.tags).toEqual(original.tags);
+  });
+
+  it("counts destination-looking media when no result confirms its origin", () => {
+    const original = event({ content: DESTINATION, tags: [["url", DESTINATION]] });
+    const result = rewriteEventMedia(original, buildDestinationRewrite([]));
+
+    expect(result.changed).toBe(false);
+    expect(result.remainingMediaUrls).toBe(1);
+  });
+
+  it("counts an unconfirmed URL even when another result confirms its origin", () => {
+    const unconfirmedUrl = `${DESTINATION}?unconfirmed=1`;
+    const unverified = mirror("unverified");
+    unverified.references = [{ event_id: ID, tag: "url", url: unconfirmedUrl, sha256: "c".repeat(64) }];
+    const original = event({ content: unconfirmedUrl, tags: [["url", unconfirmedUrl]] });
+    const result = rewriteEventMedia(original, buildDestinationRewrite([mirror(), unverified]));
+
+    expect(result.remainingMediaUrls).toBe(1);
+  });
+
+  it("lets an actual remapping win when the same URL also has an unconfirmed result", () => {
+    const unverified = mirror("unverified");
+    const result = rewriteEventMedia(event({ content: "unchanged" }), buildDestinationRewrite([mirror(), unverified]));
+
+    expect(result.changed).toBe(true);
+    expect(result.remainingMediaUrls).toBe(0);
+  });
+
+  it("recognizes the confirmed descriptor origin instead of the source origin", () => {
+    const cdnDestination = `https://cdn.example/${"c".repeat(64)}`;
+    const verified = mirror();
+    verified.destination_url = cdnDestination;
+    const original = event({ content: cdnDestination, tags: [["url", cdnDestination]] });
+    const result = rewriteEventMedia(original, buildDestinationRewrite([verified]));
+
+    expect(result.changed).toBe(false);
+    expect(result.remainingMediaUrls).toBe(0);
+  });
+
+  it("counts all direct media tags and both imeta encodings by occurrence", () => {
+    const original = event({
+      content: "unchanged",
+      tags: [
+        ["url", DESTINATION],
+        ["image", DESTINATION],
+        ["thumb", DESTINATION],
+        ["thumbnail", DESTINATION],
+        ["imeta", `url ${DESTINATION}`, `image ${DESTINATION}`, `fallback ${DESTINATION}`],
+        ["imeta", "url", DESTINATION, "thumb", DESTINATION, "thumbnail", DESTINATION],
+      ],
+    });
+
+    expect(rewriteEventMedia(original, buildDestinationRewrite([])).remainingMediaUrls).toBe(10);
+    expect(rewriteEventMedia(original, buildDestinationRewrite([mirror()])).remainingMediaUrls).toBe(0);
+  });
+
+  it("counts malformed and relative media URLs conservatively", () => {
+    const original = event({ content: "unchanged", tags: [["url", "not a URL"], ["image", "/relative.mp4"]] });
+
+    expect(rewriteEventMedia(original, buildDestinationRewrite([mirror()])).remainingMediaUrls).toBe(2);
   });
 
   it("rewrites mapped profile media and reports unmapped profile media", () => {
@@ -127,7 +229,7 @@ describe("rewriteEventMedia", () => {
       tags: [],
     });
 
-    const result = rewriteEventMedia(original, new Map([[SOURCE, DESTINATION]]));
+    const result = rewriteEventMedia(original, buildDestinationRewrite([mirror()]));
 
     expect(result.changed).toBe(true);
     expect(JSON.parse(result.template.content)).toEqual({ picture: DESTINATION, banner });
@@ -137,11 +239,18 @@ describe("rewriteEventMedia", () => {
   it("rewrites a kind-0 picture after a verified browser upload", () => {
     const source = "https://storage.googleapis.com/archive/avatar.jpg";
     const destination = "https://blossom.example/uploaded-avatar";
+    const uploaded = {
+      ...mirror("upload-verified"),
+      references: [{ event_id: ID, tag: "picture", url: source, sha256: null }],
+      source_url: source,
+      destination_url: destination,
+      expected_sha256: null,
+    };
     const result = rewriteEventMedia(event({
       kind: 0,
       content: JSON.stringify({ name: "Creator", picture: source }),
       tags: [],
-    }), new Map([[source, destination]]));
+    }), buildDestinationRewrite([uploaded]));
 
     expect(JSON.parse(result.template.content)).toMatchObject({ picture: destination });
     expect(result.remainingMediaUrls).toBe(0);
@@ -151,21 +260,45 @@ describe("rewriteEventMedia", () => {
     const source = "https://storage.googleapis.com/archive/avatar.jpg";
     const destination = "https://blossom.example/uploaded-avatar";
     const content = `{"name":"Creator","picture":"${source.replace(/\//g, "\\/")}"}`;
+    const uploaded = {
+      ...mirror("upload-verified"),
+      references: [{ event_id: ID, tag: "picture", url: source, sha256: null }],
+      source_url: source,
+      destination_url: destination,
+      expected_sha256: null,
+    };
 
-    const result = rewriteEventMedia(event({ kind: 0, content, tags: [] }), new Map([[source, destination]]));
+    const result = rewriteEventMedia(
+      event({ kind: 0, content, tags: [] }),
+      buildDestinationRewrite([uploaded]),
+    );
 
     expect(JSON.parse(result.template.content)).toEqual({ name: "Creator", picture: destination });
     expect(result.changed).toBe(true);
     expect(result.remainingMediaUrls).toBe(0);
   });
 
+  it("leaves unreferenced destination-origin profile media unchanged and confirmed", () => {
+    const original = event({
+      kind: 0,
+      content: JSON.stringify({ picture: DESTINATION }),
+      tags: [],
+    });
+
+    const result = rewriteEventMedia(original, buildDestinationRewrite([mirror()]));
+
+    expect(result.changed).toBe(false);
+    expect(result.template.content).toBe(original.content);
+    expect(result.remainingMediaUrls).toBe(0);
+  });
+
   it("ignores malformed and non-string profile media while reporting", () => {
-    expect(rewriteEventMedia(event({ kind: 0, content: "{", tags: [] }), new Map()).remainingMediaUrls).toBe(0);
+    expect(rewriteEventMedia(event({ kind: 0, content: "{", tags: [] }), buildDestinationRewrite([])).remainingMediaUrls).toBe(0);
     expect(rewriteEventMedia(event({
       kind: 0,
       content: JSON.stringify({ picture: 42, banner: "" }),
       tags: [],
-    }), new Map()).remainingMediaUrls).toBe(0);
+    }), buildDestinationRewrite([])).remainingMediaUrls).toBe(0);
   });
 
   it("does not count a non-URL banner such as a theme color as remaining media", () => {
@@ -173,7 +306,7 @@ describe("rewriteEventMedia", () => {
       kind: 0,
       content: JSON.stringify({ picture: SOURCE, banner: "0x27c58b" }),
       tags: [],
-    }), new Map());
+    }), buildDestinationRewrite([]));
 
     expect(result.remainingMediaUrls).toBe(1);
   });

--- a/src/lib/exit/eventRewrite.ts
+++ b/src/lib/exit/eventRewrite.ts
@@ -14,24 +14,63 @@ export interface EventRewrite {
   remainingMediaUrls: number;
 }
 
+export interface DestinationRewrite {
+  urls: Map<string, string>;
+  confirmedOrigins: Set<string>;
+  unconfirmedUrls: Set<string>;
+}
+
+interface MediaTagField {
+  encoding: "direct" | "spaced" | "alternating";
+  index: number;
+  key: string;
+  url: string;
+}
+
 // 4 is a NIP-04 direct message; 13 is the NIP-59 seal, which carries the
 // sender's real pubkey and so is the one of these an owner export can return;
 // 14 and 15 are NIP-17 chat and file messages; 1059 is the NIP-59 gift wrap.
 const PRIVATE_MESSAGE_KINDS = new Set([4, 13, 14, 15, 1059]);
 const DESTRUCTIVE_KINDS = new Set([5, 62]);
 
-export function buildDestinationUrlMap(results: MirrorResult[]): Map<string, string> {
+export function isConfirmedDestinationCopy(
+  result: MirrorResult,
+): result is MirrorResult & { destination_url: string } {
+  return (
+    ["descriptor-verified", "upload-verified", "already-present"].includes(result.verification)
+    && typeof result.destination_url === "string"
+    && result.destination_url.trim().length > 0
+  );
+}
+
+function originOf(value: string): string | null {
+  try {
+    return new URL(value).origin;
+  } catch {
+    return null;
+  }
+}
+
+export function buildDestinationRewrite(results: MirrorResult[]): DestinationRewrite {
   const urls = new Map<string, string>();
+  const confirmedOrigins = new Set<string>();
+  const unconfirmedUrls = new Set<string>();
   for (const result of results) {
-    if (
-      !["descriptor-verified", "upload-verified", "already-present"].includes(result.verification)
-      || !result.destination_url
-    ) continue;
-    for (const reference of result.references) {
-      urls.set(reference.url, result.destination_url);
+    if (isConfirmedDestinationCopy(result)) {
+      // Use the reported delivery origin because a Blossom server may return a
+      // separate CDN URL; the summary trusts that destination-provided origin.
+      const origin = originOf(result.destination_url);
+      if (origin) confirmedOrigins.add(origin);
+      for (const reference of result.references) {
+        urls.set(reference.url, result.destination_url);
+      }
+    } else {
+      for (const reference of result.references) {
+        unconfirmedUrls.add(reference.url);
+      }
     }
   }
-  return urls;
+  return { urls, confirmedOrigins, unconfirmedUrls };
 }
 
 export function republishSkipReason(kind: number): string | null {
@@ -47,8 +86,45 @@ export function republishCreatedAt(event: NostrEvent, now: number): number {
     : event.created_at;
 }
 
-function replaceExact(value: string, urls: ReadonlyMap<string, string>): string {
-  return urls.get(value) ?? value;
+function mediaTagFields(tag: string[]): MediaTagField[] {
+  if (URL_TAGS.has(tag[0]) && tag[1]) {
+    return [{ encoding: "direct", index: 1, key: tag[0], url: tag[1] }];
+  }
+  if (tag[0] !== "imeta") return [];
+  if (tag[1]?.includes(" ")) {
+    return tag.flatMap((value, index) => {
+      if (index === 0) return [];
+      const [key, ...body] = value.split(" ");
+      const url = body.join(" ");
+      return IMETA_URL_KEYS.has(key) && url ? [{ encoding: "spaced" as const, index, key, url }] : [];
+    });
+  }
+  const fields: MediaTagField[] = [];
+  for (let index = 1; index < tag.length; index += 2) {
+    const key = tag[index];
+    const url = tag[index + 1];
+    if (IMETA_URL_KEYS.has(key) && url) {
+      fields.push({ encoding: "alternating", index: index + 1, key, url });
+    }
+  }
+  return fields;
+}
+
+function rewriteMediaTag(tag: string[], fields: MediaTagField[], urls: ReadonlyMap<string, string>): string[] {
+  const rewritten = [...tag];
+  for (const field of fields) {
+    const replacement = urls.get(field.url);
+    if (!replacement) continue;
+    rewritten[field.index] = field.encoding === "spaced" ? `${field.key} ${replacement}` : replacement;
+  }
+  return rewritten;
+}
+
+function isRemainingMediaUrl(url: string, rewrite: DestinationRewrite): boolean {
+  if (rewrite.urls.has(url)) return false;
+  if (rewrite.unconfirmedUrls.has(url)) return true;
+  const origin = originOf(url);
+  return origin === null || !rewrite.confirmedOrigins.has(origin);
 }
 
 function rewriteProfileContent(event: NostrEvent, urls: ReadonlyMap<string, string>): string {
@@ -58,64 +134,21 @@ function rewriteProfileContent(event: NostrEvent, urls: ReadonlyMap<string, stri
   const metadata = JSON.parse(event.content) as Record<string, unknown>;
   let changed = false;
   for (const { key, url } of references) {
-    const replacement = replaceExact(url, urls);
-    if (replacement === url) continue;
+    const replacement = urls.get(url);
+    if (!replacement || replacement === url) continue;
     metadata[key] = replacement;
     changed = true;
   }
   return changed ? JSON.stringify(metadata) : event.content;
 }
 
-function rewriteImeta(tag: string[], urls: ReadonlyMap<string, string>): string[] {
-  if (tag[1]?.includes(" ")) {
-    return tag.map((value, index) => {
-      if (index === 0) return value;
-      const [key, ...body] = value.split(" ");
-      if (!IMETA_URL_KEYS.has(key)) return value;
-      const original = body.join(" ");
-      const replacement = replaceExact(original, urls);
-      return replacement === original ? value : `${key} ${replacement}`;
-    });
-  }
-
-  return tag.map((value, index) => {
-    if (index < 2 || index % 2 !== 0) return value;
-    const key = tag[index - 1];
-    return IMETA_URL_KEYS.has(key) ? replaceExact(value, urls) : value;
-  });
-}
-
-function countRemainingMediaUrls(event: NostrEvent, urls: ReadonlyMap<string, string>): number {
-  let count = 0;
-  for (const tag of event.tags) {
-    if (URL_TAGS.has(tag[0]) && tag[1] && !urls.has(tag[1])) count += 1;
-    if (tag[0] !== "imeta") continue;
-    if (tag[1]?.includes(" ")) {
-      count += tag.slice(1).filter((value) => {
-        const [key, ...body] = value.split(" ");
-        return IMETA_URL_KEYS.has(key) && body.length > 0 && !urls.has(body.join(" "));
-      }).length;
-    } else {
-      for (let index = 1; index < tag.length; index += 2) {
-        if (IMETA_URL_KEYS.has(tag[index]) && tag[index + 1] && !urls.has(tag[index + 1])) count += 1;
-      }
-    }
-  }
-  count += profileMediaUrls(event).filter(({ url }) => !urls.has(url)).length;
-  return count;
-}
-
-export function rewriteEventMedia(event: NostrEvent, urls: ReadonlyMap<string, string>): EventRewrite {
+export function rewriteEventMedia(event: NostrEvent, rewrite: DestinationRewrite): EventRewrite {
   const tags = event.tags.map((tag) => {
-    if (URL_TAGS.has(tag[0]) && tag[1]) {
-      const rewritten = [...tag];
-      rewritten[1] = replaceExact(tag[1], urls);
-      return rewritten;
-    }
-    return tag[0] === "imeta" ? rewriteImeta(tag, urls) : [...tag];
+    const fields = mediaTagFields(tag);
+    return fields.length > 0 ? rewriteMediaTag(tag, fields, rewrite.urls) : [...tag];
   });
-  let content = rewriteProfileContent(event, urls);
-  for (const [source, destination] of urls) {
+  let content = rewriteProfileContent(event, rewrite.urls);
+  for (const [source, destination] of rewrite.urls) {
     content = content.split(source).join(destination);
   }
   const changed = content !== event.content || tags.some((tag, index) =>
@@ -124,7 +157,10 @@ export function rewriteEventMedia(event: NostrEvent, urls: ReadonlyMap<string, s
   return {
     template: { kind: event.kind, created_at: event.created_at, content, tags },
     changed,
-    remainingMediaUrls: countRemainingMediaUrls(event, urls),
+    remainingMediaUrls: event.tags
+      .flatMap(mediaTagFields)
+      .filter((field) => isRemainingMediaUrl(field.url, rewrite)).length
+      + profileMediaUrls(event).filter(({ url }) => isRemainingMediaUrl(url, rewrite)).length,
   };
 }
 

--- a/src/lib/exit/relayPublisher.test.ts
+++ b/src/lib/exit/relayPublisher.test.ts
@@ -169,6 +169,34 @@ describe("publishArchiveEvents", () => {
     expect(summarizePublishResults(results).remainingMediaUrls).toBe(0);
   });
 
+  it("publishes unreferenced destination-origin media unchanged without signing", async () => {
+    const signer = makeSigner();
+    const relay = fakeRelay();
+    const unreferencedDestination = `https://blossom.example/${"d".repeat(64)}`;
+    const video = makeEvent("1", {
+      kind: 34236,
+      content: unreferencedDestination,
+      tags: [
+        ["url", unreferencedDestination],
+        ["imeta", `image ${unreferencedDestination}`],
+      ],
+    });
+
+    const results = await publishArchiveEvents({
+      destination: RELAY,
+      events: [video],
+      mirrorResults: [mirrorResult()],
+      signer,
+      relayFactory: () => relay,
+    });
+
+    expect(results).toMatchObject([{ status: "unchanged", remaining_media_urls: 0 }]);
+    expect(summarizePublishResults(results).remainingMediaUrls).toBe(0);
+    expect(signer.signEvent).not.toHaveBeenCalled();
+    expect(relay.published).toEqual([video]);
+    expect(relay.published[0].id).toBe(video.id);
+  });
+
   it("advances an addressable event changed only by reference rewriting", async () => {
     const signer = makeSigner();
     const relay = fakeRelay();

--- a/src/lib/exit/relayPublisher.ts
+++ b/src/lib/exit/relayPublisher.ts
@@ -4,7 +4,7 @@
 import type { NostrEvent, NostrSigner } from "@nostrify/nostrify";
 
 import {
-  buildDestinationUrlMap,
+  buildDestinationRewrite,
   referencedEventIds,
   republishCreatedAt,
   republishSkipReason,
@@ -74,7 +74,7 @@ async function prepareEvents(options: PublishArchiveOptions, now: number, cutoff
   results: PublishResult[];
 }> {
   const originals = new Map(options.events.map((event) => [event.id, event]));
-  const destinationUrls = buildDestinationUrlMap(options.mirrorResults);
+  const destinationRewrite = buildDestinationRewrite(options.mirrorResults);
   const replacements = new Map<string, NostrEvent>();
   const prepared = new Map<string, PreparedEvent>();
   const settled = new Set<string>();
@@ -124,7 +124,7 @@ async function prepareEvents(options: PublishArchiveOptions, now: number, cutoff
       return null;
     }
 
-    const media = rewriteEventMedia(original, destinationUrls);
+    const media = rewriteEventMedia(original, destinationRewrite);
     const timestamp = redateArchivedVideo(original, media.template, now, cutoff);
     const references = rewriteEventReferences(timestamp.template, replacements);
     const changed = media.changed || references.changed || timestamp.redated;


### PR DESCRIPTION
## Summary

- Build one destination rewrite model from confirmed copy results, their reported delivery origins, and explicitly unconfirmed source URLs.
- Count media as remaining only when it was not remapped and is not already hosted on a confirmed delivery origin.
- Share direct-tag and imeta parsing between rewriting and counting so unchanged signed events remain byte-for-byte intact.
- Document that republish summaries trust the chosen destination's reported delivery origin after HTTPS and readback validation.

## Motivation

A migration could claim that media still pointed to its original location when an event already used the selected destination but that URL had no mirror result. Descriptor-derived origins are the reliable signal because a valid copy response may use a separate delivery origin, while explicit failed or unverified results remain conservative.

The reported origin is not independently proven to belong to the typed destination. Accepting it is a deliberate trust boundary consistent with choosing that destination for the copy itself, and the architecture now records that assumption.

## Related Issue

- Closes #698
- Closes #704

## Testing

- [x] `npx vitest run src/lib/exit/eventRewrite.test.ts`
- [x] `npm run test`
- [ ] Manual verification completed

## Visuals

- [ ] UI change with screenshots/video attached
- [x] No visual change
- [x] Visuals and text avoid sensitive external brand or partner names unless explicitly approved
