### PR TITLE
chore(ci): deploy Fastly via the lockfile-pinned CLI, not a global install

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -98,17 +98,29 @@ jobs:
       - name: Install Fastly compute dependencies
         run: npm ci
 
-      # Assert that the workspace-local binary exists before npx gets a chance
-      # to fall back to the root workspace binary, then record its version.
+      # Assert which Fastly CLI npx actually resolves: its major must match the
+      # @fastly/cli pin in compute-js/package.json. This deliberately checks the
+      # resolved version rather than a node_modules path, because the path is a
+      # side effect of version-range layout. Today compute-js pins ^16 while
+      # @fastly/compute-js-static-publish pins ^15, so npm nests a second copy
+      # under compute-js/. When static-publish's range converges on ^16, npm
+      # hoists a single copy to the root and compute-js/node_modules/ stops
+      # existing — a path guard would hard-fail that routine bump even though
+      # npx resolved the right CLI. A wrong resolution (e.g. the root ^15
+      # binary) still fails here, on the major mismatch.
       - name: Show pinned Fastly CLI version
         working-directory: compute-js
         run: |
           set -euo pipefail
-          test -x node_modules/.bin/fastly || {
-            echo "::error::compute-js/node_modules/.bin/fastly is missing; npx would fall back to the root @fastly/cli."
+          want="$(node -p "require('./package.json').devDependencies['@fastly/cli'].match(/\\d+/)[0]")"
+          version_output="$(npx --no-install fastly version)"
+          line="${version_output%%$'\n'*}"
+          got="$(printf '%s' "$line" | sed -n 's/.*v\([0-9][0-9]*\)\..*/\1/p')"
+          echo "$line (compute-js pins ^${want}.x)"
+          [ "$want" = "$got" ] || {
+            echo "::error::Fastly CLI major '${got:-unparseable}' resolved, but compute-js pins ^${want}.x; deploys would run the wrong binary."
             exit 1
           }
-          npx --no-install fastly version
 
       - name: Deploy to Fastly Compute (edge worker)
         working-directory: compute-js

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -87,7 +87,12 @@ jobs:
           cache-dependency-path: package-lock.json
 
       - name: Install Fastly CLI
-        run: npm install -g @fastly/cli
+        # Pin the version so a Fastly CLI release can't silently change the
+        # production deploy mid-pipeline. The npm package pins its platform
+        # binary exactly (optionalDependencies "=<version>"), so this makes the
+        # whole publish reproducible. Bump deliberately, not by drifting to
+        # latest.
+        run: npm install -g @fastly/cli@16.0.0
 
       - name: Install Fastly compute dependencies
         run: npm ci

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -91,21 +91,24 @@ jobs:
       # `npx --no-install fastly` from working-directory: compute-js — not a
       # global `npm install -g @fastly/cli` — so the deploy uses the
       # lockfile-pinned version (reproducible, visible to dependency tooling,
-      # and the same CLI local dev uses). Two load-bearing details: the steps
-      # MUST run from compute-js (from the repo root, npx would resolve a
-      # different @fastly/cli that compute-js-static-publish pulls in), and
-      # --no-install makes a missing pin fail loudly instead of fetching an
-      # unrelated `fastly` package from the registry. Bump the pin deliberately
-      # in compute-js/package.json.
+      # and the same CLI local dev uses). The steps MUST run from compute-js;
+      # from the repo root, npx would resolve a different @fastly/cli that
+      # compute-js-static-publish pulls in. Bump the pin deliberately in
+      # compute-js/package.json.
       - name: Install Fastly compute dependencies
         run: npm ci
 
-      # Logs the resolved CLI version in the deploy record and fails fast (via
-      # --no-install, run from compute-js) if the pin didn't resolve, before we
-      # attempt an actual publish.
+      # Assert that the workspace-local binary exists before npx gets a chance
+      # to fall back to the root workspace binary, then record its version.
       - name: Show pinned Fastly CLI version
         working-directory: compute-js
-        run: npx --no-install fastly version
+        run: |
+          set -euo pipefail
+          test -x node_modules/.bin/fastly || {
+            echo "::error::compute-js/node_modules/.bin/fastly is missing; npx would fall back to the root @fastly/cli."
+            exit 1
+          }
+          npx --no-install fastly version
 
       - name: Deploy to Fastly Compute (edge worker)
         working-directory: compute-js
@@ -140,7 +143,7 @@ jobs:
           # partial publish can't go green. We match the stable ASCII "Failed:"
           # rather than the emoji so a locale/encoding change can't silently
           # disable this guard. See #426.
-          npx @fastly/compute-js-static-publish publish-content 2>&1 | tee /tmp/publish-content.log
+          npx --no-install @fastly/compute-js-static-publish publish-content 2>&1 | tee /tmp/publish-content.log
           if grep -qF 'Failed:' /tmp/publish-content.log; then
             echo "::error::publish-content dropped one or more uploads (see 'Failed:' above)."
             exit 1

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -86,14 +86,11 @@ jobs:
           cache: 'npm'
           cache-dependency-path: package-lock.json
 
-      - name: Install Fastly CLI
-        # Pin the version so a Fastly CLI release can't silently change the
-        # production deploy mid-pipeline. The npm package pins its platform
-        # binary exactly (optionalDependencies "=<version>"), so this makes the
-        # whole publish reproducible. Bump deliberately, not by drifting to
-        # latest.
-        run: npm install -g @fastly/cli@16.0.0
-
+      # Installs the compute-js workspace deps, including @fastly/cli, pinned
+      # via package-lock. We invoke it below with `npx fastly` (not a global
+      # `npm install -g @fastly/cli`) so the deploy uses the lockfile-pinned
+      # version — reproducible, Dependabot-trackable, and the same CLI local
+      # dev uses. Bump the pin deliberately in compute-js/package.json.
       - name: Install Fastly compute dependencies
         run: npm ci
 
@@ -104,7 +101,7 @@ jobs:
         run: |
           set -euo pipefail
           for attempt in $(seq 1 5); do
-            if fastly compute publish --non-interactive --token="$FASTLY_API_TOKEN"; then
+            if npx fastly compute publish --non-interactive --token="$FASTLY_API_TOKEN"; then
               exit 0
             fi
 
@@ -147,7 +144,7 @@ jobs:
             echo "Failed to read service_id from compute-js/fastly.toml" >&2
             exit 1
           }
-          fastly purge --all --service-id "$service_id" --token="$FASTLY_API_TOKEN"
+          npx fastly purge --all --service-id "$service_id" --token="$FASTLY_API_TOKEN"
 
       - name: Verify live .well-known endpoints
         run: |

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -100,6 +100,13 @@ jobs:
       - name: Install Fastly compute dependencies
         run: npm ci
 
+      # Logs the resolved CLI version in the deploy record and fails fast (via
+      # --no-install, run from compute-js) if the pin didn't resolve, before we
+      # attempt an actual publish.
+      - name: Show pinned Fastly CLI version
+        working-directory: compute-js
+        run: npx --no-install fastly version
+
       - name: Deploy to Fastly Compute (edge worker)
         working-directory: compute-js
         env:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -87,10 +87,16 @@ jobs:
           cache-dependency-path: package-lock.json
 
       # Installs the compute-js workspace deps, including @fastly/cli, pinned
-      # via package-lock. We invoke it below with `npx fastly` (not a global
-      # `npm install -g @fastly/cli`) so the deploy uses the lockfile-pinned
-      # version — reproducible, Dependabot-trackable, and the same CLI local
-      # dev uses. Bump the pin deliberately in compute-js/package.json.
+      # via package-lock. The Fastly steps below invoke it as
+      # `npx --no-install fastly` from working-directory: compute-js — not a
+      # global `npm install -g @fastly/cli` — so the deploy uses the
+      # lockfile-pinned version (reproducible, visible to dependency tooling,
+      # and the same CLI local dev uses). Two load-bearing details: the steps
+      # MUST run from compute-js (from the repo root, npx would resolve a
+      # different @fastly/cli that compute-js-static-publish pulls in), and
+      # --no-install makes a missing pin fail loudly instead of fetching an
+      # unrelated `fastly` package from the registry. Bump the pin deliberately
+      # in compute-js/package.json.
       - name: Install Fastly compute dependencies
         run: npm ci
 
@@ -101,7 +107,7 @@ jobs:
         run: |
           set -euo pipefail
           for attempt in $(seq 1 5); do
-            if npx fastly compute publish --non-interactive --token="$FASTLY_API_TOKEN"; then
+            if npx --no-install fastly compute publish --non-interactive --token="$FASTLY_API_TOKEN"; then
               exit 0
             fi
 
@@ -144,7 +150,7 @@ jobs:
             echo "Failed to read service_id from compute-js/fastly.toml" >&2
             exit 1
           }
-          npx fastly purge --all --service-id "$service_id" --token="$FASTLY_API_TOKEN"
+          npx --no-install fastly purge --all --service-id "$service_id" --token="$FASTLY_API_TOKEN"
 
       - name: Verify live .well-known endpoints
         run: |

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -100,14 +100,16 @@ jobs:
 
       # Assert which Fastly CLI npx actually resolves: its major must match the
       # @fastly/cli pin in compute-js/package.json. This deliberately checks the
-      # resolved version rather than a node_modules path, because the path is a
-      # side effect of version-range layout. Today compute-js pins ^16 while
-      # @fastly/compute-js-static-publish pins ^15, so npm nests a second copy
-      # under compute-js/. When static-publish's range converges on ^16, npm
-      # hoists a single copy to the root and compute-js/node_modules/ stops
-      # existing — a path guard would hard-fail that routine bump even though
-      # npx resolved the right CLI. A wrong resolution (e.g. the root ^15
-      # binary) still fails here, on the major mismatch.
+      # resolved version rather than a node_modules path, because where npm
+      # places that binary is an accident of lockfile history, not a stable
+      # fact. compute-js pins ^16 while @fastly/compute-js-static-publish pins
+      # ^15; in this lock the 16.0.0 copy happens to sit under compute-js/ with
+      # 15.4.0 at the root, but resolving those same ranges in a clean tree
+      # hoists 16.0.0 to the root instead, and any lockfile regeneration can
+      # flip the layout and delete compute-js/node_modules/ outright. A path
+      # guard hard-fails on that flip even though npx still resolves the right
+      # CLI. This check passes on every layout and still fails on a wrong
+      # resolution (e.g. a root ^15 binary), on the major mismatch.
       - name: Show pinned Fastly CLI version
         working-directory: compute-js
         run: |

--- a/compute-js/package.json
+++ b/compute-js/package.json
@@ -5,7 +5,7 @@
   "author": "you@example.com",
   "type": "module",
   "devDependencies": {
-    "@fastly/cli": "^15.3.1",
+    "@fastly/cli": "^16.0.0",
     "@fastly/compute-js-static-publish": "^7.0.7"
   },
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -127,11 +127,170 @@
         "@fastly/js-compute": "^3.26.0"
       },
       "devDependencies": {
-        "@fastly/cli": "^15.3.1",
+        "@fastly/cli": "^16.0.0",
         "@fastly/compute-js-static-publish": "^7.0.7"
       },
       "engines": {
         "node": ">=20.11.0"
+      }
+    },
+    "compute-js/node_modules/@fastly/cli": {
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/@fastly/cli/-/cli-16.0.0.tgz",
+      "integrity": "sha512-BAjvjUXXYoMwyAmiDAGW7IkaI/LsUiDi6CZfNafgMpqoG+IkSuYjVx4RYwxyDfWWrOzRCaMHOtgLixISkBE79A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "fastly": "fastly.js"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "optionalDependencies": {
+        "@fastly/cli-darwin-arm64": "=16.0.0",
+        "@fastly/cli-darwin-x64": "=16.0.0",
+        "@fastly/cli-linux-arm64": "=16.0.0",
+        "@fastly/cli-linux-x32": "=16.0.0",
+        "@fastly/cli-linux-x64": "=16.0.0",
+        "@fastly/cli-win32-arm64": "=16.0.0",
+        "@fastly/cli-win32-x32": "=16.0.0",
+        "@fastly/cli-win32-x64": "=16.0.0"
+      }
+    },
+    "compute-js/node_modules/@fastly/cli-darwin-arm64": {
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/@fastly/cli-darwin-arm64/-/cli-darwin-arm64-16.0.0.tgz",
+      "integrity": "sha512-xrmTC/D71zO0DgwE5EdnQGArQyTO6nwdfk4jP+wxk1W0gh1tl5KB4nwXXRnv9+5GYnUhHpjwQAefjY5388GfIg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "bin": {
+        "cli-darwin-arm64": "fastly"
+      }
+    },
+    "compute-js/node_modules/@fastly/cli-darwin-x64": {
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/@fastly/cli-darwin-x64/-/cli-darwin-x64-16.0.0.tgz",
+      "integrity": "sha512-V1HbM8PPBaY6BXOvxlHfhKbku9zjY7Bv/j5cRTR9QIiDO391Ls/oCL0M70hsmDooAGe+pSa1+eZupFGmz9lJEQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "bin": {
+        "cli-darwin-x64": "fastly"
+      }
+    },
+    "compute-js/node_modules/@fastly/cli-linux-arm64": {
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/@fastly/cli-linux-arm64/-/cli-linux-arm64-16.0.0.tgz",
+      "integrity": "sha512-N3fqvKae7wngDnkAdxyxIHfVaphEf+uwIfDhlDnGzV68ZHjx5kd91/5dP3vT/DDgM6t4sd/S4g1gtECAlYV26w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "bin": {
+        "cli-linux-arm64": "fastly"
+      }
+    },
+    "compute-js/node_modules/@fastly/cli-linux-x32": {
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/@fastly/cli-linux-x32/-/cli-linux-x32-16.0.0.tgz",
+      "integrity": "sha512-iDIa5mLqV/8wt2AWdnS1lvOm9WHmX7ziVBHSIbAHj7WHRNo7HZHTbSWWdZiEoGIEgKyADDLl1Qp1XKYXe8bzow==",
+      "cpu": [
+        "x32"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "bin": {
+        "cli-linux-x32": "fastly"
+      }
+    },
+    "compute-js/node_modules/@fastly/cli-linux-x64": {
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/@fastly/cli-linux-x64/-/cli-linux-x64-16.0.0.tgz",
+      "integrity": "sha512-na2GNXTF+wizFcTJdEC5TGeyps8vgYBRdh+TThL+TVCUEIjmSUpMoSz5Ud6hxt/G4m03FilRlnULrq+sE4u7qw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "bin": {
+        "cli-linux-x64": "fastly"
+      }
+    },
+    "compute-js/node_modules/@fastly/cli-win32-arm64": {
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/@fastly/cli-win32-arm64/-/cli-win32-arm64-16.0.0.tgz",
+      "integrity": "sha512-Jw8tfN3MPQLHduOpYzV4bh7gEnymnHkLIamT9Fupczl+50PFDcZkyzhkA5CqVo7nql5adywgnqWRBq/C1OMCPA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "bin": {
+        "cli-win32-arm64": "fastly.exe"
+      }
+    },
+    "compute-js/node_modules/@fastly/cli-win32-x32": {
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/@fastly/cli-win32-x32/-/cli-win32-x32-16.0.0.tgz",
+      "integrity": "sha512-bMyh697yK0iHFe/KoJFRZ8o/Wk1DQ8hyBAGxjSg2FHjp6xEyOTcNH/xwzuYB/dCVni2pF/G49OOUiDhMa2leWA==",
+      "cpu": [
+        "x32"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "bin": {
+        "cli-win32-x32": "fastly.exe"
+      }
+    },
+    "compute-js/node_modules/@fastly/cli-win32-x64": {
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/@fastly/cli-win32-x64/-/cli-win32-x64-16.0.0.tgz",
+      "integrity": "sha512-U2MznzAog0AfBW5YCp+fKj1PpY/zyB0dzs/4MtllQIfKPRbamLAt0TZp2jpJHnAiG1fgUve79gjdn0UH9rREZA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "bin": {
+        "cli-win32-x64": "fastly.exe"
       }
     },
     "node_modules/@adobe/css-tools": {


### PR DESCRIPTION
Production deploys installed whatever Fastly CLI version was newest at run time, so two deploys of the same commit could use different release tooling. This change makes production use the CLI recorded in `package-lock.json` instead.

### Why this fix

- Removes the global, floating `npm install -g @fastly/cli` installation.
- Runs compute publish and cache purge from `compute-js`, using its workspace-local `@fastly/cli`.
- Asserts that the Fastly CLI `npx --no-install fastly` resolves from `compute-js` at the major version pinned in `compute-js/package.json`, so the deploy fails loudly before running the wrong binary. The check reads the resolved version rather than a node_modules path, so it holds wherever npm places the binary, including the single hoisted copy a lockfile regeneration produces.
- Prevents the static-content publisher from fetching a package from the registry during a production deploy.
- Bumps the workspace CLI to 16.0.0, matching the version production had already been using successfully.

### Scope

This changes release automation with a wide production blast radius. It does not change application code or attempt to fix the Fastly-side upload failures observed on 2026-09-02.

Removing the global install does not affect API-token discovery: `@fastly/compute-js-static-publish` reads `FASTLY_API_TOKEN` from the environment before its CLI fallback.

### Verification

- Confirmed the workspace-local executable resolves to Fastly CLI 16.0.0.
- Confirmed `npx --no-install @fastly/compute-js-static-publish --help` resolves the lockfile-installed publisher.
- Parsed `.github/workflows/deploy.yml` as YAML and ran `git diff --check`.
- Ran `npm test`: 336 test files and 2,900 tests passed, followed by a successful production build.

Closes #708

