### PR TITLE
chore(i18n): translate the Discord account-linking copy that shipped in English

### DIFF
--- a/src/lib/i18n/locales.test.ts
+++ b/src/lib/i18n/locales.test.ts
@@ -184,8 +184,9 @@ const MUST_BE_TRANSLATED_PREFIXES = [
   // quote a menu item in Discord's own client and the label separates the
   // handle from the display name, so an English fallback is a wrong
   // instruction, not merely an untranslated one. discordUsernamePlaceholder
-  // is deliberately absent: it is a sample handle, and locales that do not
-  // use a Latin script keep the English one.
+  // is deliberately absent: six locales intentionally keep the English
+  // sample because their script cannot form a valid handle or, for Filipino,
+  // the surrounding copy already uses the English word "username".
   'linkedAccountsSettings.proofInstructions.discord',
   'linkedAccountsSettings.discordUsernameLabel',
   'linkedAccountsSettings.toastInvalidDiscordLink',

--- a/src/lib/i18n/locales.test.ts
+++ b/src/lib/i18n/locales.test.ts
@@ -178,6 +178,17 @@ const MUST_BE_TRANSLATED_PREFIXES = [
   'moderationSettings.noBlockedUsers',
   'moderationSettings.toastUnblockedDescription',
   'moderationSettings.toastUnblockFailed',
+  // Discord account-linking copy. #712 swapped the server-invite instruction
+  // for the message-link one and added the username label and the bad-link
+  // toast, all in English for every locale. The instruction and the toast
+  // quote a menu item in Discord's own client and the label separates the
+  // handle from the display name, so an English fallback is a wrong
+  // instruction, not merely an untranslated one. discordUsernamePlaceholder
+  // is deliberately absent: it is a sample handle, and locales that do not
+  // use a Latin script keep the English one.
+  'linkedAccountsSettings.proofInstructions.discord',
+  'linkedAccountsSettings.discordUsernameLabel',
+  'linkedAccountsSettings.toastInvalidDiscordLink',
 ];
 
 describe('i18n locale resources', () => {

--- a/src/lib/i18n/locales/ar/common.json
+++ b/src/lib/i18n/locales/ar/common.json
@@ -745,12 +745,12 @@
       "mastodon": "انشر toot يحتوي على النص أدناه، ثم الصق معرّف المنشور من الرابط.",
       "telegram": "أرسل رسالة في قناة/مجموعة عامة تحتوي على النص أدناه، ثم الصق مسار الرسالة (مثلاً channelname/123).",
       "bluesky": "انشر على Bluesky منشوراً يحتوي على النص أدناه، ثم الصق مفتاح السجل (rkey) من رابط المنشور.",
-      "discord": "Post a message containing the text below, then right-click it and pick Copy Message Link. A server invite cannot prove who owns an account. Enter your Discord username — the one on your profile, not your display name."
+      "discord": "انشر رسالة تحتوي على النص أدناه، ثم انقر عليها بزر الفأرة الأيمن واختر «Copy Message Link» (نسخ رابط الرسالة). لا يمكن لدعوة الخادم أن تثبت من يملك الحساب. أدخل اسم مستخدم Discord الخاص بك — الاسم الموجود في ملفك الشخصي، وليس اسم العرض."
     },
     "toastErrorTitle": "خطأ",
     "toastEnterProof": "يرجى إدخال رابط أو معرّف الإثبات",
-    "toastInvalidDiscordLink": "Paste a Discord message link: right-click your message and choose Copy Message Link.",
-    "discordUsernameLabel": "Your Discord username",
+    "toastInvalidDiscordLink": "الصق رابط رسالة من Discord: انقر على رسالتك بزر الفأرة الأيمن واختر «Copy Message Link» (نسخ رابط الرسالة).",
+    "discordUsernameLabel": "اسم مستخدم Discord الخاص بك",
     "discordUsernamePlaceholder": "yourusername",
     "toastCannotDetermineUsername": "تعذّر تحديد اسم المستخدم من الرابط",
     "toastVerifiedTitle": "تم التحقق!",

--- a/src/lib/i18n/locales/de/common.json
+++ b/src/lib/i18n/locales/de/common.json
@@ -693,13 +693,13 @@
       "mastodon": "Poste einen Toot mit dem Text unten und füge dann die Post-ID aus der URL ein.",
       "telegram": "Sende eine Nachricht in einem öffentlichen Kanal/einer Gruppe mit dem Text unten und füge dann den Nachrichtenpfad ein (z. B. kanalname/123).",
       "bluesky": "Poste auf Bluesky mit dem Text unten und füge dann den Record Key (rkey) aus der Post-URL ein.",
-      "discord": "Post a message containing the text below, then right-click it and pick Copy Message Link. A server invite cannot prove who owns an account. Enter your Discord username — the one on your profile, not your display name."
+      "discord": "Poste eine Nachricht mit dem Text unten, klicke sie dann mit der rechten Maustaste an und wähle „Nachrichtenlink kopieren“. Eine Servereinladung kann nicht beweisen, wem ein Konto gehört. Gib deinen Discord-Benutzernamen ein — den in deinem Profil, nicht deinen Anzeigenamen."
     },
     "toastErrorTitle": "Fehler",
     "toastEnterProof": "Bitte gib die Nachweis-URL oder -ID ein",
-    "toastInvalidDiscordLink": "Paste a Discord message link: right-click your message and choose Copy Message Link.",
-    "discordUsernameLabel": "Your Discord username",
-    "discordUsernamePlaceholder": "yourusername",
+    "toastInvalidDiscordLink": "Füge einen Discord-Nachrichtenlink ein: Klicke deine Nachricht mit der rechten Maustaste an und wähle „Nachrichtenlink kopieren“.",
+    "discordUsernameLabel": "Dein Discord-Benutzername",
+    "discordUsernamePlaceholder": "deinbenutzername",
     "toastCannotDetermineUsername": "Nutzername konnte nicht aus der URL ermittelt werden",
     "toastVerifiedTitle": "Verifiziert!",
     "toastLinkedTitle": "Verknüpft",

--- a/src/lib/i18n/locales/es/common.json
+++ b/src/lib/i18n/locales/es/common.json
@@ -700,13 +700,13 @@
       "mastodon": "Publica un toot con el texto de abajo y luego pega el ID de la publicación de la URL.",
       "telegram": "Envía un mensaje en un canal o grupo público con el texto de abajo y luego pega la ruta del mensaje (ej. nombrecanal/123).",
       "bluesky": "Publica en Bluesky con el texto de abajo y luego pega la clave de registro (rkey) de la URL de la publicación.",
-      "discord": "Post a message containing the text below, then right-click it and pick Copy Message Link. A server invite cannot prove who owns an account. Enter your Discord username — the one on your profile, not your display name."
+      "discord": "Publica un mensaje con el texto de abajo, luego haz clic derecho en él y elige «Copiar enlace del mensaje». Una invitación a un servidor no puede demostrar a quién pertenece una cuenta. Introduce tu nombre de usuario de Discord: el de tu perfil, no tu nombre para mostrar."
     },
     "toastErrorTitle": "Error",
     "toastEnterProof": "Introduce la URL o el ID de la prueba",
-    "toastInvalidDiscordLink": "Paste a Discord message link: right-click your message and choose Copy Message Link.",
-    "discordUsernameLabel": "Your Discord username",
-    "discordUsernamePlaceholder": "yourusername",
+    "toastInvalidDiscordLink": "Pega el enlace de un mensaje de Discord: haz clic derecho en tu mensaje y elige «Copiar enlace del mensaje».",
+    "discordUsernameLabel": "Tu nombre de usuario de Discord",
+    "discordUsernamePlaceholder": "tunombredeusuario",
     "toastCannotDetermineUsername": "No se pudo determinar el nombre de usuario desde la URL",
     "toastVerifiedTitle": "¡Verificada!",
     "toastLinkedTitle": "Vinculada",

--- a/src/lib/i18n/locales/fil/common.json
+++ b/src/lib/i18n/locales/fil/common.json
@@ -693,12 +693,12 @@
       "mastodon": "Mag-post ng toot na may laman ng teksto sa baba, tapos i-paste ang Post ID mula sa URL.",
       "telegram": "Magpadala ng mensahe sa public channel/group na may laman ng teksto sa baba, tapos i-paste ang path ng mensahe (hal. channelname/123).",
       "bluesky": "Mag-post sa Bluesky na may laman ng teksto sa baba, tapos i-paste ang record key (rkey) mula sa URL ng post.",
-      "discord": "Post a message containing the text below, then right-click it and pick Copy Message Link. A server invite cannot prove who owns an account. Enter your Discord username — the one on your profile, not your display name."
+      "discord": "Mag-post ng mensahe na may laman ng teksto sa baba, tapos i-right-click ito at piliin ang “Copy Message Link”. Hindi mapapatunayan ng server invite kung sino ang may-ari ng account. Ilagay ang iyong Discord username — ang nasa profile mo, hindi ang display name mo."
     },
     "toastErrorTitle": "May Problema",
     "toastEnterProof": "Ilagay ang URL o ID ng patunay",
-    "toastInvalidDiscordLink": "Paste a Discord message link: right-click your message and choose Copy Message Link.",
-    "discordUsernameLabel": "Your Discord username",
+    "toastInvalidDiscordLink": "Mag-paste ng link ng Discord message: i-right-click ang mensahe mo at piliin ang “Copy Message Link”.",
+    "discordUsernameLabel": "Ang iyong Discord username",
     "discordUsernamePlaceholder": "yourusername",
     "toastCannotDetermineUsername": "Hindi matukoy ang username mula sa URL",
     "toastVerifiedTitle": "Na-verify!",

--- a/src/lib/i18n/locales/fr/common.json
+++ b/src/lib/i18n/locales/fr/common.json
@@ -700,13 +700,13 @@
       "mastodon": "Poste un toot contenant le texte ci-dessous, puis colle l'ID du post depuis l'URL.",
       "telegram": "Envoie un message dans un canal/groupe public contenant le texte ci-dessous, puis colle le chemin du message (ex. channelname/123).",
       "bluesky": "Poste sur Bluesky avec le texte ci-dessous, puis colle la clé d'enregistrement (rkey) depuis l'URL du post.",
-      "discord": "Post a message containing the text below, then right-click it and pick Copy Message Link. A server invite cannot prove who owns an account. Enter your Discord username — the one on your profile, not your display name."
+      "discord": "Poste un message contenant le texte ci-dessous, puis fais un clic droit dessus et choisis « Copier le lien du message ». Une invitation à un serveur ne peut pas prouver à qui appartient un compte. Saisis ton nom d'utilisateur Discord : celui de ton profil, pas ton nom d'affichage."
     },
     "toastErrorTitle": "Erreur",
     "toastEnterProof": "Saisis l'URL ou l'ID de la preuve",
-    "toastInvalidDiscordLink": "Paste a Discord message link: right-click your message and choose Copy Message Link.",
-    "discordUsernameLabel": "Your Discord username",
-    "discordUsernamePlaceholder": "yourusername",
+    "toastInvalidDiscordLink": "Colle le lien d'un message Discord : fais un clic droit sur ton message et choisis « Copier le lien du message ».",
+    "discordUsernameLabel": "Ton nom d'utilisateur Discord",
+    "discordUsernamePlaceholder": "tonnomdutilisateur",
     "toastCannotDetermineUsername": "Impossible de déterminer le nom d'utilisateur depuis l'URL",
     "toastVerifiedTitle": "Vérifié !",
     "toastLinkedTitle": "Lié",

--- a/src/lib/i18n/locales/id/common.json
+++ b/src/lib/i18n/locales/id/common.json
@@ -693,13 +693,13 @@
       "mastodon": "Post toot berisi teks di bawah, lalu tempel ID Post dari URL.",
       "telegram": "Kirim pesan di channel/grup publik berisi teks di bawah, lalu tempel path pesan (mis. namachannel/123).",
       "bluesky": "Post di Bluesky berisi teks di bawah, lalu tempel record key (rkey) dari URL post.",
-      "discord": "Post a message containing the text below, then right-click it and pick Copy Message Link. A server invite cannot prove who owns an account. Enter your Discord username — the one on your profile, not your display name."
+      "discord": "Post pesan berisi teks di bawah, lalu klik kanan pesan itu dan pilih “Copy Message Link” (salin tautan pesan). Undangan server tidak bisa membuktikan siapa pemilik sebuah akun. Masukkan username Discord kamu — yang ada di profilmu, bukan nama tampilanmu (Display Name)."
     },
     "toastErrorTitle": "Error",
     "toastEnterProof": "Silakan masukkan URL atau ID bukti",
-    "toastInvalidDiscordLink": "Paste a Discord message link: right-click your message and choose Copy Message Link.",
-    "discordUsernameLabel": "Your Discord username",
-    "discordUsernamePlaceholder": "yourusername",
+    "toastInvalidDiscordLink": "Tempel tautan pesan Discord: klik kanan pesanmu dan pilih “Copy Message Link” (salin tautan pesan).",
+    "discordUsernameLabel": "Username Discord kamu",
+    "discordUsernamePlaceholder": "namapenggunamu",
     "toastCannotDetermineUsername": "Tidak bisa menentukan username dari URL",
     "toastVerifiedTitle": "Terverifikasi!",
     "toastLinkedTitle": "Tertaut",

--- a/src/lib/i18n/locales/it/common.json
+++ b/src/lib/i18n/locales/it/common.json
@@ -700,13 +700,13 @@
       "mastodon": "Pubblica un toot contenente il testo qui sotto, poi incolla l'ID del Post dall'URL.",
       "telegram": "Invia un messaggio in un canale/gruppo pubblico contenente il testo qui sotto, poi incolla il percorso del messaggio (es. nomecanale/123).",
       "bluesky": "Pubblica su Bluesky un post contenente il testo qui sotto, poi incolla la chiave del record (rkey) dall'URL del post.",
-      "discord": "Post a message containing the text below, then right-click it and pick Copy Message Link. A server invite cannot prove who owns an account. Enter your Discord username — the one on your profile, not your display name."
+      "discord": "Pubblica un messaggio contenente il testo qui sotto, poi fai clic con il tasto destro sul messaggio e scegli «Copia il link del messaggio». Un invito a un server non può dimostrare a chi appartiene un account. Inserisci il tuo nome utente Discord: quello sul tuo profilo, non il tuo nome visualizzato."
     },
     "toastErrorTitle": "Errore",
     "toastEnterProof": "Inserisci l'URL o l'ID della prova",
-    "toastInvalidDiscordLink": "Paste a Discord message link: right-click your message and choose Copy Message Link.",
-    "discordUsernameLabel": "Your Discord username",
-    "discordUsernamePlaceholder": "yourusername",
+    "toastInvalidDiscordLink": "Incolla il link di un messaggio Discord: fai clic con il tasto destro sul tuo messaggio e scegli «Copia il link del messaggio».",
+    "discordUsernameLabel": "Il tuo nome utente Discord",
+    "discordUsernamePlaceholder": "tuonomeutente",
     "toastCannotDetermineUsername": "Impossibile determinare il nome utente dall'URL",
     "toastVerifiedTitle": "Verificato!",
     "toastLinkedTitle": "Collegato",

--- a/src/lib/i18n/locales/ja/common.json
+++ b/src/lib/i18n/locales/ja/common.json
@@ -693,12 +693,12 @@
       "mastodon": "下のテキストを含むtootを投稿し、URLから投稿IDを貼り付けてください。",
       "telegram": "下のテキストを含むメッセージを公開チャンネル/グループに送信し、メッセージパス（例：channelname/123）を貼り付けてください。",
       "bluesky": "下のテキストを含む投稿をBlueskyに行い、投稿URLからレコードキー（rkey）を貼り付けてください。",
-      "discord": "Post a message containing the text below, then right-click it and pick Copy Message Link. A server invite cannot prove who owns an account. Enter your Discord username — the one on your profile, not your display name."
+      "discord": "下のテキストを含むメッセージを投稿し、そのメッセージを右クリックして「メッセージリンクをコピー」を選択してください。サーバーの招待リンクでは、アカウントの所有者を証明できません。Discordのユーザー名を入力してください。表示名ではなく、プロフィールに表示されるユーザー名です。"
     },
     "toastErrorTitle": "エラー",
     "toastEnterProof": "証明URLまたはIDを入力してください",
-    "toastInvalidDiscordLink": "Paste a Discord message link: right-click your message and choose Copy Message Link.",
-    "discordUsernameLabel": "Your Discord username",
+    "toastInvalidDiscordLink": "Discordのメッセージリンクを貼り付けてください。自分のメッセージを右クリックして「メッセージリンクをコピー」を選択します。",
+    "discordUsernameLabel": "あなたのDiscordユーザー名",
     "discordUsernamePlaceholder": "yourusername",
     "toastCannotDetermineUsername": "URLからユーザー名を特定できませんでした",
     "toastVerifiedTitle": "検証されました！",

--- a/src/lib/i18n/locales/ko/common.json
+++ b/src/lib/i18n/locales/ko/common.json
@@ -693,12 +693,12 @@
       "mastodon": "아래 텍스트가 포함된 toot을 게시한 다음 URL에서 게시물 ID를 붙여넣으세요.",
       "telegram": "아래 텍스트가 포함된 메시지를 공개 채널/그룹에 보낸 다음 메시지 경로(예: channelname/123)를 붙여넣으세요.",
       "bluesky": "아래 텍스트가 포함된 게시물을 Bluesky에 올린 다음 게시물 URL에서 record key(rkey)를 붙여넣으세요.",
-      "discord": "Post a message containing the text below, then right-click it and pick Copy Message Link. A server invite cannot prove who owns an account. Enter your Discord username — the one on your profile, not your display name."
+      "discord": "아래 텍스트가 포함된 메시지를 게시한 다음, 그 메시지를 마우스 오른쪽 버튼으로 클릭하고 ‘메시지 링크 복사’를 선택하세요. 서버 초대 링크로는 계정 소유자를 증명할 수 없어요. Discord 사용자명을 입력하세요. 별명이 아니라 프로필에 있는 사용자명이에요."
     },
     "toastErrorTitle": "오류",
     "toastEnterProof": "증명 URL이나 ID를 입력하세요",
-    "toastInvalidDiscordLink": "Paste a Discord message link: right-click your message and choose Copy Message Link.",
-    "discordUsernameLabel": "Your Discord username",
+    "toastInvalidDiscordLink": "Discord 메시지 링크를 붙여넣으세요. 메시지를 마우스 오른쪽 버튼으로 클릭하고 ‘메시지 링크 복사’를 선택하면 돼요.",
+    "discordUsernameLabel": "내 Discord 사용자명",
     "discordUsernamePlaceholder": "yourusername",
     "toastCannotDetermineUsername": "URL에서 사용자명을 알아낼 수 없어요",
     "toastVerifiedTitle": "확인됨!",

--- a/src/lib/i18n/locales/ms/common.json
+++ b/src/lib/i18n/locales/ms/common.json
@@ -693,13 +693,13 @@
       "mastodon": "Poskan toot yang mengandungi teks di bawah, kemudian tampal ID Pos daripada URL.",
       "telegram": "Hantar mesej dalam saluran/kumpulan awam yang mengandungi teks di bawah, kemudian tampal laluan mesej (cth. namasaluran/123).",
       "bluesky": "Pos di Bluesky yang mengandungi teks di bawah, kemudian tampal kunci rekod (rkey) daripada URL pos.",
-      "discord": "Post a message containing the text below, then right-click it and pick Copy Message Link. A server invite cannot prove who owns an account. Enter your Discord username — the one on your profile, not your display name."
+      "discord": "Poskan mesej yang mengandungi teks di bawah, kemudian klik kanan mesej itu dan pilih “Copy Message Link” (salin pautan mesej). Jemputan pelayan tidak dapat membuktikan siapa pemilik sesuatu akaun. Masukkan nama pengguna Discord anda — yang ada pada profil anda, bukan nama paparan anda (Display Name)."
     },
     "toastErrorTitle": "Ralat",
     "toastEnterProof": "Sila masukkan URL atau ID bukti",
-    "toastInvalidDiscordLink": "Paste a Discord message link: right-click your message and choose Copy Message Link.",
-    "discordUsernameLabel": "Your Discord username",
-    "discordUsernamePlaceholder": "yourusername",
+    "toastInvalidDiscordLink": "Tampal pautan mesej Discord: klik kanan mesej anda dan pilih “Copy Message Link” (salin pautan mesej).",
+    "discordUsernameLabel": "Nama pengguna Discord anda",
+    "discordUsernamePlaceholder": "namapenggunaanda",
     "toastCannotDetermineUsername": "Tidak dapat menentukan nama pengguna daripada URL",
     "toastVerifiedTitle": "Disahkan!",
     "toastLinkedTitle": "Terpaut",

--- a/src/lib/i18n/locales/nl/common.json
+++ b/src/lib/i18n/locales/nl/common.json
@@ -693,13 +693,13 @@
       "mastodon": "Plaats een toot met de onderstaande tekst en plak vervolgens de Post-ID uit de URL.",
       "telegram": "Stuur een bericht in een openbaar kanaal/groep met de onderstaande tekst en plak vervolgens het berichtpad (bijv. channelname/123).",
       "bluesky": "Post op Bluesky met de onderstaande tekst en plak vervolgens de record key (rkey) uit de post-URL.",
-      "discord": "Post a message containing the text below, then right-click it and pick Copy Message Link. A server invite cannot prove who owns an account. Enter your Discord username — the one on your profile, not your display name."
+      "discord": "Plaats een bericht met de onderstaande tekst, klik er dan met de rechtermuisknop op en kies ‘Kopieer berichtenlink’. Een serveruitnodiging kan niet bewijzen van wie een account is. Vul je Discord-gebruikersnaam in — die op je profiel, niet je weergavenaam."
     },
     "toastErrorTitle": "Fout",
     "toastEnterProof": "Voer de bewijs-URL of -ID in",
-    "toastInvalidDiscordLink": "Paste a Discord message link: right-click your message and choose Copy Message Link.",
-    "discordUsernameLabel": "Your Discord username",
-    "discordUsernamePlaceholder": "yourusername",
+    "toastInvalidDiscordLink": "Plak een link naar een Discord-bericht: klik met de rechtermuisknop op je bericht en kies ‘Kopieer berichtenlink’.",
+    "discordUsernameLabel": "Je Discord-gebruikersnaam",
+    "discordUsernamePlaceholder": "jegebruikersnaam",
     "toastCannotDetermineUsername": "Kon de gebruikersnaam niet uit de URL bepalen",
     "toastVerifiedTitle": "Geverifieerd!",
     "toastLinkedTitle": "Gekoppeld",

--- a/src/lib/i18n/locales/pl/common.json
+++ b/src/lib/i18n/locales/pl/common.json
@@ -707,13 +707,13 @@
       "mastodon": "Opublikuj toota z poniższym tekstem, potem wklej ID posta z URL.",
       "telegram": "Wyślij wiadomość na publicznym kanale/grupie z poniższym tekstem, potem wklej ścieżkę wiadomości (np. nazwakanalu/123).",
       "bluesky": "Opublikuj post na Bluesky z poniższym tekstem, potem wklej record key (rkey) z URL posta.",
-      "discord": "Post a message containing the text below, then right-click it and pick Copy Message Link. A server invite cannot prove who owns an account. Enter your Discord username — the one on your profile, not your display name."
+      "discord": "Opublikuj wiadomość z poniższym tekstem, potem kliknij ją prawym przyciskiem myszy i wybierz „Kopiuj link z wiadomością”. Zaproszenie na serwer nie dowodzi, kto jest właścicielem konta. Wpisz swoją nazwę użytkownika Discord — tę z profilu, nie wyświetlaną nazwę."
     },
     "toastErrorTitle": "Błąd",
     "toastEnterProof": "Wpisz URL lub ID dowodu",
-    "toastInvalidDiscordLink": "Paste a Discord message link: right-click your message and choose Copy Message Link.",
-    "discordUsernameLabel": "Your Discord username",
-    "discordUsernamePlaceholder": "yourusername",
+    "toastInvalidDiscordLink": "Wklej link do wiadomości na Discordzie: kliknij swoją wiadomość prawym przyciskiem myszy i wybierz „Kopiuj link z wiadomością”.",
+    "discordUsernameLabel": "Twoja nazwa użytkownika Discord",
+    "discordUsernamePlaceholder": "nazwauzytkownika",
     "toastCannotDetermineUsername": "Nie udało się ustalić nazwy użytkownika z URL",
     "toastVerifiedTitle": "Zweryfikowane!",
     "toastLinkedTitle": "Podłączone",

--- a/src/lib/i18n/locales/pt/common.json
+++ b/src/lib/i18n/locales/pt/common.json
@@ -700,13 +700,13 @@
       "mastodon": "Poste um toot com o texto abaixo, depois cole o ID do post pego da URL.",
       "telegram": "Mande uma mensagem em um canal/grupo público com o texto abaixo, depois cole o caminho da mensagem (ex: nomedocanal/123).",
       "bluesky": "Poste no Bluesky com o texto abaixo, depois cole a record key (rkey) da URL do post.",
-      "discord": "Post a message containing the text below, then right-click it and pick Copy Message Link. A server invite cannot prove who owns an account. Enter your Discord username — the one on your profile, not your display name."
+      "discord": "Poste uma mensagem com o texto abaixo, depois clique nela com o botão direito e escolha “Copiar link da mensagem”. Um convite de servidor não pode provar quem é o dono de uma conta. Digite seu nome de usuário do Discord — o que aparece no seu perfil, não seu nome exibido."
     },
     "toastErrorTitle": "Erro",
     "toastEnterProof": "Digite a URL ou ID da prova",
-    "toastInvalidDiscordLink": "Paste a Discord message link: right-click your message and choose Copy Message Link.",
-    "discordUsernameLabel": "Your Discord username",
-    "discordUsernamePlaceholder": "yourusername",
+    "toastInvalidDiscordLink": "Cole o link de uma mensagem do Discord: clique na sua mensagem com o botão direito e escolha “Copiar link da mensagem”.",
+    "discordUsernameLabel": "Seu nome de usuário do Discord",
+    "discordUsernamePlaceholder": "seunomedeusuario",
     "toastCannotDetermineUsername": "Não foi possível identificar o nome de usuário pela URL",
     "toastVerifiedTitle": "Verificado!",
     "toastLinkedTitle": "Vinculado",

--- a/src/lib/i18n/locales/ro/common.json
+++ b/src/lib/i18n/locales/ro/common.json
@@ -700,13 +700,13 @@
       "mastodon": "Postează un toot care să conțină textul de mai jos, apoi lipește ID-ul postării din URL.",
       "telegram": "Trimite un mesaj într-un canal/grup public care să conțină textul de mai jos, apoi lipește calea mesajului (ex. nume_canal/123).",
       "bluesky": "Postează pe Bluesky un mesaj care să conțină textul de mai jos, apoi lipește cheia înregistrării (rkey) din URL-ul postării.",
-      "discord": "Post a message containing the text below, then right-click it and pick Copy Message Link. A server invite cannot prove who owns an account. Enter your Discord username — the one on your profile, not your display name."
+      "discord": "Postează un mesaj care să conțină textul de mai jos, apoi dă clic dreapta pe el și alege „Copiază link-ul mesajului”. O invitație pe un server nu poate dovedi cine deține un cont. Introdu numele tău de utilizator Discord — cel de pe profilul tău, nu numele afișat."
     },
     "toastErrorTitle": "Eroare",
     "toastEnterProof": "Te rugăm introdu URL-ul sau ID-ul dovezii",
-    "toastInvalidDiscordLink": "Paste a Discord message link: right-click your message and choose Copy Message Link.",
-    "discordUsernameLabel": "Your Discord username",
-    "discordUsernamePlaceholder": "yourusername",
+    "toastInvalidDiscordLink": "Lipește link-ul unui mesaj Discord: dă clic dreapta pe mesajul tău și alege „Copiază link-ul mesajului”.",
+    "discordUsernameLabel": "Numele tău de utilizator Discord",
+    "discordUsernamePlaceholder": "numedeutilizator",
     "toastCannotDetermineUsername": "Nu am putut determina numele de utilizator din URL",
     "toastVerifiedTitle": "Verificat!",
     "toastLinkedTitle": "Conectat",

--- a/src/lib/i18n/locales/sv/common.json
+++ b/src/lib/i18n/locales/sv/common.json
@@ -693,13 +693,13 @@
       "mastodon": "Posta en toot som innehåller texten nedan, och klistra sedan in Post-ID:t från URL:en.",
       "telegram": "Skicka ett meddelande i en publik kanal/grupp som innehåller texten nedan, och klistra sedan in meddelandesökvägen (t.ex. channelname/123).",
       "bluesky": "Posta på Bluesky med texten nedan, och klistra sedan in record key (rkey) från inläggets URL.",
-      "discord": "Post a message containing the text below, then right-click it and pick Copy Message Link. A server invite cannot prove who owns an account. Enter your Discord username — the one on your profile, not your display name."
+      "discord": "Posta ett meddelande som innehåller texten nedan, högerklicka sedan på det och välj ”Kopiera meddelandelänk”. En serverinbjudan kan inte bevisa vem som äger ett konto. Ange ditt Discord-användarnamn — det som står på din profil, inte ditt visningsnamn."
     },
     "toastErrorTitle": "Fel",
     "toastEnterProof": "Ange bevis-URL eller -ID",
-    "toastInvalidDiscordLink": "Paste a Discord message link: right-click your message and choose Copy Message Link.",
-    "discordUsernameLabel": "Your Discord username",
-    "discordUsernamePlaceholder": "yourusername",
+    "toastInvalidDiscordLink": "Klistra in en länk till ett Discord-meddelande: högerklicka på ditt meddelande och välj ”Kopiera meddelandelänk”.",
+    "discordUsernameLabel": "Ditt Discord-användarnamn",
+    "discordUsernamePlaceholder": "dittanvandarnamn",
     "toastCannotDetermineUsername": "Kunde inte fastställa användarnamn från URL:en",
     "toastVerifiedTitle": "Verifierad!",
     "toastLinkedTitle": "Länkad",

--- a/src/lib/i18n/locales/tr/common.json
+++ b/src/lib/i18n/locales/tr/common.json
@@ -693,13 +693,13 @@
       "mastodon": "Aşağıdaki metni içeren bir toot paylaş, sonra URL'deki Post ID'sini yapıştır.",
       "telegram": "Herkese açık bir kanal/grupta aşağıdaki metni içeren bir mesaj gönder, sonra mesaj yolunu yapıştır (örn. kanaladi/123).",
       "bluesky": "Bluesky'da aşağıdaki metni içeren bir paylaşım yap, sonra gönderi URL'sinden record key'i (rkey) yapıştır.",
-      "discord": "Post a message containing the text below, then right-click it and pick Copy Message Link. A server invite cannot prove who owns an account. Enter your Discord username — the one on your profile, not your display name."
+      "discord": "Aşağıdaki metni içeren bir mesaj gönder, sonra mesaja sağ tıklayıp “Mesaj Bağlantısını Kopyala” seçeneğini seç. Bir sunucu daveti, bir hesabın kime ait olduğunu kanıtlayamaz. Discord kullanıcı adını gir — profilindeki kullanıcı adını, görünen adını değil."
     },
     "toastErrorTitle": "Hata",
     "toastEnterProof": "Lütfen kanıt URL'sini ya da ID'sini gir",
-    "toastInvalidDiscordLink": "Paste a Discord message link: right-click your message and choose Copy Message Link.",
-    "discordUsernameLabel": "Your Discord username",
-    "discordUsernamePlaceholder": "yourusername",
+    "toastInvalidDiscordLink": "Bir Discord mesaj bağlantısı yapıştır: mesajına sağ tıklayıp “Mesaj Bağlantısını Kopyala” seçeneğini seç.",
+    "discordUsernameLabel": "Discord kullanıcı adın",
+    "discordUsernamePlaceholder": "kullaniciadin",
     "toastCannotDetermineUsername": "URL'den kullanıcı adı belirlenemedi",
     "toastVerifiedTitle": "Doğrulandı!",
     "toastLinkedTitle": "Bağlandı",

--- a/src/lib/i18n/locales/ur/common.json
+++ b/src/lib/i18n/locales/ur/common.json
@@ -693,12 +693,12 @@
       "mastodon": "نیچے دیا گیا متن شامل toot پوسٹ کریں، پھر URL سے Post ID پیسٹ کریں۔",
       "telegram": "نیچے دیا گیا متن کسی عوامی چینل/گروپ میں بھیجیں، پھر پیغام کا پاتھ پیسٹ کریں (مثلاً channelname/123)۔",
       "bluesky": "نیچے دیا گیا متن Bluesky پر پوسٹ کریں، پھر پوسٹ URL سے record key (rkey) پیسٹ کریں۔",
-      "discord": "Post a message containing the text below, then right-click it and pick Copy Message Link. A server invite cannot prove who owns an account. Enter your Discord username — the one on your profile, not your display name."
+      "discord": "نیچے دیا گیا متن شامل پیغام پوسٹ کریں، پھر اس پر دایاں کلک کریں اور «Copy Message Link» (پیغام کا لنک کاپی کریں) منتخب کریں۔ سرور کا دعوت نامہ یہ ثابت نہیں کر سکتا کہ اکاؤنٹ کس کا ہے۔ اپنا Discord صارف نام درج کریں — وہ جو آپ کے پروفائل پر ہے، آپ کا ڈسپلے نام نہیں۔"
     },
     "toastErrorTitle": "خرابی",
     "toastEnterProof": "ثبوت کا URL یا ID درج کریں",
-    "toastInvalidDiscordLink": "Paste a Discord message link: right-click your message and choose Copy Message Link.",
-    "discordUsernameLabel": "Your Discord username",
+    "toastInvalidDiscordLink": "Discord پیغام کا لنک پیسٹ کریں: اپنے پیغام پر دایاں کلک کریں اور «Copy Message Link» (پیغام کا لنک کاپی کریں) منتخب کریں۔",
+    "discordUsernameLabel": "آپ کا Discord صارف نام",
     "discordUsernamePlaceholder": "yourusername",
     "toastCannotDetermineUsername": "URL سے صارف نام معلوم نہیں ہو سکا",
     "toastVerifiedTitle": "تصدیق ہو گئی!",

--- a/src/lib/i18n/locales/vi/common.json
+++ b/src/lib/i18n/locales/vi/common.json
@@ -693,13 +693,13 @@
       "mastodon": "Đăng một toot chứa đoạn văn bản bên dưới, rồi dán Post ID từ URL.",
       "telegram": "Gửi một tin nhắn trong kênh/nhóm công khai chứa đoạn văn bản bên dưới, rồi dán đường dẫn tin nhắn (ví dụ: channelname/123).",
       "bluesky": "Đăng trên Bluesky một bài chứa đoạn văn bản bên dưới, rồi dán record key (rkey) từ URL bài đăng.",
-      "discord": "Post a message containing the text below, then right-click it and pick Copy Message Link. A server invite cannot prove who owns an account. Enter your Discord username — the one on your profile, not your display name."
+      "discord": "Đăng một tin nhắn chứa đoạn văn bản bên dưới, rồi nhấp chuột phải vào tin nhắn đó và chọn “Sao Chép Đường Dẫn Tin Nhắn”. Lời mời vào máy chủ không thể chứng minh ai là chủ tài khoản. Nhập tên người dùng Discord của bạn — mục “Tên đăng nhập” trên hồ sơ của bạn, không phải tên hiển thị."
     },
     "toastErrorTitle": "Lỗi",
     "toastEnterProof": "Vui lòng nhập URL hoặc ID chứng minh",
-    "toastInvalidDiscordLink": "Paste a Discord message link: right-click your message and choose Copy Message Link.",
-    "discordUsernameLabel": "Your Discord username",
-    "discordUsernamePlaceholder": "yourusername",
+    "toastInvalidDiscordLink": "Dán liên kết tin nhắn Discord: nhấp chuột phải vào tin nhắn của bạn và chọn “Sao Chép Đường Dẫn Tin Nhắn”.",
+    "discordUsernameLabel": "Tên người dùng Discord của bạn",
+    "discordUsernamePlaceholder": "tennguoidung",
     "toastCannotDetermineUsername": "Không xác định được tên người dùng từ URL",
     "toastVerifiedTitle": "Đã xác minh!",
     "toastLinkedTitle": "Đã liên kết",

--- a/src/lib/i18n/locales/vi/common.json
+++ b/src/lib/i18n/locales/vi/common.json
@@ -693,11 +693,11 @@
       "mastodon": "Đăng một toot chứa đoạn văn bản bên dưới, rồi dán Post ID từ URL.",
       "telegram": "Gửi một tin nhắn trong kênh/nhóm công khai chứa đoạn văn bản bên dưới, rồi dán đường dẫn tin nhắn (ví dụ: channelname/123).",
       "bluesky": "Đăng trên Bluesky một bài chứa đoạn văn bản bên dưới, rồi dán record key (rkey) từ URL bài đăng.",
-      "discord": "Đăng một tin nhắn chứa đoạn văn bản bên dưới, rồi nhấp chuột phải vào tin nhắn đó và chọn “Sao Chép Đường Dẫn Tin Nhắn”. Lời mời vào máy chủ không thể chứng minh ai là chủ tài khoản. Nhập tên người dùng Discord của bạn — mục “Tên đăng nhập” trên hồ sơ của bạn, không phải tên hiển thị."
+      "discord": "Đăng một tin nhắn chứa đoạn văn bản bên dưới, rồi nhấp chuột phải vào tin nhắn đó và chọn “Sao Chép Liên Kết Tin Nhắn”. Lời mời vào máy chủ không thể chứng minh ai là chủ tài khoản. Nhập tên người dùng Discord của bạn — mục “Tên đăng nhập” trên hồ sơ của bạn, không phải tên hiển thị."
     },
     "toastErrorTitle": "Lỗi",
     "toastEnterProof": "Vui lòng nhập URL hoặc ID chứng minh",
-    "toastInvalidDiscordLink": "Dán liên kết tin nhắn Discord: nhấp chuột phải vào tin nhắn của bạn và chọn “Sao Chép Đường Dẫn Tin Nhắn”.",
+    "toastInvalidDiscordLink": "Dán liên kết tin nhắn Discord: nhấp chuột phải vào tin nhắn của bạn và chọn “Sao Chép Liên Kết Tin Nhắn”.",
     "discordUsernameLabel": "Tên người dùng Discord của bạn",
     "discordUsernamePlaceholder": "tennguoidung",
     "toastCannotDetermineUsername": "Không xác định được tên người dùng từ URL",

--- a/src/lib/i18n/locales/vi/common.json
+++ b/src/lib/i18n/locales/vi/common.json
@@ -693,11 +693,11 @@
       "mastodon": "Đăng một toot chứa đoạn văn bản bên dưới, rồi dán Post ID từ URL.",
       "telegram": "Gửi một tin nhắn trong kênh/nhóm công khai chứa đoạn văn bản bên dưới, rồi dán đường dẫn tin nhắn (ví dụ: channelname/123).",
       "bluesky": "Đăng trên Bluesky một bài chứa đoạn văn bản bên dưới, rồi dán record key (rkey) từ URL bài đăng.",
-      "discord": "Đăng một tin nhắn chứa đoạn văn bản bên dưới, rồi nhấp chuột phải vào tin nhắn đó và chọn “Sao Chép Liên Kết Tin Nhắn”. Lời mời vào máy chủ không thể chứng minh ai là chủ tài khoản. Nhập tên người dùng Discord của bạn — mục “Tên đăng nhập” trên hồ sơ của bạn, không phải tên hiển thị."
+      "discord": "Đăng một tin nhắn chứa đoạn văn bản bên dưới, rồi nhấp chuột phải vào tin nhắn đó và chọn “Sao Chép Đường Dẫn Tin Nhắn”. Lời mời vào máy chủ không thể chứng minh ai là chủ tài khoản. Nhập tên người dùng Discord của bạn — mục “Tên đăng nhập” trên hồ sơ của bạn, không phải tên hiển thị."
     },
     "toastErrorTitle": "Lỗi",
     "toastEnterProof": "Vui lòng nhập URL hoặc ID chứng minh",
-    "toastInvalidDiscordLink": "Dán liên kết tin nhắn Discord: nhấp chuột phải vào tin nhắn của bạn và chọn “Sao Chép Liên Kết Tin Nhắn”.",
+    "toastInvalidDiscordLink": "Dán liên kết tin nhắn Discord: nhấp chuột phải vào tin nhắn của bạn và chọn “Sao Chép Đường Dẫn Tin Nhắn”.",
     "discordUsernameLabel": "Tên người dùng Discord của bạn",
     "discordUsernamePlaceholder": "tennguoidung",
     "toastCannotDetermineUsername": "Không xác định được tên người dùng từ URL",

--- a/src/lib/i18n/locales/zh/common.json
+++ b/src/lib/i18n/locales/zh/common.json
@@ -693,12 +693,12 @@
       "mastodon": "发一条包含以下文字的嘟文，然后从 URL 中粘贴帖子 ID。",
       "telegram": "在公开频道/群组发一条包含以下文字的消息，然后粘贴消息路径（例如 channelname/123）。",
       "bluesky": "在 Bluesky 上发一条包含以下文字的帖子，然后从帖子 URL 中粘贴记录键（rkey）。",
-      "discord": "Post a message containing the text below, then right-click it and pick Copy Message Link. A server invite cannot prove who owns an account. Enter your Discord username — the one on your profile, not your display name."
+      "discord": "发一条包含以下文字的消息，然后右键点击该消息并选择“复制消息链接”。服务器邀请链接无法证明账号归谁所有。请输入你的 Discord 用户名（个人资料上的用户名，不是昵称）。"
     },
     "toastErrorTitle": "出错",
     "toastEnterProof": "请输入证明 URL 或 ID",
-    "toastInvalidDiscordLink": "Paste a Discord message link: right-click your message and choose Copy Message Link.",
-    "discordUsernameLabel": "Your Discord username",
+    "toastInvalidDiscordLink": "请粘贴 Discord 消息链接：右键点击你的消息，然后选择“复制消息链接”。",
+    "discordUsernameLabel": "你的 Discord 用户名",
     "discordUsernamePlaceholder": "yourusername",
     "toastCannotDetermineUsername": "无法从 URL 判断用户名",
     "toastVerifiedTitle": "验证成功！",


### PR DESCRIPTION
## Summary

- Translates the Discord account-linking instruction, username label, and invalid-link toast that #712 left in English across all 19 non-English locales.
- Guards those keys against English fallback and extends the existing guard to every platform-specific proof instruction.
- Isolates the embedded English menu label in Arabic and Urdu so mixed-direction text renders predictably.

## Motivation

- #712 replaced the obsolete invite-based proof flow quickly. The previous translations no longer described an accepted proof, so English shipped as a temporary safe fallback. #715 tracks translating the replacement flow.
- The instruction and toast quote the localized Discord menu label where Discord provides one, read from Discord's web-client string tables rather than translated word for word (for example German "Nachrichtenlink kopieren", Polish "Kopiuj link z wiadomością", Japanese "メッセージリンクをコピー"). Locales without a Discord client translation retain `Copy Message Link` with a local-language gloss: Discord ships no Arabic, Filipino, Indonesian, Malay, or Urdu interface.
- The username copy must distinguish the unique account handle from the display name, and each locale names that field the way the localized Discord client names it, so a reader can find it on their own profile. Discord's Korean client calls it 별명 and its Simplified Chinese client calls it 昵称; neither client uses a literal rendering of "display name". Vietnamese quotes Discord's "Tên đăng nhập" for the handle itself.
- Arabic and Urdu wrap the quoted English label in Unicode left-to-right isolate markers so punctuation and the following right-to-left gloss keep their intended order.
- Handle placeholders are localized only where the locale can provide a valid lowercase ASCII Discord handle. The six intentionally English placeholders remain outside the translation guard.

## What this leaves alone

- The English copy and account-linking behavior are unchanged.
- The instructions retain the English source's desktop `right-click` wording. Mobile long-press guidance remains a separate copy decision.

## Related Issue

- Closes #715

## Testing

- [x] `npm test` stages run individually in the worktree: TypeScript passed; ESLint reported 0 errors and 16 pre-existing warnings, none in changed files; Vitest passed 338 files and 2,923 tests; the production build succeeded.
- [x] `npx vitest run src/lib/i18n/locales.test.ts` — 8 tests passed.
- [x] `node scripts/check-analytics-contract.mjs` and `git diff --check` passed.
- [x] Manual verification: the guard keys were added first and the locale suite failed for exactly the three keys in every non-English locale, then passed once the translations landed. Every quoted Discord label and field name was read from Discord's web-client string tables on 2026-09-05.

## Visuals

- [ ] UI change with screenshots/video attached
- [x] No layout change; this PR changes localized copy and adds explicit bidi isolation for mixed-direction text
- [x] Visuals and text avoid sensitive external brand or partner names unless explicitly approved
