### PR TITLE
fix(verify): stop invalid Discord proofs from rendering as links

### DIFF
--- a/src/hooks/useExternalIdentities.test.ts
+++ b/src/hooks/useExternalIdentities.test.ts
@@ -153,6 +153,19 @@ describe('parseIdentityTag', () => {
     });
   });
 
+  it('does not link legacy Discord invite proofs', () => {
+    const result = parseIdentityTag(['i', 'discord:alice', 'AbCdEf']);
+
+    expect(result?.proof).toBe('AbCdEf');
+    expect(result?.proofUrl).toBe('');
+  });
+
+  it('does not link arbitrary Discord proof schemes', () => {
+    const result = parseIdentityTag(['i', 'discord:alice', 'javascript:alert(1)']);
+
+    expect(result?.proofUrl).toBe('');
+  });
+
   it('handles unknown platforms with empty URLs', () => {
     const tag = ['i', 'linkedin:someone', 'someproof'];
     const result = parseIdentityTag(tag);

--- a/src/hooks/useExternalIdentities.ts
+++ b/src/hooks/useExternalIdentities.ts
@@ -7,7 +7,7 @@ import type { NostrEvent } from '@nostrify/nostrify';
 import { nip19 } from 'nostr-tools';
 import { getCachedVerification, setCachedVerification } from '@/lib/verificationCache';
 import { API_CONFIG, getFeatureFlag } from '@/config/api';
-import { discordProofFromInput } from '@/lib/discordProof';
+import { isDiscordMessageLink } from '@/lib/discordProof';
 
 export interface ExternalIdentity {
   platform: string;
@@ -117,7 +117,7 @@ const PLATFORM_CONFIG: Record<string, PlatformConfig> = {
   discord: {
     label: 'Discord',
     profileUrl: (id) => `https://discord.com/users/${id}`,
-    proofUrl: (_id, proof) => proof,
+    proofUrl: (_id, proof) => isDiscordMessageLink(proof) ? proof.trim() : '',
     verificationText: (npub) => [
       `Verifying that I control the following Nostr public key: "${npub}"`,
     ],
@@ -243,7 +243,7 @@ function cleanProofId(platform: string, proof: string): string {
       // The verifier parses the message URL itself, and a message id is
       // meaningless without its channel. Reducing it to a bare id made the
       // service fall back to its own configured channel and 404 everywhere else.
-      case 'discord': return discordProofFromInput(proof).proof;
+      case 'discord': return proof.trim();
       case 'youtube': {
         if (url.hostname.includes('youtu.be')) return parts[0] || proof;
         if (parts[0] === 'watch') return url.searchParams.get('v') || proof;

--- a/src/lib/discordProof.test.ts
+++ b/src/lib/discordProof.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { discordProofFromInput, isDiscordMessageLink } from './discordProof';
+import { isDiscordMessageLink } from './discordProof';
 
 const GUILD = '1234567890123456789';
 const CHANNEL = '9876543210987654321';
@@ -33,29 +33,6 @@ describe('discordProof', () => {
 
     it('rejects a host that merely contains discord.com', () => {
       expect(isDiscordMessageLink(`https://discord.com.evil.example/channels/${GUILD}/${CHANNEL}/${MESSAGE}`)).toBe(false);
-    });
-  });
-
-  describe('discordProofFromInput', () => {
-    it('keeps the whole message link as the proof', () => {
-      // The verifier parses the URL itself, and a Discord message id is
-      // meaningless without the channel it lives in.
-      expect(discordProofFromInput(LINK).proof).toBe(LINK);
-    });
-
-    it('does not invent an identity from the message id', () => {
-      // A message URL names a guild, a channel and a message — never the
-      // author. Deriving one made the username a snowflake, which the
-      // verifier's author check can never match.
-      expect(discordProofFromInput(LINK).identity).toBeUndefined();
-    });
-
-    it('trims what a paste picked up', () => {
-      expect(discordProofFromInput(`  ${LINK}  `).proof).toBe(LINK);
-    });
-
-    it('passes a bare message id through unchanged', () => {
-      expect(discordProofFromInput(MESSAGE).proof).toBe(MESSAGE);
     });
   });
 });

--- a/src/lib/discordProof.ts
+++ b/src/lib/discordProof.ts
@@ -31,21 +31,3 @@ export function isDiscordMessageLink(value: string): boolean {
   // A DM link spells the guild `@me`, and no bot is in that conversation.
   return segments.slice(1).every((segment) => /^\d+$/.test(segment));
 }
-
-/**
- * Turns what the user pasted into the identity/proof pair the verifier expects.
- *
- * The proof passes through whole: the verifier parses the message URL itself,
- * and a Discord message id is meaningless without the channel it lives in.
- *
- * The identity is deliberately absent. A message URL names a guild, a channel
- * and a message — never the author — so the username has to be typed. Deriving
- * one from the URL made it a snowflake, which the verifier's author check can
- * never match.
- */
-export function discordProofFromInput(input: string): {
-  identity?: string;
-  proof: string;
-} {
-  return { proof: input.trim() };
-}

--- a/src/pages/LinkedAccountsSettingsPage.test.tsx
+++ b/src/pages/LinkedAccountsSettingsPage.test.tsx
@@ -114,6 +114,6 @@ describe('LinkedAccountsSettingsPage Discord flow', () => {
     );
     await user.click(screen.getByRole('button', { name: /linkedAccountsSettings.linkAccountButton/i }));
 
-    await waitFor(() => expect(mockAdd).not.toHaveBeenCalled());
+    expect(mockAdd).not.toHaveBeenCalled();
   });
 });

--- a/src/pages/LinkedAccountsSettingsPage.tsx
+++ b/src/pages/LinkedAccountsSettingsPage.tsx
@@ -18,7 +18,7 @@ import { Skeleton } from '@/components/ui/skeleton';
 import { LinkSimple as Link2, Plus, Trash as Trash2, PencilSimple as Pencil, CheckCircle as CheckCircle2, Warning as AlertTriangle, CircleNotch as Loader2, ArrowSquareOut as ExternalLink, GithubLogo as Github, ChatCircle as MessageCircle, At as AtSign, Shield, Copy, Check, X, ArrowLeft } from '@phosphor-icons/react';
 import { useToast } from '@/hooks/useToast';
 import { nip19 } from 'nostr-tools';
-import { discordProofFromInput, isDiscordMessageLink } from '@/lib/discordProof';
+import { isDiscordMessageLink } from '@/lib/discordProof';
 
 // X/Twitter icon (simple)
 function XIcon({ className }: { className?: string }) {
@@ -85,11 +85,6 @@ const PROOF_PLACEHOLDERS: Record<string, string> = {
   tiktok: 'https://www.tiktok.com/@you/video/123456789',
 };
 
-// Platforms whose identity cannot be derived from the proof URL, so the user
-// has to type it. A Discord message link names a guild, a channel and a
-// message, never the author, so there is nothing to auto-detect.
-const MANUAL_IDENTITY_PLATFORMS = new Set(['discord']);
-
 /** Extract identity and proof from a URL, or return input as proof only */
 function extractFromUrl(platform: string, input: string): { identity?: string; proof: string } {
   const trimmed = input.trim();
@@ -134,7 +129,7 @@ function extractFromUrl(platform: string, input: string): { identity?: string; p
         // The proof is the message link, whole. Popping the last segment made
         // identity and proof both the message id, so the username became a
         // snowflake the verifier's author check could never match.
-        return discordProofFromInput(trimmed);
+        return { proof: trimmed };
       case 'youtube': {
         // https://www.youtube.com/@channel or /channel/UC... + proof from watch/shorts URLs
         const watchId = url.searchParams.get('v');
@@ -414,7 +409,7 @@ export default function LinkedAccountsSettingsPage() {
       // Refuse anything that is not a message link — an invite, a DM link, a
       // channel link, a look-alike host — rather than publishing it as a proof
       // that can never verify.
-      if (MANUAL_IDENTITY_PLATFORMS.has(platform) && !isDiscordMessageLink(cleanProof)) {
+      if (platform === 'discord' && !isDiscordMessageLink(cleanProof)) {
         toast({
           title: t('linkedAccountsSettings.toastErrorTitle'),
           description: t('linkedAccountsSettings.toastInvalidDiscordLink'),
@@ -429,7 +424,7 @@ export default function LinkedAccountsSettingsPage() {
       // the identity slot and the verifier could never match it.
       const cleanIdentity = extracted.identity
         || identity.trim()
-        || (MANUAL_IDENTITY_PLATFORMS.has(platform) ? '' : cleanProof);
+        || (platform === 'discord' ? '' : cleanProof);
       if (!cleanIdentity) {
         toast({ title: t('linkedAccountsSettings.toastErrorTitle'), description: t('linkedAccountsSettings.toastCannotDetermineUsername'), variant: 'destructive' });
         return;
@@ -636,7 +631,7 @@ export default function LinkedAccountsSettingsPage() {
           </Card>
 
           {/* The handle, where the proof link cannot carry it */}
-          {MANUAL_IDENTITY_PLATFORMS.has(platform) && (
+          {platform === 'discord' && (
             <div className="space-y-2">
               <Label className="text-sm font-medium">
                 {t('linkedAccountsSettings.discordUsernameLabel')}
@@ -665,7 +660,7 @@ export default function LinkedAccountsSettingsPage() {
                 }
               }}
             />
-            {identity && !MANUAL_IDENTITY_PLATFORMS.has(platform) && (
+            {identity && platform !== 'discord' && (
               <p className="text-xs text-green-600">
                 {t('linkedAccountsSettings.detectedLabel')} <span className="font-medium">{identity}</span>
               </p>
@@ -683,7 +678,7 @@ export default function LinkedAccountsSettingsPage() {
               onClick={handleAdd}
               disabled={
                 !proof.trim()
-                || (MANUAL_IDENTITY_PLATFORMS.has(platform) && !identity.trim())
+                || (platform === 'discord' && !identity.trim())
                 || addIdentity.isPending
               }
               className="w-full"


### PR DESCRIPTION
## The problem

#712 changed Discord proofs from invite codes to message links, but its proof-link builder returned the saved tag value directly. Existing accounts still carry invite-code proofs, so their settings links became broken relative URLs. An arbitrary proof scheme could also reach the rendered `href`.

## Why this fix

Only recognized Discord message links now become clickable proof URLs. Existing proof data remains untouched for verification and migration purposes, while legacy invite codes and arbitrary schemes no longer render as links.

The follow-up also removes the Discord-only behavior from a misleading generic platform set and deletes a trim-only wrapper that added no behavior. It does not change the newly published NIP-39 tag shape, verifier request, or cache semantics from #712.

## Testing

- `npm run test` — TypeScript, ESLint (0 errors), 2,921 tests across 338 files, and production build passed before rebasing onto the merged #712 tree.
- `npx vitest run src/hooks/useExternalIdentities.test.ts src/lib/discordProof.test.ts src/pages/LinkedAccountsSettingsPage.test.tsx` — 61 tests passed after rebase.
- Mutation check: removing the proof-link guard makes both new legacy-invite and arbitrary-scheme assertions fail.

## Visuals

No visual change for valid proofs. Invalid and legacy Discord proofs no longer render a clickable proof link.

## Related

Follow-up to #712, which merged before the takeover commit attached to its branch.