### PR TITLE
fix(exit): move hashless profile images to the destination

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -233,9 +233,11 @@ normalize to the domain root because BUD-01 serves every Blossom endpoint there.
 The first eligible
 copy is the destination capability canary, kind-24242 upload authorization is
 scoped to one advertised hash, and later file failures do not stop the remaining
-copies. Sources without an advertised hash and generated HLS manifests are
-skipped. Descriptor hashes and redirect-aware `HEAD` readback results remain
-distinct from independent byte hashing.
+copies. Hashless profile images are read through a five-megabyte streaming cap,
+hashed in the browser, and sent through BUD-02 `PUT /upload`; other hashless
+media and generated HLS manifests are skipped. Source-advertised hashes,
+browser-computed upload hashes, descriptor hashes, and redirect-aware `HEAD`
+readback results remain distinct.
 
 After mirroring finishes, the page can republish durable public events to one
 custom `wss://` relay. Migration writes use a standalone authenticated relay

--- a/src/components/exit/DestinationForm.test.tsx
+++ b/src/components/exit/DestinationForm.test.tsx
@@ -4,6 +4,20 @@ import { describe, expect, it, vi } from "vitest";
 import { DestinationForm } from "./DestinationForm";
 
 describe("DestinationForm", () => {
+  it("explains the bounded browser upload path for hashless profile images", () => {
+    render(
+      <DestinationForm
+        state="idle"
+        progress={null}
+        summary={null}
+        failure={null}
+        onStart={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText(/your browser verifies and uploads the image directly/i)).toBeInTheDocument();
+  });
+
   it("describes already-present progress and hides zero summary categories", () => {
     render(
       <DestinationForm

--- a/src/components/exit/DestinationForm.tsx
+++ b/src/components/exit/DestinationForm.tsx
@@ -22,6 +22,7 @@ interface DestinationFormProps {
 function progressLabel(progress: MirrorProgress): string {
   switch (progress.result.verification) {
     case "descriptor-verified": return "Mirrored and confirmed by the destination";
+    case "upload-verified": return "Uploaded and confirmed by the destination";
     case "already-present": return "Already at the destination";
     case "unverified": return "Mirrored without confirmed readback";
     case "hash-mismatch": return "Destination reported a different hash";
@@ -69,7 +70,7 @@ export function DestinationForm({ state, progress, summary, failure, onStart }: 
       </CardHeader>
       <CardContent className="space-y-5">
         <p className="text-base leading-relaxed text-muted-foreground">
-          Enter a Blossom server you trust. The server copies each original file directly from its current URL—your browser never re-uploads the media.
+          Enter a Blossom server you trust. It copies content-addressed media from the source. For hashless profile images, your browser verifies and uploads the image directly.
         </p>
         <div className="space-y-2">
           <label htmlFor="blossom-destination" className="text-sm font-semibold text-foreground">Blossom server URL</label>

--- a/src/lib/exit/eventRewrite.test.ts
+++ b/src/lib/exit/eventRewrite.test.ts
@@ -147,6 +147,18 @@ describe("rewriteEventMedia", () => {
     expect(result.remainingMediaUrls).toBe(0);
   });
 
+  it("rewrites mapped profile media when JSON escapes URL slashes", () => {
+    const source = "https://storage.googleapis.com/archive/avatar.jpg";
+    const destination = "https://blossom.example/uploaded-avatar";
+    const content = `{"name":"Creator","picture":"${source.replace(/\//g, "\\/")}"}`;
+
+    const result = rewriteEventMedia(event({ kind: 0, content, tags: [] }), new Map([[source, destination]]));
+
+    expect(JSON.parse(result.template.content)).toEqual({ name: "Creator", picture: destination });
+    expect(result.changed).toBe(true);
+    expect(result.remainingMediaUrls).toBe(0);
+  });
+
   it("ignores malformed and non-string profile media while reporting", () => {
     expect(rewriteEventMedia(event({ kind: 0, content: "{", tags: [] }), new Map()).remainingMediaUrls).toBe(0);
     expect(rewriteEventMedia(event({

--- a/src/lib/exit/eventRewrite.test.ts
+++ b/src/lib/exit/eventRewrite.test.ts
@@ -56,6 +56,20 @@ describe("buildDestinationUrlMap", () => {
       [DESTINATION, DESTINATION],
     ]);
   });
+
+  it("uses verified browser uploads", () => {
+    const source = "https://storage.googleapis.com/archive/avatar.jpg";
+    const destination = "https://blossom.example/uploaded-avatar";
+    const uploaded = {
+      ...mirror("upload-verified"),
+      references: [{ event_id: ID, tag: "picture", url: source, sha256: null }],
+      source_url: source,
+      destination_url: destination,
+      expected_sha256: null,
+    };
+
+    expect(buildDestinationUrlMap([uploaded])).toEqual(new Map([[source, destination]]));
+  });
 });
 
 describe("rewriteEventMedia", () => {
@@ -118,6 +132,19 @@ describe("rewriteEventMedia", () => {
     expect(result.changed).toBe(true);
     expect(JSON.parse(result.template.content)).toEqual({ picture: DESTINATION, banner });
     expect(result.remainingMediaUrls).toBe(1);
+  });
+
+  it("rewrites a kind-0 picture after a verified browser upload", () => {
+    const source = "https://storage.googleapis.com/archive/avatar.jpg";
+    const destination = "https://blossom.example/uploaded-avatar";
+    const result = rewriteEventMedia(event({
+      kind: 0,
+      content: JSON.stringify({ name: "Creator", picture: source }),
+      tags: [],
+    }), new Map([[source, destination]]));
+
+    expect(JSON.parse(result.template.content)).toMatchObject({ picture: destination });
+    expect(result.remainingMediaUrls).toBe(0);
   });
 
   it("ignores malformed and non-string profile media while reporting", () => {

--- a/src/lib/exit/eventRewrite.ts
+++ b/src/lib/exit/eventRewrite.ts
@@ -24,7 +24,7 @@ export function buildDestinationUrlMap(results: MirrorResult[]): Map<string, str
   const urls = new Map<string, string>();
   for (const result of results) {
     if (
-      (result.verification !== "descriptor-verified" && result.verification !== "already-present")
+      !["descriptor-verified", "upload-verified", "already-present"].includes(result.verification)
       || !result.destination_url
     ) continue;
     for (const reference of result.references) {

--- a/src/lib/exit/eventRewrite.ts
+++ b/src/lib/exit/eventRewrite.ts
@@ -51,6 +51,21 @@ function replaceExact(value: string, urls: ReadonlyMap<string, string>): string 
   return urls.get(value) ?? value;
 }
 
+function rewriteProfileContent(event: NostrEvent, urls: ReadonlyMap<string, string>): string {
+  const references = profileMediaUrls(event);
+  if (references.length === 0) return event.content;
+
+  const metadata = JSON.parse(event.content) as Record<string, unknown>;
+  let changed = false;
+  for (const { key, url } of references) {
+    const replacement = replaceExact(url, urls);
+    if (replacement === url) continue;
+    metadata[key] = replacement;
+    changed = true;
+  }
+  return changed ? JSON.stringify(metadata) : event.content;
+}
+
 function rewriteImeta(tag: string[], urls: ReadonlyMap<string, string>): string[] {
   if (tag[1]?.includes(" ")) {
     return tag.map((value, index) => {
@@ -99,7 +114,7 @@ export function rewriteEventMedia(event: NostrEvent, urls: ReadonlyMap<string, s
     }
     return tag[0] === "imeta" ? rewriteImeta(tag, urls) : [...tag];
   });
-  let content = event.content;
+  let content = rewriteProfileContent(event, urls);
   for (const [source, destination] of urls) {
     content = content.split(source).join(destination);
   }

--- a/src/lib/exit/mediaBlob.test.ts
+++ b/src/lib/exit/mediaBlob.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { fetchAndHashBlob, isDivineMediaOrigin } from "./mediaBlob";
+
+const helloHash = "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824";
+
+describe("fetchAndHashBlob", () => {
+  it("returns bounded bytes and their SHA-256", async () => {
+    const result = await fetchAndHashBlob({
+      url: "https://example.com/avatar.jpg",
+      fetcher: vi.fn(async () => new Response("hello", {
+        headers: { "content-type": "image/jpeg", "content-length": "5" },
+      })),
+      maxBytes: 5,
+    });
+
+    expect(result).toMatchObject({ computedSha256: helloHash, contentType: "image/jpeg" });
+    expect(result.bytes).toEqual(new TextEncoder().encode("hello"));
+  });
+
+  it("rejects advertised and streamed bodies over the limit", async () => {
+    await expect(fetchAndHashBlob({
+      url: "https://example.com/large.jpg",
+      fetcher: vi.fn(async () => new Response("hello", { headers: { "content-length": "6" } })),
+      maxBytes: 5,
+    })).rejects.toThrow("larger than 5 bytes");
+
+    await expect(fetchAndHashBlob({
+      url: "https://example.com/large.jpg",
+      fetcher: vi.fn(async () => new Response("hello!")),
+      maxBytes: 5,
+    })).rejects.toThrow("larger than 5 bytes");
+  });
+
+  it("sends viewer authorization only to the exact Divine media origin", async () => {
+    const signer = {
+      getPublicKey: vi.fn(),
+      signEvent: vi.fn(async (event) => ({ ...event, id: "a".repeat(64), pubkey: "b".repeat(64), sig: "c".repeat(128) })),
+    };
+    const divineFetch = vi.fn()
+      .mockResolvedValueOnce(new Response(null, { status: 401 }))
+      .mockResolvedValueOnce(new Response("hello"));
+
+    await fetchAndHashBlob({ url: "https://media.divine.video/blob", signer, fetcher: divineFetch });
+    expect(divineFetch).toHaveBeenCalledTimes(2);
+    expect(divineFetch.mock.calls[1][1]).toMatchObject({ redirect: "error" });
+    expect(new Headers(divineFetch.mock.calls[1][1]?.headers).get("Authorization")).toMatch(/^Nostr /);
+
+    const thirdPartyFetch = vi.fn(async () => new Response(null, { status: 401 }));
+    await expect(fetchAndHashBlob({
+      url: "https://media.divine.video.evil.example/blob", signer, fetcher: thirdPartyFetch,
+    })).rejects.toThrow("HTTP 401");
+    expect(thirdPartyFetch).toHaveBeenCalledOnce();
+  });
+
+  it("rejects an authorized response that resolves off the Divine media origin", async () => {
+    const redirected = new Response("hello");
+    Object.defineProperty(redirected, "url", { value: "https://cdn.example/blob" });
+    const fetcher = vi.fn()
+      .mockResolvedValueOnce(new Response(null, { status: 401 }))
+      .mockResolvedValueOnce(redirected);
+    const signer = {
+      getPublicKey: vi.fn(),
+      signEvent: vi.fn(async (event) => ({ ...event, id: "a".repeat(64), pubkey: "b".repeat(64), sig: "c".repeat(128) })),
+    };
+
+    await expect(fetchAndHashBlob({
+      url: "https://media.divine.video/blob", signer, fetcher,
+    })).rejects.toThrow("redirected to an untrusted origin");
+  });
+});
+
+describe("isDivineMediaOrigin", () => {
+  it("requires the exact HTTPS origin", () => {
+    expect(isDivineMediaOrigin("https://media.divine.video/blob")).toBe(true);
+    expect(isDivineMediaOrigin("http://media.divine.video/blob")).toBe(false);
+    expect(isDivineMediaOrigin("https://media.divine.video.evil.example/blob")).toBe(false);
+  });
+});

--- a/src/lib/exit/mediaBlob.ts
+++ b/src/lib/exit/mediaBlob.ts
@@ -1,0 +1,113 @@
+// ABOUTME: Fetches media bytes with bounded reads and computes their SHA-256
+// ABOUTME: Keeps viewer authorization scoped to the exact Divine media origin
+
+import type { NostrSigner } from "@nostrify/nostrify";
+
+import { createMediaViewerAuthHeader } from "@/lib/mediaViewerAuth";
+
+interface FetchAndHashBlobOptions {
+  url: string;
+  expectedSha256?: string | null;
+  signer?: NostrSigner | null;
+  signal?: AbortSignal;
+  fetcher?: typeof fetch;
+  maxBytes?: number;
+}
+
+export interface HashedBlob {
+  bytes: Uint8Array<ArrayBuffer>;
+  computedSha256: string;
+  contentType: string | null;
+  finalUrl: string;
+}
+
+export function isDivineMediaOrigin(url: string): boolean {
+  try {
+    const parsed = new URL(url);
+    return parsed.protocol === "https:" && parsed.hostname === "media.divine.video";
+  } catch {
+    return false;
+  }
+}
+
+function hex(bytes: ArrayBuffer): string {
+  return Array.from(new Uint8Array(bytes), (byte) => byte.toString(16).padStart(2, "0")).join("");
+}
+
+function assertWithinLimit(byteSize: number, maxBytes?: number): void {
+  if (maxBytes !== undefined && byteSize > maxBytes) {
+    throw new Error(`The source is larger than ${maxBytes} bytes.`);
+  }
+}
+
+async function readBytes(response: Response, maxBytes?: number): Promise<Uint8Array<ArrayBuffer>> {
+  const advertisedSize = response.headers.get("content-length");
+  if (advertisedSize !== null) assertWithinLimit(Number(advertisedSize), maxBytes);
+  const reader = response.body?.getReader();
+  if (!reader) {
+    const bytes = new Uint8Array(await response.arrayBuffer());
+    assertWithinLimit(bytes.length, maxBytes);
+    if (advertisedSize !== null && Number(advertisedSize) !== bytes.length) {
+      throw new Error("Response byte count did not match Content-Length");
+    }
+    return bytes;
+  }
+
+  const chunks: Uint8Array[] = [];
+  let byteSize = 0;
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    byteSize += value.length;
+    if (maxBytes !== undefined && byteSize > maxBytes) {
+      await reader.cancel();
+      assertWithinLimit(byteSize, maxBytes);
+    }
+    chunks.push(value);
+  }
+  if (advertisedSize !== null && Number(advertisedSize) !== byteSize) {
+    throw new Error("Response byte count did not match Content-Length");
+  }
+  const bytes: Uint8Array<ArrayBuffer> = new Uint8Array(byteSize);
+  let offset = 0;
+  for (const chunk of chunks) {
+    bytes.set(chunk, offset);
+    offset += chunk.length;
+  }
+  return bytes;
+}
+
+export async function fetchAndHashBlob(options: FetchAndHashBlobOptions): Promise<HashedBlob> {
+  const fetcher = options.fetcher ?? fetch;
+  const request = async (authorization?: string | null) => fetcher(options.url, {
+    method: "GET",
+    signal: options.signal,
+    redirect: authorization ? "error" : "follow",
+    headers: authorization ? { Authorization: authorization } : undefined,
+  });
+  let response = await request();
+  let usedAuthorization = false;
+  if ((response.status === 401 || response.status === 403) && isDivineMediaOrigin(options.url)) {
+    const authorization = await createMediaViewerAuthHeader({
+      signer: options.signer,
+      url: options.url,
+      sha256: options.expectedSha256 ?? undefined,
+    });
+    if (authorization) {
+      response = await request(authorization);
+      usedAuthorization = true;
+    }
+  }
+  if (!response.ok) throw new Error(`HTTP ${response.status}`);
+  const finalUrl = response.url || options.url;
+  if (usedAuthorization && !isDivineMediaOrigin(finalUrl)) {
+    throw new Error("Divine media redirected to an untrusted origin");
+  }
+  const bytes = await readBytes(response, options.maxBytes);
+  return {
+    bytes,
+    computedSha256: hex(await crypto.subtle.digest("SHA-256", bytes)),
+    contentType: response.headers.get("content-type")?.split(";", 1)[0].trim().toLowerCase() ?? null,
+    finalUrl,
+  };
+}

--- a/src/lib/exit/mediaDownloader.test.ts
+++ b/src/lib/exit/mediaDownloader.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { MediaReference } from "./archive";
-import { downloadArchiveMedia, isDivineMediaOrigin } from "./mediaDownloader";
+import { downloadArchiveMedia } from "./mediaDownloader";
 
 const helloHash = "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824";
 const reference = (url: string, sha256: string | null = helloHash): MediaReference => ({
@@ -137,13 +137,5 @@ describe("downloadArchiveMedia", () => {
 
     expect(result).toMatchObject({ verification: "failed" });
     expect(result.failure_reason).toContain("redirected to an untrusted origin");
-  });
-});
-
-describe("isDivineMediaOrigin", () => {
-  it("requires the exact HTTPS origin", () => {
-    expect(isDivineMediaOrigin("https://media.divine.video/blob")).toBe(true);
-    expect(isDivineMediaOrigin("http://media.divine.video/blob")).toBe(false);
-    expect(isDivineMediaOrigin("https://media.divine.video.evil.example/blob")).toBe(false);
   });
 });

--- a/src/lib/exit/mediaDownloader.ts
+++ b/src/lib/exit/mediaDownloader.ts
@@ -3,8 +3,9 @@
 
 import type { NostrSigner } from "@nostrify/nostrify";
 
-import { createMediaViewerAuthHeader } from "@/lib/mediaViewerAuth";
 import type { MediaReference } from "./archive";
+import { fetchAndHashBlob } from "./mediaBlob";
+import { groupMediaReferences } from "./mediaReferences";
 
 export type MediaVerification = "verified" | "unverified" | "hash-mismatch" | "failed";
 
@@ -40,57 +41,12 @@ const EXTENSIONS: Record<string, string> = {
   "image/webp": "webp", "image/gif": "gif", "application/vnd.apple.mpegurl": "m3u8",
 };
 
-export function isDivineMediaOrigin(url: string): boolean {
-  try {
-    const parsed = new URL(url);
-    return parsed.protocol === "https:" && parsed.hostname === "media.divine.video";
-  } catch {
-    return false;
-  }
-}
-
 function extension(contentType: string | null): string {
   return EXTENSIONS[contentType?.split(";")[0].trim().toLowerCase() ?? ""] ?? "bin";
 }
 
-function hex(bytes: ArrayBuffer): string {
-  return Array.from(new Uint8Array(bytes), (byte) => byte.toString(16).padStart(2, "0")).join("");
-}
-
-async function fetchCandidate(url: string, expectedHash: string | null, options: Pick<DownloadOptions, "fetcher" | "signer" | "signal">) {
-  const fetcher = options.fetcher ?? fetch;
-  const request = async (authorization?: string | null) => fetcher(url, {
-    method: "GET", signal: options.signal, redirect: authorization ? "error" : "follow",
-    headers: authorization ? { Authorization: authorization } : undefined,
-  });
-  let response = await request();
-  let usedAuthorization = false;
-  if ((response.status === 401 || response.status === 403) && isDivineMediaOrigin(url)) {
-    const auth = await createMediaViewerAuthHeader({ signer: options.signer, url, sha256: expectedHash ?? undefined });
-    if (auth) {
-      response = await request(auth);
-      usedAuthorization = true;
-    }
-  }
-  if (!response.ok) throw new Error(`HTTP ${response.status}`);
-  if (usedAuthorization && !isDivineMediaOrigin(response.url || url)) throw new Error("Divine media redirected to an untrusted origin");
-  const bytes = new Uint8Array(await response.arrayBuffer());
-  const advertisedSize = response.headers.get("content-length");
-  if (advertisedSize && Number(advertisedSize) !== bytes.length) throw new Error("Response byte count did not match Content-Length");
-  return { bytes, contentType: response.headers.get("content-type"), finalUrl: response.url || url };
-}
-
-function groups(references: MediaReference[]): MediaReference[][] {
-  const grouped = new Map<string, MediaReference[]>();
-  for (const reference of references) {
-    const key = reference.sha256 ? `hash:${reference.sha256}` : `url:${reference.url}`;
-    grouped.set(key, [...(grouped.get(key) ?? []), reference]);
-  }
-  return [...grouped.values()];
-}
-
 export async function downloadArchiveMedia(options: DownloadOptions): Promise<MediaDownloadResult[]> {
-  const batches = groups(options.references);
+  const batches = groupMediaReferences(options.references);
   const results: MediaDownloadResult[] = [];
   for (const references of batches) {
     const expectedHash = references[0].sha256;
@@ -101,8 +57,14 @@ export async function downloadArchiveMedia(options: DownloadOptions): Promise<Me
     for (const url of candidates) {
       if (options.signal?.aborted) { failures.push("Download cancelled"); break; }
       try {
-        const response = await fetchCandidate(url, expectedHash, options);
-        const computedHash = hex(await crypto.subtle.digest("SHA-256", response.bytes));
+        const response = await fetchAndHashBlob({
+          url,
+          expectedSha256: expectedHash,
+          signer: options.signer,
+          signal: options.signal,
+          fetcher: options.fetcher,
+        });
+        const computedHash = response.computedSha256;
         const status: MediaVerification = expectedHash ? (expectedHash === computedHash ? "verified" : "hash-mismatch") : "unverified";
         const folder = status === "hash-mismatch" ? "media/mismatched" : status === "unverified" ? "media/unverified" : "media";
         const archivePath = `${folder}/${status === "hash-mismatch" ? expectedHash : computedHash}.${extension(response.contentType)}`;

--- a/src/lib/exit/mediaReferences.ts
+++ b/src/lib/exit/mediaReferences.ts
@@ -3,8 +3,19 @@
 
 import type { NostrEvent } from "@nostrify/nostrify";
 
+import type { MediaReference } from "./archive";
+
 export const URL_TAGS = new Set(["url", "image", "thumb", "thumbnail"]);
 export const IMETA_URL_KEYS = new Set(["url", "image", "thumb", "thumbnail", "fallback"]);
+
+export function groupMediaReferences(references: MediaReference[]): MediaReference[][] {
+  const grouped = new Map<string, MediaReference[]>();
+  for (const reference of references) {
+    const key = reference.sha256 ? `hash:${reference.sha256}` : `url:${reference.url}`;
+    grouped.set(key, [...(grouped.get(key) ?? []), reference]);
+  }
+  return [...grouped.values()];
+}
 
 const PROFILE_MEDIA_KEYS = ["picture", "banner"] as const;
 

--- a/src/lib/exit/mirrorClient.test.ts
+++ b/src/lib/exit/mirrorClient.test.ts
@@ -126,18 +126,70 @@ describe("mirrorArchiveMedia", () => {
     expect(onProgress.mock.calls.map(([progress]) => progress.completed)).toEqual([1, 2]);
   });
 
-  it("skips a source without an advertised hash before signing or requesting it", async () => {
-    const fetcher = vi.fn<typeof fetch>();
+  it("uploads a hashless image with its computed hash", async () => {
+    const imageHash = "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824";
+    const fetcher = vi.fn<typeof fetch>()
+      .mockResolvedValueOnce(new Response("hello", { headers: { "content-type": "image/jpeg" } }))
+      .mockResolvedValueOnce(new Response(JSON.stringify(descriptor(imageHash)), { status: 200 }));
     const results = await mirrorArchiveMedia({
-      destination: "https://blossom.example", references: [reference("https://source.example/no-hash", null)], signer, fetcher,
+      destination: "https://blossom.example", references: [reference("https://source.example/avatar.jpg", null)], signer, fetcher,
+    });
+    expect(results[0]).toMatchObject({
+      verification: "upload-verified",
+      expected_sha256: null,
+      destination_sha256: imageHash,
+      destination_url: `https://blossom.example/${imageHash}`,
+    });
+    expect(fetcher.mock.calls[1][0]).toBe("https://blossom.example/upload");
+    expect(fetcher.mock.calls[1][1]).toMatchObject({ method: "PUT", body: expect.any(Uint8Array) });
+    expect(decodeAuthorization(new Headers(fetcher.mock.calls[1][1]?.headers).get("Authorization") ?? "").tags)
+      .toContainEqual(["x", imageHash]);
+  });
+
+  it("skips a hashless image when the destination has no upload support", async () => {
+    const fetcher = vi.fn<typeof fetch>()
+      .mockResolvedValueOnce(new Response("hello", { headers: { "content-type": "image/jpeg" } }))
+      .mockResolvedValueOnce(new Response(null, { status: 404 }));
+
+    const results = await mirrorArchiveMedia({
+      destination: "https://blossom.example", references: [reference("https://source.example/avatar.jpg", null)], signer, fetcher,
     });
     expect(results[0]).toMatchObject({
       verification: "skipped",
-      destination_sha256: null,
-      reason: expect.stringContaining("did not advertise a SHA-256 hash"),
+      reason: expect.stringContaining("does not support browser uploads"),
     });
-    expect(signer.signEvent).not.toHaveBeenCalled();
-    expect(fetcher).not.toHaveBeenCalled();
+  });
+
+  it("does not certify a hashless upload whose descriptor reports another hash", async () => {
+    const fetcher = vi.fn<typeof fetch>()
+      .mockResolvedValueOnce(new Response("hello", { headers: { "content-type": "image/jpeg" } }))
+      .mockResolvedValueOnce(new Response(JSON.stringify(descriptor(otherHash)), { status: 200 }));
+    const results = await mirrorArchiveMedia({
+      destination: "https://blossom.example", references: [reference("https://source.example/avatar.jpg", null)], signer, fetcher,
+    });
+    expect(results[0]).toMatchObject({ verification: "hash-mismatch", destination_sha256: otherHash });
+  });
+
+  it("skips hashless non-images and oversized images without uploading them", async () => {
+    const nonImageFetcher = vi.fn<typeof fetch>()
+      .mockResolvedValueOnce(new Response("hello", { headers: { "content-type": "video/mp4" } }));
+    const [nonImage] = await mirrorArchiveMedia({
+      destination: "https://blossom.example", references: [reference("https://source.example/video", null)], signer,
+      fetcher: nonImageFetcher,
+    });
+    expect(nonImage).toMatchObject({ verification: "skipped", reason: expect.stringContaining("not a supported image") });
+    expect(nonImageFetcher).toHaveBeenCalledOnce();
+
+    const oversizedFetcher = vi.fn<typeof fetch>()
+      .mockResolvedValueOnce(new Response("hello", {
+        headers: { "content-type": "image/jpeg", "content-length": String(5 * 1024 * 1024 + 1) },
+      }));
+    const [oversized] = await mirrorArchiveMedia({
+      destination: "https://blossom.example", references: [reference("https://source.example/avatar.jpg", null)], signer,
+      fetcher: oversizedFetcher,
+    });
+    expect(oversized).toMatchObject({ verification: "skipped", reason: expect.stringContaining("larger than") });
+    expect(oversizedFetcher).toHaveBeenCalledOnce();
   });
 
   it("sends a BUD-11-compliant authorization token to a strict destination", async () => {
@@ -377,7 +429,8 @@ describe("mirrorArchiveMedia", () => {
       { references: [], source_url: "one", destination_url: "one", expected_sha256: hash, destination_sha256: hash, byte_size: null, verification: "already-present" },
       { references: [], source_url: "two", destination_url: "two", expected_sha256: hash, destination_sha256: hash, byte_size: 5, verification: "descriptor-verified" },
       { references: [], source_url: "three", destination_url: null, expected_sha256: hash, destination_sha256: null, byte_size: null, verification: "failed" },
-    ])).toEqual({ mirrored: 1, alreadyPresent: 1, failed: 1, skipped: 0, unverified: 0 });
+      { references: [], source_url: "four", destination_url: "four", expected_sha256: null, destination_sha256: hash, byte_size: 5, verification: "upload-verified" },
+    ])).toEqual({ mirrored: 2, alreadyPresent: 1, failed: 1, skipped: 0, unverified: 0 });
   });
 
   it("throws a typed destination error after exhausted canary rate limits", async () => {

--- a/src/lib/exit/mirrorClient.test.ts
+++ b/src/lib/exit/mirrorClient.test.ts
@@ -17,6 +17,10 @@ function reference(url: string, sha256: string | null = hash): MediaReference {
   return { event_id: "f".repeat(64), tag: "url", url, sha256 };
 }
 
+function profileReference(url: string): MediaReference {
+  return { ...reference(url, null), tag: "picture" };
+}
+
 function descriptor(sha256 = hash, size = 5) {
   return { url: `https://blossom.example/${sha256}`, sha256, size, type: "video/mp4" };
 }
@@ -132,7 +136,7 @@ describe("mirrorArchiveMedia", () => {
       .mockResolvedValueOnce(new Response("hello", { headers: { "content-type": "image/jpeg" } }))
       .mockResolvedValueOnce(new Response(JSON.stringify(descriptor(imageHash)), { status: 200 }));
     const results = await mirrorArchiveMedia({
-      destination: "https://blossom.example", references: [reference("https://source.example/avatar.jpg", null)], signer, fetcher,
+      destination: "https://blossom.example", references: [profileReference("https://source.example/avatar.jpg")], signer, fetcher,
     });
     expect(results[0]).toMatchObject({
       verification: "upload-verified",
@@ -152,7 +156,7 @@ describe("mirrorArchiveMedia", () => {
       .mockResolvedValueOnce(new Response(null, { status: 404 }));
 
     const results = await mirrorArchiveMedia({
-      destination: "https://blossom.example", references: [reference("https://source.example/avatar.jpg", null)], signer, fetcher,
+      destination: "https://blossom.example", references: [profileReference("https://source.example/avatar.jpg")], signer, fetcher,
     });
     expect(results[0]).toMatchObject({
       verification: "skipped",
@@ -165,7 +169,7 @@ describe("mirrorArchiveMedia", () => {
       .mockResolvedValueOnce(new Response("hello", { headers: { "content-type": "image/jpeg" } }))
       .mockResolvedValueOnce(new Response(JSON.stringify(descriptor(otherHash)), { status: 200 }));
     const results = await mirrorArchiveMedia({
-      destination: "https://blossom.example", references: [reference("https://source.example/avatar.jpg", null)], signer, fetcher,
+      destination: "https://blossom.example", references: [profileReference("https://source.example/avatar.jpg")], signer, fetcher,
     });
     expect(results[0]).toMatchObject({ verification: "hash-mismatch", destination_sha256: otherHash });
   });
@@ -174,7 +178,7 @@ describe("mirrorArchiveMedia", () => {
     const nonImageFetcher = vi.fn<typeof fetch>()
       .mockResolvedValueOnce(new Response("hello", { headers: { "content-type": "video/mp4" } }));
     const [nonImage] = await mirrorArchiveMedia({
-      destination: "https://blossom.example", references: [reference("https://source.example/video", null)], signer,
+      destination: "https://blossom.example", references: [profileReference("https://source.example/video")], signer,
       fetcher: nonImageFetcher,
     });
     expect(nonImage).toMatchObject({ verification: "skipped", reason: expect.stringContaining("not a supported image") });
@@ -185,11 +189,26 @@ describe("mirrorArchiveMedia", () => {
         headers: { "content-type": "image/jpeg", "content-length": String(5 * 1024 * 1024 + 1) },
       }));
     const [oversized] = await mirrorArchiveMedia({
-      destination: "https://blossom.example", references: [reference("https://source.example/avatar.jpg", null)], signer,
+      destination: "https://blossom.example", references: [profileReference("https://source.example/avatar.jpg")], signer,
       fetcher: oversizedFetcher,
     });
     expect(oversized).toMatchObject({ verification: "skipped", reason: expect.stringContaining("larger than") });
     expect(oversizedFetcher).toHaveBeenCalledOnce();
+  });
+
+  it("leaves hashless non-profile images untouched", async () => {
+    const fetcher = vi.fn<typeof fetch>();
+    const thumbnail = { ...reference("https://source.example/thumbnail.jpg", null), tag: "thumbnail" };
+
+    const [result] = await mirrorArchiveMedia({
+      destination: "https://blossom.example", references: [thumbnail], signer, fetcher,
+    });
+
+    expect(result).toMatchObject({
+      verification: "skipped",
+      reason: expect.stringContaining("did not advertise a SHA-256 hash"),
+    });
+    expect(fetcher).not.toHaveBeenCalled();
   });
 
   it("sends a BUD-11-compliant authorization token to a strict destination", async () => {

--- a/src/lib/exit/mirrorClient.test.ts
+++ b/src/lib/exit/mirrorClient.test.ts
@@ -134,7 +134,8 @@ describe("mirrorArchiveMedia", () => {
     const imageHash = "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824";
     const fetcher = vi.fn<typeof fetch>()
       .mockResolvedValueOnce(new Response("hello", { headers: { "content-type": "image/jpeg" } }))
-      .mockResolvedValueOnce(new Response(JSON.stringify(descriptor(imageHash)), { status: 200 }));
+      .mockResolvedValueOnce(new Response(JSON.stringify(descriptor(imageHash)), { status: 200 }))
+      .mockResolvedValueOnce(blobHead(5, "image/jpeg"));
     const results = await mirrorArchiveMedia({
       destination: "https://blossom.example", references: [profileReference("https://source.example/avatar.jpg")], signer, fetcher,
     });
@@ -146,8 +147,33 @@ describe("mirrorArchiveMedia", () => {
     });
     expect(fetcher.mock.calls[1][0]).toBe("https://blossom.example/upload");
     expect(fetcher.mock.calls[1][1]).toMatchObject({ method: "PUT", body: expect.any(Uint8Array) });
+    expect(fetcher.mock.calls[2][1]).toMatchObject({ method: "HEAD", redirect: "follow" });
     expect(decodeAuthorization(new Headers(fetcher.mock.calls[1][1]?.headers).get("Authorization") ?? "").tags)
       .toContainEqual(["x", imageHash]);
+  });
+
+  it("does not rewrite to an uploaded descriptor URL that fails readback", async () => {
+    const imageHash = "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824";
+    const fetcher = vi.fn<typeof fetch>()
+      .mockResolvedValueOnce(new Response("hello", { headers: { "content-type": "image/jpeg" } }))
+      .mockResolvedValueOnce(new Response(JSON.stringify(descriptor(imageHash)), { status: 200 }))
+      .mockResolvedValueOnce(new Response(null, { status: 404 }));
+
+    const [result] = await mirrorArchiveMedia({
+      destination: "https://blossom.example", references: [profileReference("https://source.example/avatar.jpg")], signer, fetcher,
+    });
+
+    expect(result).toMatchObject({ verification: "unverified", destination_sha256: imageHash });
+  });
+
+  it("fails fast when the first hashless upload needs destination access", async () => {
+    const fetcher = vi.fn<typeof fetch>()
+      .mockResolvedValueOnce(new Response("hello", { headers: { "content-type": "image/jpeg" } }))
+      .mockResolvedValueOnce(new Response(null, { status: 401 }));
+
+    await expect(mirrorArchiveMedia({
+      destination: "https://blossom.example", references: [profileReference("https://source.example/avatar.jpg")], signer, fetcher,
+    })).rejects.toMatchObject({ code: "auth-required" });
   });
 
   it("skips a hashless image when the destination has no upload support", async () => {
@@ -162,6 +188,21 @@ describe("mirrorArchiveMedia", () => {
       verification: "skipped",
       reason: expect.stringContaining("does not support browser uploads"),
     });
+  });
+
+  it("keeps the canary for a mirror after skipping unsupported browser uploads", async () => {
+    const fetcher = vi.fn<typeof fetch>()
+      .mockResolvedValueOnce(new Response("hello", { headers: { "content-type": "image/jpeg" } }))
+      .mockResolvedValueOnce(new Response(null, { status: 404 }))
+      .mockResolvedValueOnce(new Response(null, { status: 401 }))
+      .mockResolvedValueOnce(new Response(null, { status: 404 }));
+
+    await expect(mirrorArchiveMedia({
+      destination: "https://blossom.example",
+      references: [profileReference("https://source.example/avatar.jpg"), reference("https://source.example/video.mp4")],
+      signer,
+      fetcher,
+    })).rejects.toMatchObject({ code: "auth-required" });
   });
 
   it("does not certify a hashless upload whose descriptor reports another hash", async () => {

--- a/src/lib/exit/mirrorClient.test.ts
+++ b/src/lib/exit/mirrorClient.test.ts
@@ -205,6 +205,23 @@ describe("mirrorArchiveMedia", () => {
     })).rejects.toMatchObject({ code: "auth-required" });
   });
 
+  it("keeps the mirror canary after a successful browser upload", async () => {
+    const imageHash = "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824";
+    const fetcher = vi.fn<typeof fetch>()
+      .mockResolvedValueOnce(new Response("hello", { headers: { "content-type": "image/jpeg" } }))
+      .mockResolvedValueOnce(new Response(JSON.stringify(descriptor(imageHash)), { status: 200 }))
+      .mockResolvedValueOnce(blobHead(5, "image/jpeg"))
+      .mockResolvedValueOnce(new Response(null, { status: 404 }))
+      .mockResolvedValueOnce(new Response(null, { status: 404 }));
+
+    await expect(mirrorArchiveMedia({
+      destination: "https://blossom.example",
+      references: [profileReference("https://source.example/avatar.jpg"), reference("https://source.example/video.mp4")],
+      signer,
+      fetcher,
+    })).rejects.toMatchObject({ code: "no-mirror-support" });
+  });
+
   it("does not certify a hashless upload whose descriptor reports another hash", async () => {
     const fetcher = vi.fn<typeof fetch>()
       .mockResolvedValueOnce(new Response("hello", { headers: { "content-type": "image/jpeg" } }))

--- a/src/lib/exit/mirrorClient.ts
+++ b/src/lib/exit/mirrorClient.ts
@@ -329,7 +329,34 @@ function skippedResult(references: MediaReference[], reason: string): MirrorResu
   };
 }
 
-async function uploadHashlessImage(references: MediaReference[], options: MirrorOptions): Promise<MirrorResult> {
+async function verifyUploadedReadback(
+  references: MediaReference[],
+  descriptor: BlobDescriptor,
+  options: MirrorOptions,
+): Promise<MirrorResult> {
+  try {
+    const response = await (options.fetcher ?? fetch)(descriptor.url, {
+      method: "HEAD",
+      signal: options.signal,
+      redirect: "follow",
+    });
+    const size = response.headers.get("content-length");
+    if (response.ok && size !== null && Number(size) === descriptor.size) {
+      return { references, source_url: references[0].url, destination_url: descriptor.url, expected_sha256: null,
+        destination_sha256: descriptor.sha256, byte_size: descriptor.size, verification: "upload-verified" };
+    }
+  } catch {
+    if (options.signal?.aborted) throw new DOMException("Mirror cancelled", "AbortError");
+  }
+  return { references, source_url: references[0].url, destination_url: descriptor.url, expected_sha256: null,
+    destination_sha256: descriptor.sha256, byte_size: descriptor.size, verification: "unverified",
+    reason: "The destination accepted the upload, but browser readback could not be confirmed." };
+}
+
+async function uploadHashlessImage(
+  references: MediaReference[],
+  options: MirrorOptions,
+): Promise<{ result: MirrorResult; destinationError: DestinationError | null; copyAttempted: boolean }> {
   let blob: HashedBlob;
   try {
     blob = await fetchAndHashBlob({
@@ -343,38 +370,36 @@ async function uploadHashlessImage(references: MediaReference[], options: Mirror
     if (options.signal?.aborted) throw new DOMException("Mirror cancelled", "AbortError");
     const reason = error instanceof Error ? error.message : "download failed";
     if (reason.includes("larger than")) {
-      return skippedResult(references, "The hashless image is larger than 5 MB, so it was not uploaded.");
+      return { result: skippedResult(references, "The hashless image is larger than 5 MB, so it was not uploaded."), destinationError: null, copyAttempted: false };
     }
-    return failedResult(references, "failed", `The source image could not be read: ${reason}`);
+    return { result: failedResult(references, "failed", `The source image could not be read: ${reason}`), destinationError: null, copyAttempted: false };
   }
   if (!blob.contentType || !UPLOADABLE_IMAGE_TYPES.has(blob.contentType)) {
-    return skippedResult(references, "The hashless source is not a supported image, so it was not uploaded.");
+    return { result: skippedResult(references, "The hashless source is not a supported image, so it was not uploaded."), destinationError: null, copyAttempted: false };
   }
 
   const response = await requestUpload(blob, options);
   if (response instanceof DestinationError) {
-    return failedResult(references, "failed", response.message);
+    return { result: failedResult(references, "failed", response.message), destinationError: response, copyAttempted: true };
   }
   if (response.status === 404 || response.status === 405 || response.status === 501) {
-    return skippedResult(references, `${options.destination} does not support browser uploads.`);
+    return { result: skippedResult(references, `${options.destination} does not support browser uploads.`), destinationError: null, copyAttempted: false };
+  }
+  const destinationError = response.status === 429
+    ? new DestinationError("rate-limited", `${options.destination} is rate limiting media copies. Try again later.`, 429)
+    : destinationFailure(response.status, options.destination);
+  if (destinationError) {
+    return { result: failedResult(references, "failed", destinationError.message), destinationError, copyAttempted: true };
   }
   if (!response.ok) {
-    return failedResult(references, "failed", `The destination refused this upload (HTTP ${response.status}).${serverReason(response)}`);
+    return { result: failedResult(references, "failed", `The destination refused this upload (HTTP ${response.status}).${serverReason(response)}`), destinationError: null, copyAttempted: true };
   }
   const descriptor = await readDescriptor(response);
-  if (!descriptor) return failedResult(references, "failed", "The destination returned an invalid blob descriptor.");
+  if (!descriptor) return { result: failedResult(references, "failed", "The destination returned an invalid blob descriptor."), destinationError: null, copyAttempted: true };
   if (descriptor.sha256 !== blob.computedSha256 || descriptor.size !== blob.bytes.length) {
-    return failedResult(references, "hash-mismatch", "The destination reported different uploaded bytes.", descriptor);
+    return { result: failedResult(references, "hash-mismatch", "The destination reported different uploaded bytes.", descriptor), destinationError: null, copyAttempted: true };
   }
-  return {
-    references,
-    source_url: blob.finalUrl,
-    destination_url: descriptor.url,
-    expected_sha256: null,
-    destination_sha256: descriptor.sha256,
-    byte_size: descriptor.size,
-    verification: "upload-verified",
-  };
+  return { result: await verifyUploadedReadback(references, descriptor, options), destinationError: null, copyAttempted: true };
 }
 
 export async function mirrorArchiveMedia(options: MirrorOptions): Promise<MirrorResult[]> {
@@ -388,9 +413,16 @@ export async function mirrorArchiveMedia(options: MirrorOptions): Promise<Mirror
     if (isHlsManifest(reference.url)) {
       result = skippedResult(references, "Streaming manifests are generated derivatives and were not copied.");
     } else if (!reference.sha256) {
-      result = references.some(({ tag }) => PROFILE_IMAGE_TAGS.has(tag))
-        ? await uploadHashlessImage(references, options)
-        : skippedResult(references, "The source did not advertise a SHA-256 hash, so a secure copy could not be authorized.");
+      if (references.some(({ tag }) => PROFILE_IMAGE_TAGS.has(tag))) {
+        const outcome = await uploadHashlessImage(references, options);
+        if (outcome.copyAttempted) {
+          if (copyAttempts === 0 && outcome.destinationError) throw outcome.destinationError;
+          copyAttempts += 1;
+        }
+        result = outcome.result;
+      } else {
+        result = skippedResult(references, "The source did not advertise a SHA-256 hash, so a secure copy could not be authorized.");
+      }
     } else {
       const outcome = await mirrorOne(references, reference.sha256, options);
       if (outcome.result.verification !== "already-present") {

--- a/src/lib/exit/mirrorClient.ts
+++ b/src/lib/exit/mirrorClient.ts
@@ -7,8 +7,10 @@ import { createBlossomUploadAuthHeader } from "@/lib/blossomAuth";
 
 import type { MediaReference } from "./archive";
 import { DestinationError } from "./destination";
+import { fetchAndHashBlob, type HashedBlob } from "./mediaBlob";
+import { groupMediaReferences } from "./mediaReferences";
 
-export type MirrorVerification = "descriptor-verified" | "already-present" | "unverified" | "hash-mismatch" | "failed" | "skipped";
+export type MirrorVerification = "descriptor-verified" | "upload-verified" | "already-present" | "unverified" | "hash-mismatch" | "failed" | "skipped";
 
 export interface MirrorResult {
   references: MediaReference[];
@@ -52,14 +54,8 @@ interface MirrorOptions {
   onProgress?(progress: MirrorProgress): void;
 }
 
-function groupReferences(references: MediaReference[]): MediaReference[][] {
-  const grouped = new Map<string, MediaReference[]>();
-  for (const reference of references) {
-    const key = reference.sha256 ? `hash:${reference.sha256}` : `url:${reference.url}`;
-    grouped.set(key, [...(grouped.get(key) ?? []), reference]);
-  }
-  return [...grouped.values()];
-}
+const MAX_HASHLESS_IMAGE_BYTES = 5 * 1024 * 1024;
+const UPLOADABLE_IMAGE_TYPES = new Set(["image/gif", "image/jpeg", "image/png", "image/webp"]);
 
 function isHlsManifest(url: string): boolean {
   try {
@@ -156,6 +152,28 @@ async function requestMirror(
         signal: options.signal,
         headers: { Authorization: authorization, "Content-Type": "application/json" },
         body: JSON.stringify({ url: references[0].url }),
+      });
+      if (response.status !== 429 || attempt >= (options.maxRateLimitRetries ?? 2)) return response;
+      await wait(retryDelay(response), options.signal);
+    } catch (error) {
+      if (options.signal?.aborted) throw new DOMException("Mirror cancelled", "AbortError");
+      if (!(error instanceof TypeError)) throw error;
+      return new DestinationError("unreachable", `Your browser couldn't reach ${options.destination}. The server may be down, or it may not accept requests from other websites.`);
+    }
+  }
+}
+
+async function requestUpload(blob: HashedBlob, options: MirrorOptions): Promise<Response | DestinationError> {
+  const fetcher = options.fetcher ?? fetch;
+  const wait = options.wait ?? defaultWait;
+  for (let attempt = 0; ; attempt += 1) {
+    const authorization = await createBlossomUploadAuthHeader(options.signer, blob.computedSha256);
+    try {
+      const response = await fetcher(`${options.destination}/upload`, {
+        method: "PUT",
+        signal: options.signal,
+        headers: { Authorization: authorization, "Content-Type": blob.contentType! },
+        body: blob.bytes,
       });
       if (response.status !== 429 || attempt >= (options.maxRateLimitRetries ?? 2)) return response;
       await wait(retryDelay(response), options.signal);
@@ -297,8 +315,69 @@ async function mirrorOne(
   return { result: await verifyReadback(references, descriptor, options), destinationError: null };
 }
 
+function skippedResult(references: MediaReference[], reason: string): MirrorResult {
+  return {
+    references,
+    source_url: references[0].url,
+    destination_url: null,
+    expected_sha256: references[0].sha256,
+    destination_sha256: null,
+    byte_size: null,
+    verification: "skipped",
+    reason,
+  };
+}
+
+async function uploadHashlessImage(references: MediaReference[], options: MirrorOptions): Promise<MirrorResult> {
+  let blob: HashedBlob;
+  try {
+    blob = await fetchAndHashBlob({
+      url: references[0].url,
+      signer: options.signer,
+      signal: options.signal,
+      fetcher: options.fetcher,
+      maxBytes: MAX_HASHLESS_IMAGE_BYTES,
+    });
+  } catch (error) {
+    if (options.signal?.aborted) throw new DOMException("Mirror cancelled", "AbortError");
+    const reason = error instanceof Error ? error.message : "download failed";
+    if (reason.includes("larger than")) {
+      return skippedResult(references, "The hashless image is larger than 5 MB, so it was not uploaded.");
+    }
+    return failedResult(references, "failed", `The source image could not be read: ${reason}`);
+  }
+  if (!blob.contentType || !UPLOADABLE_IMAGE_TYPES.has(blob.contentType)) {
+    return skippedResult(references, "The hashless source is not a supported image, so it was not uploaded.");
+  }
+
+  const response = await requestUpload(blob, options);
+  if (response instanceof DestinationError) {
+    return failedResult(references, "failed", response.message);
+  }
+  if (response.status === 404 || response.status === 405 || response.status === 501) {
+    return skippedResult(references, `${options.destination} does not support browser uploads.`);
+  }
+  if (!response.ok) {
+    return failedResult(references, "failed", `The destination refused this upload (HTTP ${response.status}).${serverReason(response)}`);
+  }
+  const descriptor = await readDescriptor(response);
+  if (!descriptor) return failedResult(references, "failed", "The destination returned an invalid blob descriptor.");
+  if (descriptor.sha256 !== blob.computedSha256 || descriptor.size !== blob.bytes.length) {
+    return failedResult(references, "hash-mismatch", "The destination reported different uploaded bytes.", descriptor);
+  }
+  return {
+    references,
+    source_url: blob.finalUrl,
+    destination_url: descriptor.url,
+    expected_sha256: null,
+    destination_sha256: descriptor.sha256,
+    byte_size: descriptor.size,
+    verification: "upload-verified",
+  };
+}
+
 export async function mirrorArchiveMedia(options: MirrorOptions): Promise<MirrorResult[]> {
-  const groups = groupReferences(options.references);
+  const groups = groupMediaReferences(options.references);
   const results: MirrorResult[] = [];
   let copyAttempts = 0;
   for (const references of groups) {
@@ -306,17 +385,9 @@ export async function mirrorArchiveMedia(options: MirrorOptions): Promise<Mirror
     const reference = references[0];
     let result: MirrorResult;
     if (isHlsManifest(reference.url)) {
-      result = {
-        references, source_url: reference.url, destination_url: null, expected_sha256: reference.sha256,
-        destination_sha256: null, byte_size: null, verification: "skipped",
-        reason: "Streaming manifests are generated derivatives and were not copied.",
-      };
+      result = skippedResult(references, "Streaming manifests are generated derivatives and were not copied.");
     } else if (!reference.sha256) {
-      result = {
-        references, source_url: reference.url, destination_url: null, expected_sha256: null,
-        destination_sha256: null, byte_size: null, verification: "skipped",
-        reason: "The source did not advertise a SHA-256 hash, so a secure copy could not be authorized.",
-      };
+      result = await uploadHashlessImage(references, options);
     } else {
       const outcome = await mirrorOne(references, reference.sha256, options);
       if (outcome.result.verification !== "already-present") {
@@ -333,7 +404,7 @@ export async function mirrorArchiveMedia(options: MirrorOptions): Promise<Mirror
 
 export function summarizeMirrorResults(results: MirrorResult[]): MirrorSummary {
   return {
-    mirrored: results.filter((result) => result.verification === "descriptor-verified").length,
+    mirrored: results.filter((result) => result.verification === "descriptor-verified" || result.verification === "upload-verified").length,
     alreadyPresent: results.filter((result) => result.verification === "already-present").length,
     failed: results.filter((result) => result.verification === "failed" || result.verification === "hash-mismatch").length,
     skipped: results.filter((result) => result.verification === "skipped").length,

--- a/src/lib/exit/mirrorClient.ts
+++ b/src/lib/exit/mirrorClient.ts
@@ -55,6 +55,7 @@ interface MirrorOptions {
 }
 
 const MAX_HASHLESS_IMAGE_BYTES = 5 * 1024 * 1024;
+const PROFILE_IMAGE_TAGS = new Set(["picture", "banner"]);
 const UPLOADABLE_IMAGE_TYPES = new Set(["image/gif", "image/jpeg", "image/png", "image/webp"]);
 
 function isHlsManifest(url: string): boolean {
@@ -387,7 +388,9 @@ export async function mirrorArchiveMedia(options: MirrorOptions): Promise<Mirror
     if (isHlsManifest(reference.url)) {
       result = skippedResult(references, "Streaming manifests are generated derivatives and were not copied.");
     } else if (!reference.sha256) {
-      result = await uploadHashlessImage(references, options);
+      result = references.some(({ tag }) => PROFILE_IMAGE_TAGS.has(tag))
+        ? await uploadHashlessImage(references, options)
+        : skippedResult(references, "The source did not advertise a SHA-256 hash, so a secure copy could not be authorized.");
     } else {
       const outcome = await mirrorOne(references, reference.sha256, options);
       if (outcome.result.verification !== "already-present") {

--- a/src/lib/exit/mirrorClient.ts
+++ b/src/lib/exit/mirrorClient.ts
@@ -405,7 +405,8 @@ async function uploadHashlessImage(
 export async function mirrorArchiveMedia(options: MirrorOptions): Promise<MirrorResult[]> {
   const groups = groupMediaReferences(options.references);
   const results: MirrorResult[] = [];
-  let copyAttempts = 0;
+  let mirrorAttempts = 0;
+  let uploadAttempts = 0;
   for (const references of groups) {
     if (options.signal?.aborted) throw new DOMException("Mirror cancelled", "AbortError");
     const reference = references[0];
@@ -416,8 +417,8 @@ export async function mirrorArchiveMedia(options: MirrorOptions): Promise<Mirror
       if (references.some(({ tag }) => PROFILE_IMAGE_TAGS.has(tag))) {
         const outcome = await uploadHashlessImage(references, options);
         if (outcome.copyAttempted) {
-          if (copyAttempts === 0 && outcome.destinationError) throw outcome.destinationError;
-          copyAttempts += 1;
+          if (uploadAttempts === 0 && outcome.destinationError) throw outcome.destinationError;
+          uploadAttempts += 1;
         }
         result = outcome.result;
       } else {
@@ -426,8 +427,8 @@ export async function mirrorArchiveMedia(options: MirrorOptions): Promise<Mirror
     } else {
       const outcome = await mirrorOne(references, reference.sha256, options);
       if (outcome.result.verification !== "already-present") {
-        if (copyAttempts === 0 && outcome.destinationError) throw outcome.destinationError;
-        copyAttempts += 1;
+        if (mirrorAttempts === 0 && outcome.destinationError) throw outcome.destinationError;
+        mirrorAttempts += 1;
       }
       result = outcome.result;
     }


### PR DESCRIPTION
## Summary

- Upload hashless profile images to the chosen Blossom destination after computing their SHA-256 in the browser.
- Rewrite republished profile events only after the destination returns a matching descriptor.
- Share bounded media fetching and reference grouping between archive downloads and destination copies.
- Explain the browser upload path in the destination form and document it in the architecture guide.

## Motivation

Restored profile images can use path-based archive URLs with no advertised hash. The existing BUD-04 mirror flow could not authorize those sources, so migrated profiles continued loading their avatars from Divine storage. The archive bucket now permits browser reads; this change uses a five-megabyte, image-only BUD-02 upload path to complete the move without coupling it to the optional ZIP download.

The legacy bucket ownership follow-up is tracked in divinevideo/divine-iac-coreconfig#1950.

## Related Issue

- Closes #701

## Testing

- [x] `npm run test`
- [x] Manual verification completed: a real archive object returns `Access-Control-Allow-Origin: *`, and `/exit/start` renders locally.

## Visuals

- [x] UI change with screenshots/video attached
- [ ] No visual change
- [x] Visuals and text avoid sensitive external brand or partner names unless explicitly approved

The visible change is explanatory copy inside the post-export destination form. The screenshot renders the exact PR-head component without requiring a signed account export.

<img width="1291" height="791" alt="Destination form explaining the browser upload path for hashless profile images" src="https://github.com/user-attachments/assets/6db76240-8ff4-49ef-9378-6a50e1b1430d" />
