### PR TITLE
fix(moderation): guard against reporting or muting your own content

### DIFF
--- a/src/components/FullscreenVideoItem.test.tsx
+++ b/src/components/FullscreenVideoItem.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import { forwardRef, type HTMLAttributes, type ReactNode } from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { ParsedVideoData } from '@/types/video';
@@ -8,6 +8,14 @@ const playbackMocks = vi.hoisted(() => ({
   setActiveVideo: vi.fn(),
   setUserPaused: vi.fn(),
   setGlobalMuted: vi.fn(),
+}));
+
+const authMocks = vi.hoisted(() => ({
+  useCurrentUser: vi.fn(() => ({ user: null as { pubkey: string } | null })),
+}));
+
+vi.mock('@/hooks/useCurrentUser', () => ({
+  useCurrentUser: () => authMocks.useCurrentUser(),
 }));
 
 vi.mock('react-i18next', () => ({
@@ -130,6 +138,30 @@ function renderItem(prefix?: ReactNode) {
 function setPaused(el: HTMLMediaElement, paused: boolean) {
   Object.defineProperty(el, 'paused', { value: paused, configurable: true });
 }
+
+describe('FullscreenVideoItem self-moderation affordances', () => {
+  beforeEach(() => {
+    authMocks.useCurrentUser.mockReturnValue({ user: null });
+  });
+
+  it('hides report and mute actions on the viewer\'s own video', () => {
+    authMocks.useCurrentUser.mockReturnValue({ user: { pubkey: 'f'.repeat(64) } });
+    renderItem();
+
+    expect(screen.queryByText('fullscreenVideoItem.reportVideo')).not.toBeInTheDocument();
+    expect(screen.queryByText('fullscreenVideoItem.reportUser')).not.toBeInTheDocument();
+    expect(screen.queryByText('fullscreenVideoItem.muteUser')).not.toBeInTheDocument();
+  });
+
+  it('shows report and mute actions on another user\'s video', () => {
+    authMocks.useCurrentUser.mockReturnValue({ user: { pubkey: 'a'.repeat(64) } });
+    renderItem();
+
+    expect(screen.getByText('fullscreenVideoItem.reportVideo')).toBeInTheDocument();
+    expect(screen.getByText('fullscreenVideoItem.reportUser')).toBeInTheDocument();
+    expect(screen.getByText('fullscreenVideoItem.muteUser')).toBeInTheDocument();
+  });
+});
 
 describe('FullscreenVideoItem tap-to-pause', () => {
   beforeEach(() => {

--- a/src/components/FullscreenVideoItem.test.tsx
+++ b/src/components/FullscreenVideoItem.test.tsx
@@ -42,7 +42,10 @@ vi.mock('@/hooks/useVideoLists', () => ({ useVideosInLists: () => ({ data: undef
 vi.mock('@/hooks/useModeration', () => ({ useMuteItem: () => ({ mutateAsync: vi.fn() }) }));
 vi.mock('@/hooks/useDeleteVideo', () => ({
   useDeleteVideo: () => ({ mutate: vi.fn(), isPending: false }),
-  useCanDeleteVideo: () => false,
+}));
+vi.mock('@/hooks/useIsOwnVideo', () => ({
+  useIsOwnVideo: (video?: ParsedVideoData) =>
+    authMocks.useCurrentUser().user?.pubkey === video?.pubkey,
 }));
 vi.mock('@/hooks/useToast', () => ({ useToast: () => ({ toast: vi.fn() }) }));
 vi.mock('@/hooks/useBadges', () => ({ useBadges: () => ({ data: undefined }) }));
@@ -139,11 +142,11 @@ function setPaused(el: HTMLMediaElement, paused: boolean) {
   Object.defineProperty(el, 'paused', { value: paused, configurable: true });
 }
 
-describe('FullscreenVideoItem self-moderation affordances', () => {
-  beforeEach(() => {
-    authMocks.useCurrentUser.mockReturnValue({ user: null });
-  });
+beforeEach(() => {
+  authMocks.useCurrentUser.mockReturnValue({ user: null });
+});
 
+describe('FullscreenVideoItem self-moderation affordances', () => {
   it('hides report and mute actions on the viewer\'s own video', () => {
     authMocks.useCurrentUser.mockReturnValue({ user: { pubkey: 'f'.repeat(64) } });
     renderItem();

--- a/src/components/FullscreenVideoItem.tsx
+++ b/src/components/FullscreenVideoItem.tsx
@@ -20,8 +20,8 @@ import { useVideoPlayback } from '@/hooks/useVideoPlayback';
 import { useVideoReactions } from '@/hooks/useVideoReactions';
 import { useVideosInLists } from '@/hooks/useVideoLists';
 import { useMuteItem } from '@/hooks/useModeration';
-import { useCurrentUser } from '@/hooks/useCurrentUser';
-import { useDeleteVideo, useCanDeleteVideo } from '@/hooks/useDeleteVideo';
+import { useDeleteVideo } from '@/hooks/useDeleteVideo';
+import { useIsOwnVideo } from '@/hooks/useIsOwnVideo';
 import { useToast } from '@/hooks/useToast';
 import { enhanceAuthorData } from '@/lib/generateProfile';
 import { genUserName } from '@/lib/genUserName';
@@ -117,12 +117,7 @@ export function FullscreenVideoItem({
   const { toast } = useToast();
   const muteUser = useMuteItem();
   const { mutate: deleteVideo, isPending: isDeleting } = useDeleteVideo();
-  const canDelete = useCanDeleteVideo(video);
-  const { user: currentUser } = useCurrentUser();
-  // Reporting and muting are meaningless against yourself, and divine-web is a
-  // trusted report client, so hide those affordances on your own content. The
-  // useReportContent/useMuteItem hooks reject self-targets regardless.
-  const isOwnVideo = !!currentUser && currentUser.pubkey === video.pubkey;
+  const isOwnVideo = useIsOwnVideo(video);
   const { data: reactions } = useVideoReactions(video.id, video.pubkey, video.vineId);
   const { data: lists } = useVideosInLists(video.vineId ?? undefined, video.id);
   const playbackCountLabel = video.isVineMigrated
@@ -515,7 +510,7 @@ export function FullscreenVideoItem({
                   </button>
                 </DropdownMenuTrigger>
                 <DropdownMenuContent align="end" className="bg-black/90 border-white/20 text-white">
-                  {canDelete && (
+                  {isOwnVideo && (
                     <>
                       <DropdownMenuItem
                         onClick={() => setShowDeleteDialog(true)}

--- a/src/components/FullscreenVideoItem.tsx
+++ b/src/components/FullscreenVideoItem.tsx
@@ -20,6 +20,7 @@ import { useVideoPlayback } from '@/hooks/useVideoPlayback';
 import { useVideoReactions } from '@/hooks/useVideoReactions';
 import { useVideosInLists } from '@/hooks/useVideoLists';
 import { useMuteItem } from '@/hooks/useModeration';
+import { useCurrentUser } from '@/hooks/useCurrentUser';
 import { useDeleteVideo, useCanDeleteVideo } from '@/hooks/useDeleteVideo';
 import { useToast } from '@/hooks/useToast';
 import { enhanceAuthorData } from '@/lib/generateProfile';
@@ -117,6 +118,11 @@ export function FullscreenVideoItem({
   const muteUser = useMuteItem();
   const { mutate: deleteVideo, isPending: isDeleting } = useDeleteVideo();
   const canDelete = useCanDeleteVideo(video);
+  const { user: currentUser } = useCurrentUser();
+  // Reporting and muting are meaningless against yourself, and divine-web is a
+  // trusted report client, so hide those affordances on your own content. The
+  // useReportContent/useMuteItem hooks reject self-targets regardless.
+  const isOwnVideo = !!currentUser && currentUser.pubkey === video.pubkey;
   const { data: reactions } = useVideoReactions(video.id, video.pubkey, video.vineId);
   const { data: lists } = useVideosInLists(video.vineId ?? undefined, video.id);
   const playbackCountLabel = video.isVineMigrated
@@ -521,29 +527,33 @@ export function FullscreenVideoItem({
                       <DropdownMenuSeparator className="bg-white/20" />
                     </>
                   )}
-                  <DropdownMenuItem
-                    onClick={() => setShowReportDialog(true)}
-                    className="focus:bg-white/10"
-                  >
-                    <Flag className="h-4 w-4 mr-2" />
-                    {t('fullscreenVideoItem.reportVideo')}
-                  </DropdownMenuItem>
-                  <DropdownMenuItem
-                    onClick={() => setShowReportUserDialog(true)}
-                    className="focus:bg-white/10"
-                  >
-                    <Flag className="h-4 w-4 mr-2" />
-                    {t('fullscreenVideoItem.reportUser')}
-                  </DropdownMenuItem>
-                  <DropdownMenuSeparator className="bg-white/20" />
-                  <DropdownMenuItem
-                    onClick={handleMuteUser}
-                    className="text-red-400 focus:text-red-400 focus:bg-red-500/20"
-                  >
-                    <UserX className="h-4 w-4 mr-2" />
-                    {t('fullscreenVideoItem.muteUser', { name: displayName })}
-                  </DropdownMenuItem>
-                  <DropdownMenuSeparator className="bg-white/20" />
+                  {!isOwnVideo && (
+                    <>
+                      <DropdownMenuItem
+                        onClick={() => setShowReportDialog(true)}
+                        className="focus:bg-white/10"
+                      >
+                        <Flag className="h-4 w-4 mr-2" />
+                        {t('fullscreenVideoItem.reportVideo')}
+                      </DropdownMenuItem>
+                      <DropdownMenuItem
+                        onClick={() => setShowReportUserDialog(true)}
+                        className="focus:bg-white/10"
+                      >
+                        <Flag className="h-4 w-4 mr-2" />
+                        {t('fullscreenVideoItem.reportUser')}
+                      </DropdownMenuItem>
+                      <DropdownMenuSeparator className="bg-white/20" />
+                      <DropdownMenuItem
+                        onClick={handleMuteUser}
+                        className="text-red-400 focus:text-red-400 focus:bg-red-500/20"
+                      >
+                        <UserX className="h-4 w-4 mr-2" />
+                        {t('fullscreenVideoItem.muteUser', { name: displayName })}
+                      </DropdownMenuItem>
+                      <DropdownMenuSeparator className="bg-white/20" />
+                    </>
+                  )}
                   <DropdownMenuItem
                     onClick={() => setShowViewSourceDialog(true)}
                     className="focus:bg-white/10"

--- a/src/components/VideoCard.test.tsx
+++ b/src/components/VideoCard.test.tsx
@@ -671,4 +671,24 @@ describe('VideoCard', () => {
     expect(screen.getByTestId(`video-player-${video.id}`)).toBeInTheDocument();
     expect(screen.queryByText('Failed to load video')).not.toBeInTheDocument();
   });
+
+  describe('self-moderation affordances', () => {
+    it('hides report and mute actions on the viewer\'s own video', () => {
+      authMocks.useCurrentUser.mockReturnValue({ user: { pubkey: 'f'.repeat(64) } });
+      render(<VideoCard video={baseVideo} />);
+
+      expect(screen.queryByText('Report video')).not.toBeInTheDocument();
+      expect(screen.queryByText('Report user')).not.toBeInTheDocument();
+      expect(screen.queryByText(/^Mute /)).not.toBeInTheDocument();
+    });
+
+    it('shows report and mute actions on another user\'s video', () => {
+      authMocks.useCurrentUser.mockReturnValue({ user: { pubkey: 'a'.repeat(64) } });
+      render(<VideoCard video={baseVideo} />);
+
+      expect(screen.getByText('Report video')).toBeInTheDocument();
+      expect(screen.getByText('Report user')).toBeInTheDocument();
+      expect(screen.getByText(/^Mute /)).toBeInTheDocument();
+    });
+  });
 });

--- a/src/components/VideoCard.test.tsx
+++ b/src/components/VideoCard.test.tsx
@@ -219,7 +219,11 @@ vi.mock('@/hooks/useDeleteVideo', () => ({
     mutate: playbackMocks.deleteVideo,
     isPending: false,
   }),
-  useCanDeleteVideo: () => false,
+}));
+
+vi.mock('@/hooks/useIsOwnVideo', () => ({
+  useIsOwnVideo: (video?: ParsedVideoData) =>
+    authMocks.useCurrentUser()?.user?.pubkey === video?.pubkey,
 }));
 
 vi.mock('@/hooks/usePinnedVideos', () => ({

--- a/src/components/VideoCard.tsx
+++ b/src/components/VideoCard.tsx
@@ -23,7 +23,8 @@ import { VideoVerificationBadgeRow } from '@/components/VideoVerificationBadgeRo
 import { useAuthor } from '@/hooks/useAuthor';
 import { useIsMobile } from '@/hooks/useIsMobile';
 import { useMuteItem } from '@/hooks/useModeration';
-import { useDeleteVideo, useCanDeleteVideo } from '@/hooks/useDeleteVideo';
+import { useDeleteVideo } from '@/hooks/useDeleteVideo';
+import { useIsOwnVideo } from '@/hooks/useIsOwnVideo';
 import { useIsVideoPinned, usePinVideo, useUnpinVideo } from '@/hooks/usePinnedVideos';
 import { useCurrentUser } from '@/hooks/useCurrentUser';
 import { useAdultVerification } from '@/hooks/useAdultVerification';
@@ -259,12 +260,8 @@ export function VideoCard({
   const showSubtitles = subtitlesVisible && hasSubtitles;
 
   const { mutate: deleteVideo, isPending: isDeleting } = useDeleteVideo();
-  const canDelete = useCanDeleteVideo(video);
+  const isOwnVideo = useIsOwnVideo(video);
   const { user: currentUser } = useCurrentUser();
-  // Reporting and muting are meaningless against yourself, and divine-web is a
-  // trusted report client, so hide those affordances on your own content. The
-  // useReportContent/useMuteItem hooks reject self-targets regardless.
-  const isOwnVideo = !!currentUser && currentUser.pubkey === video.pubkey;
   const coordinate = video.vineId ? `${SHORT_VIDEO_KIND}:${video.pubkey}:${video.vineId}` : undefined;
   const isPinned = useIsVideoPinned(coordinate);
   const { mutateAsync: pinVideo } = usePinVideo();
@@ -1021,7 +1018,7 @@ export function VideoCard({
                   <DropdownMenuSeparator />
                 </>
               )}
-              {canDelete && (
+              {isOwnVideo && (
                 <>
                   <DropdownMenuItem
                     onClick={() => setShowDeleteDialog(true)}

--- a/src/components/VideoCard.tsx
+++ b/src/components/VideoCard.tsx
@@ -261,6 +261,10 @@ export function VideoCard({
   const { mutate: deleteVideo, isPending: isDeleting } = useDeleteVideo();
   const canDelete = useCanDeleteVideo(video);
   const { user: currentUser } = useCurrentUser();
+  // Reporting and muting are meaningless against yourself, and divine-web is a
+  // trusted report client, so hide those affordances on your own content. The
+  // useReportContent/useMuteItem hooks reject self-targets regardless.
+  const isOwnVideo = !!currentUser && currentUser.pubkey === video.pubkey;
   const coordinate = video.vineId ? `${SHORT_VIDEO_KIND}:${video.pubkey}:${video.vineId}` : undefined;
   const isPinned = useIsVideoPinned(coordinate);
   const { mutateAsync: pinVideo } = usePinVideo();
@@ -1029,20 +1033,24 @@ export function VideoCard({
                   <DropdownMenuSeparator />
                 </>
               )}
-              <DropdownMenuItem onClick={() => setShowReportDialog(true)}>
-                <Flag className="h-4 w-4 mr-2" />
-                {t('videoCard.menu.reportVideo')}
-              </DropdownMenuItem>
-              <DropdownMenuItem onClick={() => setShowReportUserDialog(true)}>
-                <Flag className="h-4 w-4 mr-2" />
-                {t('videoCard.menu.reportUser')}
-              </DropdownMenuItem>
-              <DropdownMenuSeparator />
-              <DropdownMenuItem onClick={handleMuteUser} className="text-destructive focus:text-destructive">
-                <UserX className="h-4 w-4 mr-2" />
-                {t('videoCard.menu.muteUser', { name: displayName })}
-              </DropdownMenuItem>
-              <DropdownMenuSeparator />
+              {!isOwnVideo && (
+                <>
+                  <DropdownMenuItem onClick={() => setShowReportDialog(true)}>
+                    <Flag className="h-4 w-4 mr-2" />
+                    {t('videoCard.menu.reportVideo')}
+                  </DropdownMenuItem>
+                  <DropdownMenuItem onClick={() => setShowReportUserDialog(true)}>
+                    <Flag className="h-4 w-4 mr-2" />
+                    {t('videoCard.menu.reportUser')}
+                  </DropdownMenuItem>
+                  <DropdownMenuSeparator />
+                  <DropdownMenuItem onClick={handleMuteUser} className="text-destructive focus:text-destructive">
+                    <UserX className="h-4 w-4 mr-2" />
+                    {t('videoCard.menu.muteUser', { name: displayName })}
+                  </DropdownMenuItem>
+                  <DropdownMenuSeparator />
+                </>
+              )}
               <DropdownMenuItem onClick={() => setShowViewSourceDialog(true)}>
                 <Code className="h-4 w-4 mr-2" />
                 {t('videoCard.menu.viewSource')}

--- a/src/hooks/useDeleteVideo.ts
+++ b/src/hooks/useDeleteVideo.ts
@@ -87,15 +87,3 @@ export function useDeleteVideo() {
     },
   });
 }
-
-/**
- * Hook for checking if user can delete a video
- */
-export function useCanDeleteVideo(video?: ParsedVideoData): boolean {
-  const { user } = useCurrentUser();
-
-  if (!user?.pubkey || !video) return false;
-
-  // User can only delete their own videos
-  return user.pubkey === video.pubkey;
-}

--- a/src/hooks/useIsOwnVideo.ts
+++ b/src/hooks/useIsOwnVideo.ts
@@ -1,0 +1,10 @@
+import { useCurrentUser } from '@/hooks/useCurrentUser';
+import type { ParsedVideoData } from '@/types/video';
+
+export function useIsOwnVideo(video?: ParsedVideoData): boolean {
+  const { user } = useCurrentUser();
+
+  if (!user?.pubkey || !video) return false;
+
+  return user.pubkey === video.pubkey;
+}

--- a/src/hooks/useModeration.test.ts
+++ b/src/hooks/useModeration.test.ts
@@ -218,6 +218,45 @@ describe('useReportContent', () => {
     expect(call.tags).toContainEqual(['L', 'social.nos.ontology']);
     expect(call.tags).toContainEqual(['l', 'NS-harassment', 'social.nos.ontology']);
   });
+
+  it('rejects a report of the reporter\'s own content and publishes nothing', async () => {
+    mockPublishEvent.mockResolvedValue({ id: 'test' });
+
+    const { result } = renderHook(() => useReportContent(), { wrapper: createWrapper() });
+
+    let error: unknown;
+    await act(async () => {
+      try {
+        await result.current.mutateAsync({
+          eventId: mockEventId,
+          pubkey: mockUserPubkey,
+          reason: ContentFilterReason.SPAM,
+        });
+      } catch (e) {
+        error = e;
+      }
+    });
+
+    expect(error).toBeInstanceOf(Error);
+    expect((error as Error).message).toBe('Cannot report your own content');
+    expect(mockPublishEvent).not.toHaveBeenCalled();
+  });
+
+  it('still reports another user\'s content', async () => {
+    mockPublishEvent.mockResolvedValue({ id: 'test' });
+
+    const { result } = renderHook(() => useReportContent(), { wrapper: createWrapper() });
+
+    await act(() =>
+      result.current.mutateAsync({
+        pubkey: mockReportedPubkey,
+        reason: ContentFilterReason.SPAM,
+      })
+    );
+
+    expect(mockPublishEvent).toHaveBeenCalledOnce();
+    expect(mockPublishEvent.mock.calls[0][0].kind).toBe(1984);
+  });
 });
 
 function makeMuteEvent(
@@ -526,6 +565,56 @@ describe('useMuteItem', () => {
 
     expect(error).toBeInstanceOf(Error);
     expect(mockPublishEvent).not.toHaveBeenCalled();
+  });
+
+  it('rejects muting the current user\'s own pubkey and publishes nothing', async () => {
+    mockMuteQuery.mockResolvedValue([]);
+    mockPublishEvent.mockResolvedValue({});
+
+    const { result } = renderHook(() => useMuteItem(), { wrapper: createWrapper() });
+
+    let error: unknown;
+    await act(async () => {
+      try {
+        await result.current.mutateAsync({ type: MuteType.USER, value: mockUserPubkey });
+      } catch (e) {
+        error = e;
+      }
+    });
+
+    expect(error).toBeInstanceOf(Error);
+    expect((error as Error).message).toBe('Cannot mute yourself');
+    expect(mockPublishEvent).not.toHaveBeenCalled();
+  });
+
+  it('still mutes another user', async () => {
+    mockMuteQuery.mockResolvedValue([]);
+    mockPublishEvent.mockResolvedValue({});
+
+    const { result } = renderHook(() => useMuteItem(), { wrapper: createWrapper() });
+
+    await act(async () => {
+      await result.current.mutateAsync({ type: MuteType.USER, value: 'target-pubkey' });
+    });
+
+    expect(mockPublishEvent).toHaveBeenCalledOnce();
+    expect(mockPublishEvent.mock.calls[0][0].kind).toBe(MUTE_LIST_KIND);
+  });
+
+  it('does not treat a non-user mute whose value equals the pubkey as a self-mute', async () => {
+    // The self-guard is scoped to user mutes; a hashtag or keyword that happens
+    // to equal the viewer's pubkey string must still publish.
+    mockMuteQuery.mockResolvedValue([]);
+    mockPublishEvent.mockResolvedValue({});
+
+    const { result } = renderHook(() => useMuteItem(), { wrapper: createWrapper() });
+
+    await act(async () => {
+      await result.current.mutateAsync({ type: MuteType.HASHTAG, value: mockUserPubkey });
+    });
+
+    expect(mockPublishEvent).toHaveBeenCalledOnce();
+    expect(mockPublishEvent.mock.calls[0][0].tags).toContainEqual(['t', mockUserPubkey]);
   });
 });
 

--- a/src/hooks/useModeration.ts
+++ b/src/hooks/useModeration.ts
@@ -284,6 +284,12 @@ export function useMuteItem() {
       reason?: string;
     }) => {
       if (!user) throw new Error('Must be logged in to mute content');
+      // A user muting their own pubkey is nonsensical and, more importantly,
+      // divine-web is a trusted report client: keep every self-directed
+      // moderation path closed at the hook, mirroring useBlockUser.
+      if (type === MuteType.USER && value === user.pubkey) {
+        throw new Error('Cannot mute yourself');
+      }
 
       const didPublish = await publishMuteListUpdate({
         nostr,
@@ -430,6 +436,13 @@ export function useReportContent() {
       reporterName?: string;
     }) => {
       if (!user) throw new Error('Must be logged in to report content');
+      // divine-web is a TRUSTED_REPORT_CLIENT: a kind-1984 report published here
+      // counts toward the two-reporter threshold for automatic age restriction,
+      // so a self-report would let a user supply half that threshold against
+      // themselves. Reject it before anything is published, mirroring useBlockUser.
+      if (pubkey === user.pubkey) {
+        throw new Error('Cannot report your own content');
+      }
 
       // NIP-56: p tag is required for all kind:1984 reports
       const tags: string[][] = [];

--- a/src/lib/i18n/locales/ar/common.json
+++ b/src/lib/i18n/locales/ar/common.json
@@ -672,6 +672,7 @@
     "toastErrorTitle": "خطأ",
     "toastErrorEnterValue": "يرجى إدخال قيمة لكتمها",
     "toastErrorInvalidNpub": "صيغة npub غير صالحة",
+    "toastErrorMuteYourself": "لا يمكنك كتم نفسك.",
     "toastMutedTitle": "تم الكتم",
     "toastMutedDescription": "تمت الإضافة إلى قائمة الكتم بنجاح",
     "toastMuteFailed": "فشل الكتم. يرجى المحاولة مجدداً.",

--- a/src/lib/i18n/locales/de/common.json
+++ b/src/lib/i18n/locales/de/common.json
@@ -628,6 +628,7 @@
     "toastErrorTitle": "Fehler",
     "toastErrorEnterValue": "Bitte gib einen Wert zum Stummschalten ein",
     "toastErrorInvalidNpub": "Ungültiges npub-Format",
+    "toastErrorMuteYourself": "Du kannst dich nicht selbst stummschalten.",
     "toastMutedTitle": "Stummgeschaltet",
     "toastMutedDescription": "Erfolgreich zur Mute-Liste hinzugefügt",
     "toastMuteFailed": "Stummschalten fehlgeschlagen. Bitte nochmal versuchen.",

--- a/src/lib/i18n/locales/en/common.json
+++ b/src/lib/i18n/locales/en/common.json
@@ -628,6 +628,7 @@
     "toastErrorTitle": "Error",
     "toastErrorEnterValue": "Please enter a value to mute",
     "toastErrorInvalidNpub": "Invalid npub format",
+    "toastErrorMuteYourself": "You can’t mute yourself.",
     "toastMutedTitle": "Muted",
     "toastMutedDescription": "Successfully added to mute list",
     "toastMuteFailed": "Failed to mute. Please try again.",

--- a/src/lib/i18n/locales/es/common.json
+++ b/src/lib/i18n/locales/es/common.json
@@ -628,6 +628,7 @@
     "toastErrorTitle": "Error",
     "toastErrorEnterValue": "Introduce un valor para silenciar",
     "toastErrorInvalidNpub": "Formato de npub inválido",
+    "toastErrorMuteYourself": "No puedes silenciarte.",
     "toastMutedTitle": "Silenciado",
     "toastMutedDescription": "Añadido a la lista de silenciados",
     "toastMuteFailed": "Falló al silenciar. Inténtalo de nuevo.",

--- a/src/lib/i18n/locales/fil/common.json
+++ b/src/lib/i18n/locales/fil/common.json
@@ -628,6 +628,7 @@
     "toastErrorTitle": "May Problema",
     "toastErrorEnterValue": "Maglagay ng value na imu-mute",
     "toastErrorInvalidNpub": "Mali ang format ng npub",
+    "toastErrorMuteYourself": "Hindi mo puwedeng i-mute ang sarili mo.",
     "toastMutedTitle": "Na-mute",
     "toastMutedDescription": "Naidagdag sa mute list",
     "toastMuteFailed": "Hindi na-mute. Subukan ulit?",

--- a/src/lib/i18n/locales/fr/common.json
+++ b/src/lib/i18n/locales/fr/common.json
@@ -628,6 +628,7 @@
     "toastErrorTitle": "Erreur",
     "toastErrorEnterValue": "Saisis une valeur à couper",
     "toastErrorInvalidNpub": "Format de npub invalide",
+    "toastErrorMuteYourself": "Tu ne peux pas te mettre toi-même en sourdine.",
     "toastMutedTitle": "Coupé",
     "toastMutedDescription": "Ajouté à la liste de mute",
     "toastMuteFailed": "Échec du mute. Réessaie.",

--- a/src/lib/i18n/locales/id/common.json
+++ b/src/lib/i18n/locales/id/common.json
@@ -628,6 +628,7 @@
     "toastErrorTitle": "Error",
     "toastErrorEnterValue": "Silakan masukkan nilai untuk dibisukan",
     "toastErrorInvalidNpub": "Format npub tidak valid",
+    "toastErrorMuteYourself": "Kamu tidak dapat membisukan diri sendiri.",
     "toastMutedTitle": "Dibisukan",
     "toastMutedDescription": "Berhasil ditambahkan ke mute list",
     "toastMuteFailed": "Gagal membisukan. Coba lagi.",

--- a/src/lib/i18n/locales/it/common.json
+++ b/src/lib/i18n/locales/it/common.json
@@ -628,6 +628,7 @@
     "toastErrorTitle": "Errore",
     "toastErrorEnterValue": "Inserisci un valore da silenziare",
     "toastErrorInvalidNpub": "Formato npub non valido",
+    "toastErrorMuteYourself": "Non puoi silenziare te stesso.",
     "toastMutedTitle": "Silenziato",
     "toastMutedDescription": "Aggiunto correttamente alla lista silenziati",
     "toastMuteFailed": "Silenziamento non riuscito. Riprova.",

--- a/src/lib/i18n/locales/ja/common.json
+++ b/src/lib/i18n/locales/ja/common.json
@@ -628,6 +628,7 @@
     "toastErrorTitle": "エラー",
     "toastErrorEnterValue": "ミュートする値を入力してください",
     "toastErrorInvalidNpub": "npubの形式が無効です",
+    "toastErrorMuteYourself": "自分自身をミュートすることはできません。",
     "toastMutedTitle": "ミュートしました",
     "toastMutedDescription": "ミュートリストに追加しました",
     "toastMuteFailed": "ミュートに失敗しました。もう一度試してください。",

--- a/src/lib/i18n/locales/ko/common.json
+++ b/src/lib/i18n/locales/ko/common.json
@@ -628,6 +628,7 @@
     "toastErrorTitle": "오류",
     "toastErrorEnterValue": "음소거할 값을 입력하세요",
     "toastErrorInvalidNpub": "잘못된 npub 형식",
+    "toastErrorMuteYourself": "자기 자신을 음소거할 수 없습니다.",
     "toastMutedTitle": "음소거됨",
     "toastMutedDescription": "음소거 리스트에 추가됐어요",
     "toastMuteFailed": "음소거 실패. 다시 시도해 주세요.",

--- a/src/lib/i18n/locales/ms/common.json
+++ b/src/lib/i18n/locales/ms/common.json
@@ -628,6 +628,7 @@
     "toastErrorTitle": "Ralat",
     "toastErrorEnterValue": "Sila masukkan nilai untuk disenyapkan",
     "toastErrorInvalidNpub": "Format npub tidak sah",
+    "toastErrorMuteYourself": "Anda tidak boleh menyenyapkan diri sendiri.",
     "toastMutedTitle": "Disenyapkan",
     "toastMutedDescription": "Berjaya ditambah ke senarai senyap",
     "toastMuteFailed": "Gagal menyenyapkan. Sila cuba lagi.",

--- a/src/lib/i18n/locales/nl/common.json
+++ b/src/lib/i18n/locales/nl/common.json
@@ -628,6 +628,7 @@
     "toastErrorTitle": "Fout",
     "toastErrorEnterValue": "Voer een waarde in om te dempen",
     "toastErrorInvalidNpub": "Ongeldig npub-formaat",
+    "toastErrorMuteYourself": "Je kunt jezelf niet dempen.",
     "toastMutedTitle": "Gedempt",
     "toastMutedDescription": "Met succes toegevoegd aan mutelist",
     "toastMuteFailed": "Dempen mislukt. Probeer het opnieuw.",

--- a/src/lib/i18n/locales/pl/common.json
+++ b/src/lib/i18n/locales/pl/common.json
@@ -628,6 +628,7 @@
     "toastErrorTitle": "Błąd",
     "toastErrorEnterValue": "Wpisz wartość do wyciszenia",
     "toastErrorInvalidNpub": "Nieprawidłowy format npub",
+    "toastErrorMuteYourself": "Nie możesz wyciszyć siebie.",
     "toastMutedTitle": "Wyciszone",
     "toastMutedDescription": "Dodano do listy wyciszeń",
     "toastMuteFailed": "Wyciszenie się nie udało. Spróbuj jeszcze raz.",

--- a/src/lib/i18n/locales/pt/common.json
+++ b/src/lib/i18n/locales/pt/common.json
@@ -628,6 +628,7 @@
     "toastErrorTitle": "Erro",
     "toastErrorEnterValue": "Digita um valor pra silenciar",
     "toastErrorInvalidNpub": "Formato de npub inválido",
+    "toastErrorMuteYourself": "Não podes silenciar-te.",
     "toastMutedTitle": "Silenciado",
     "toastMutedDescription": "Adicionado à lista de silenciamento",
     "toastMuteFailed": "Falha ao silenciar. Tenta de novo.",

--- a/src/lib/i18n/locales/ro/common.json
+++ b/src/lib/i18n/locales/ro/common.json
@@ -628,6 +628,7 @@
     "toastErrorTitle": "Eroare",
     "toastErrorEnterValue": "Te rugăm introdu o valoare pentru mute",
     "toastErrorInvalidNpub": "Format npub invalid",
+    "toastErrorMuteYourself": "Nu te poți dezactiva pe tine.",
     "toastMutedTitle": "Mut",
     "toastMutedDescription": "Adăugat cu succes pe lista de mute",
     "toastMuteFailed": "Mute-ul a eșuat. Mai încearcă.",

--- a/src/lib/i18n/locales/sv/common.json
+++ b/src/lib/i18n/locales/sv/common.json
@@ -628,6 +628,7 @@
     "toastErrorTitle": "Fel",
     "toastErrorEnterValue": "Ange ett värde att tysta",
     "toastErrorInvalidNpub": "Ogiltigt npub-format",
+    "toastErrorMuteYourself": "Du kan inte tysta dig själv.",
     "toastMutedTitle": "Tystad",
     "toastMutedDescription": "Tillagd i tystningslistan",
     "toastMuteFailed": "Kunde inte tysta. Försök igen.",

--- a/src/lib/i18n/locales/tr/common.json
+++ b/src/lib/i18n/locales/tr/common.json
@@ -628,6 +628,7 @@
     "toastErrorTitle": "Hata",
     "toastErrorEnterValue": "Lütfen susturmak için bir değer gir",
     "toastErrorInvalidNpub": "Geçersiz npub formatı",
+    "toastErrorMuteYourself": "Kendini susturamazsın.",
     "toastMutedTitle": "Susturuldu",
     "toastMutedDescription": "Susturma listesine eklendi",
     "toastMuteFailed": "Susturma başarısız. Lütfen tekrar dene.",

--- a/src/lib/i18n/locales/ur/common.json
+++ b/src/lib/i18n/locales/ur/common.json
@@ -628,6 +628,7 @@
     "toastErrorTitle": "خرابی",
     "toastErrorEnterValue": "میوٹ کرنے کے لیے کوئی قیمت درج کریں",
     "toastErrorInvalidNpub": "npub فارمیٹ غلط ہے",
+    "toastErrorMuteYourself": "آپ خود کو میوٹ نہیں کر سکتے۔",
     "toastMutedTitle": "میوٹ کر دیا گیا",
     "toastMutedDescription": "میوٹ فہرست میں کامیابی سے شامل کر دیا گیا",
     "toastMuteFailed": "میوٹ ناکام۔ دوبارہ کوشش کریں۔",

--- a/src/lib/i18n/locales/vi/common.json
+++ b/src/lib/i18n/locales/vi/common.json
@@ -628,6 +628,7 @@
     "toastErrorTitle": "Lỗi",
     "toastErrorEnterValue": "Vui lòng nhập giá trị để tắt tiếng",
     "toastErrorInvalidNpub": "Định dạng npub không hợp lệ",
+    "toastErrorMuteYourself": "Bạn không thể tự tắt tiếng mình.",
     "toastMutedTitle": "Đã tắt tiếng",
     "toastMutedDescription": "Đã thêm vào danh sách tắt tiếng",
     "toastMuteFailed": "Không tắt tiếng được. Vui lòng thử lại.",

--- a/src/lib/i18n/locales/zh/common.json
+++ b/src/lib/i18n/locales/zh/common.json
@@ -628,6 +628,7 @@
     "toastErrorTitle": "出错",
     "toastErrorEnterValue": "请输入要屏蔽的内容",
     "toastErrorInvalidNpub": "npub 格式无效",
+    "toastErrorMuteYourself": "你不能屏蔽自己。",
     "toastMutedTitle": "已屏蔽",
     "toastMutedDescription": "已成功加入屏蔽列表",
     "toastMuteFailed": "屏蔽失败，请再试一次。",

--- a/src/pages/ModerationSettingsPage.test.tsx
+++ b/src/pages/ModerationSettingsPage.test.tsx
@@ -2,6 +2,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import type { ButtonHTMLAttributes, HTMLAttributes, InputHTMLAttributes, ReactNode } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { nip19 } from 'nostr-tools';
 
 import { initializeI18n } from '@/lib/i18n';
 import ModerationSettingsPage from './ModerationSettingsPage';
@@ -12,6 +13,7 @@ const {
   mockInvalidateQueries,
   mockMuteList,
   mockBlockedPubkeys,
+  mockMute,
   mockUnmute,
 } = vi.hoisted(() => ({
   mockToast: vi.fn(),
@@ -25,6 +27,7 @@ const {
     origin?: 'web' | 'unknown';
   }>,
   mockBlockedPubkeys: new Set<string>(),
+  mockMute: vi.fn(),
   mockUnmute: vi.fn(),
 }));
 
@@ -40,7 +43,7 @@ vi.mock('@/hooks/useModeration', () => ({
     isLoading: false,
   }),
   useMuteItem: () => ({
-    mutateAsync: vi.fn(),
+    mutateAsync: mockMute,
     isPending: false,
   }),
   useUnmuteItem: () => ({
@@ -270,5 +273,21 @@ describe('ModerationSettingsPage', () => {
 
     expect(await screen.findByText(/This mute was added from web/i)).toBeInTheDocument();
     expect(mockUnmute).not.toHaveBeenCalled();
+  });
+
+  it('explains why the current user cannot mute themselves', async () => {
+    renderPage();
+
+    fireEvent.change(screen.getByLabelText(/npub or pubkey/i), {
+      target: { value: nip19.npubEncode('f'.repeat(64)) },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /add to mute list/i }));
+
+    expect(mockToast).toHaveBeenCalledWith({
+      title: 'Error',
+      description: 'You can’t mute yourself.',
+      variant: 'destructive',
+    });
+    expect(mockMute).not.toHaveBeenCalled();
   });
 });

--- a/src/pages/ModerationSettingsPage.tsx
+++ b/src/pages/ModerationSettingsPage.tsx
@@ -266,6 +266,15 @@ export default function ModerationSettingsPage() {
           });
           return;
         }
+
+        if (value === user?.pubkey) {
+          toast({
+            title: t('moderationSettings.toastErrorTitle'),
+            description: t('moderationSettings.toastErrorMuteYourself'),
+            variant: 'destructive',
+          });
+          return;
+        }
       }
 
       await muteItem.mutateAsync({


### PR DESCRIPTION
Closes #705.

## What
Stop a signed-in user from reporting or muting their own content.

## Why
divine-web is a trusted report client, so a kind-1984 report from here counts toward the two-reporter threshold for automatic age restriction. Without a guard a user could report their own video and supply half that threshold against themselves. Muting yourself had the same missing guard. Blocking was already protected; reporting and muting were not.

## Change
Guard at the hook, before anything publishes:
- `useReportContent` rejects a report whose target is your own pubkey.
- `useMuteItem` rejects a self-directed user mute, and leaves hashtag and keyword mutes alone.

Both throw before any relay publish, Zendesk POST, or local write, mirroring the existing self-block guard. Every report and mute entry point (video card, fullscreen, profile, comments, moderation settings) flows through these two hooks, so the guard closes every path. The menu items are also hidden on your own videos in `VideoCard` and `FullscreenVideoItem`, matching how delete is gated; that part is convenience, the hook is the backstop.

## Tests
- Self-report and self-mute are rejected and publish nothing; reporting or muting another user still works; a hashtag mute equal to your own pubkey string still publishes.
- Menu items hidden on your own video, shown on another's.
- Confirmed the report test fails when the guard is removed.

## Related
- divinevideo/divine-mobile#8454 closed the same gap in the mobile client.
- divinevideo/divine-moderation-service#213 adds a server-side backstop that flags self-reports and does not auto-act on them.
